### PR TITLE
[gofmt] Cleanup gofmt errors

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -21,13 +21,13 @@ import (
 
 // deviceCache is a local cache of devices seeded from Core Metadata.
 type deviceCache struct {
-	devices     map[string]*models.Device
-	names       map[string]string
+	devices map[string]*models.Device
+	names   map[string]string
 }
 
 var (
-	dcOnce  sync.Once
-	dc      *deviceCache
+	dcOnce sync.Once
+	dc     *deviceCache
 )
 
 // Creates a singleton deviceCache instance.

--- a/examples/simple/cmd/main.go
+++ b/examples/simple/cmd/main.go
@@ -15,8 +15,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/edgexfoundry/device-sdk-go/examples/simple"
 	device "github.com/edgexfoundry/device-sdk-go"
+	"github.com/edgexfoundry/device-sdk-go/examples/simple"
 )
 
 const (

--- a/examples/simple/simpledriver.go
+++ b/examples/simple/simpledriver.go
@@ -12,9 +12,9 @@ package simple
 import (
 	"fmt"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
-	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	device "github.com/edgexfoundry/device-sdk-go"
+	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 type SimpleDriver struct {

--- a/profiles.go
+++ b/profiles.go
@@ -36,10 +36,9 @@ type profileCache struct {
 }
 
 var (
-	pcOnce   sync.Once
-	pc       *profileCache
+	pcOnce sync.Once
+	pc     *profileCache
 )
-
 
 func findProfile(name string, profiles []models.DeviceProfile) (found bool) {
 	for _, prof := range profiles {
@@ -448,9 +447,9 @@ func (p *profileCache) createDescriptor(name string, devObj models.DeviceObject)
 	svc.lc.Debug(fmt.Sprintf("ps: createDescriptor: %v value: %v units: %s\n", name, value, units))
 
 	desc := &models.ValueDescriptor{
-		Name: name,
-		Min:  value.Minimum,
-		Max:  value.Maximum,
+		Name:         name,
+		Min:          value.Minimum,
+		Max:          value.Maximum,
 		Type:         value.Type,
 		UomLabel:     units.DefaultValue,
 		DefaultValue: value.DefaultValue,

--- a/protocoldriver.go
+++ b/protocoldriver.go
@@ -11,8 +11,8 @@
 package device
 
 import (
-	"github.com/edgexfoundry/edgex-go/pkg/models"
 	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 // ProtocolDriver is a low-level device-specific interface used by

--- a/service.go
+++ b/service.go
@@ -13,7 +13,6 @@
 package device
 
 import (
-
 	"bytes"
 	"fmt"
 	"net/http"
@@ -22,10 +21,10 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/pkg/clients/coredata"
+	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/metadata"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/gorilla/mux"
 
 	"gopkg.in/mgo.v2/bson"


### PR DESCRIPTION
There are a number of gofmt errors that slipped through
when we did the initial code import.  This commits cleans
them all up.

Signed-off-by: Tony Espy <espy@canonical.com>