### PR TITLE
Use package global svc var

### DIFF
--- a/async.go
+++ b/async.go
@@ -15,10 +15,10 @@ import (
 // processAsyncResults processes readings that are pushed from
 // a DS implementation. Each is reading is optionally transformed
 // before being pushed to Core Data.
-func (s *Service) processAsyncResults() {
-	for !s.stopped {
-		readings := make([]models.Reading, 0, s.c.Device.MaxCmdOps)
-		cr := <-s.asyncCh
+func processAsyncResults() {
+	for !svc.stopped {
+		readings := make([]models.Reading, 0, svc.c.Device.MaxCmdOps)
+		cr := <-svc.asyncCh
 
 		// get the device resource associated with the rsp.RO
 		do := pc.getDeviceObjectByName(cr.DeviceName, cr.RO)
@@ -30,7 +30,7 @@ func (s *Service) processAsyncResults() {
 
 		// push to Core Data
 		event := &models.Event{Device: cr.DeviceName, Readings: readings}
-		_, err := s.ec.Add(event)
+		_, err := svc.ec.Add(event)
 		if err != nil {
 			msg := fmt.Sprintf("internal error; failed to push event for dev: %s to CoreData: %s", cr.DeviceName, err)
 			svc.lc.Error(msg)

--- a/command_test.go
+++ b/command_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -25,14 +26,24 @@ import (
 const deviceCommandTest = "device-command-test"
 const testCmd = "TestCmd"
 
+func TestMain(m *testing.M) {
+	lc := logger.NewClient("command_test", false, "./command_test.log")
+	r := mux.NewRouter().PathPrefix(apiV1).Subrouter()
+	svc = &Service{lc: lc, r: r}
+	initCommand()
+	os.Exit(m.Run())
+}
+
 // Test Command REST call when service is locked.
 func TestCommandServiceLocked(t *testing.T) {
-	ch := &commandHandler{fn: commandFunc}
+	reset()
+
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", v1Device, "nil", "nil"), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": "nil", "cmd": "nil"})
+	svc.locked = true
 
 	rr := httptest.NewRecorder()
-	ch.ServeHTTP(rr, req)
+	svc.r.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusLocked {
 		t.Errorf("ServiceLocked: handler returned wrong status code: got %v want %v",
 			status, http.StatusLocked)
@@ -49,21 +60,16 @@ func TestCommandServiceLocked(t *testing.T) {
 // TestCommandNoDevice tests the command REST call when the given deviceId doesn't
 // specify an existing device.
 func TestCommandNoDevice(t *testing.T) {
+	reset()
+
 	badDeviceId := "5abae51de23bf81c9ef0f390"
-
-	lc := logger.NewClient("command_test", false, "./command_test.log")
-
-	// Setup dummy service with logger, and mocked devices cache
-	// Empty cache will by default have no devices.
-	s := &Service{lc: lc}
 	newDeviceCache("fakeID")
 
-	ch := &commandHandler{fn: commandFunc, s: s}
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", v1Device, badDeviceId, testCmd), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": badDeviceId, "cmd": testCmd})
 
 	rr := httptest.NewRecorder()
-	ch.ServeHTTP(rr, req)
+	svc.r.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("NoDevice: handler returned wrong status code: got %v want %v",
@@ -81,6 +87,8 @@ func TestCommandNoDevice(t *testing.T) {
 // TestCommandNoDevice tests the command REST call when the device specified
 // by deviceId is locked.
 func TestCommandDeviceLocked(t *testing.T) {
+	reset()
+
 	// Empty cache will by default have no devices.
 	newDeviceCache("fakeID")
 
@@ -109,12 +117,11 @@ func TestCommandDeviceLocked(t *testing.T) {
 
 	s.cd.Add(d)
 
-	ch := &commandHandler{fn: commandFunc, s: s}
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", v1Device, testDeviceId, testCmd), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": testDeviceId, "cmd": testCmd})
 
 	rr := httptest.NewRecorder()
-	ch.ServeHTTP(rr, req)
+	svc.r.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusLocked {
 		t.Errorf("NoDevice: handler returned wrong status code: got %v want %v",
@@ -128,4 +135,9 @@ func TestCommandDeviceLocked(t *testing.T) {
 		t.Errorf("DeviceLocked: handler returned wrong body:\nexpected: %s\ngot:      %s", expected, body)
 	}
 	*/
+}
+
+// reset re-initializes dependencies for each test
+func reset() {
+     svc.locked = false
 }

--- a/command_test.go
+++ b/command_test.go
@@ -23,8 +23,11 @@ import (
 	//	"gopkg.in/mgo.v2/bson"
 )
 
-const deviceCommandTest = "device-command-test"
-const testCmd = "TestCmd"
+const (
+	badDeviceId       = "5abae51de23bf81c9ef0f390"
+	deviceCommandTest = "device-command-test"
+	testCmd           = "TestCmd"
+)
 
 func TestMain(m *testing.M) {
 	lc := logger.NewClient("command_test", false, "./command_test.log")
@@ -62,7 +65,6 @@ func TestCommandServiceLocked(t *testing.T) {
 func TestCommandNoDevice(t *testing.T) {
 	reset()
 
-	badDeviceId := "5abae51de23bf81c9ef0f390"
 	newDeviceCache("fakeID")
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", v1Device, badDeviceId, testCmd), nil)
@@ -139,5 +141,5 @@ func TestCommandDeviceLocked(t *testing.T) {
 
 // reset re-initializes dependencies for each test
 func reset() {
-     svc.locked = false
+	svc.locked = false
 }

--- a/commandresult_test.go
+++ b/commandresult_test.go
@@ -62,7 +62,7 @@ func TestNewStringResult(t *testing.T) {
 	}
 
 	if result != cr.StringResult {
-		t.Errorf("NewStringResult: cr.StringResult: %s doesn't match result: %s")
+		t.Errorf("NewStringResult: cr.StringResult: %s doesn't match result: %s", cr.StringResult, result)
 	}
 
 	reading = cr.Reading("FakeDevice", "FakeDeviceObject")

--- a/control.go
+++ b/control.go
@@ -26,7 +26,7 @@ func transformHandler(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, "OK")
 }
 
-func initService(s *Service) {
-	s.r.HandleFunc("/discovery", discoveryHandler).Methods("POST")
-	s.r.HandleFunc("/debug/transformData/{transformData}", transformHandler).Methods("GET")
+func initControl() {
+	svc.r.HandleFunc("/discovery", discoveryHandler).Methods("POST")
+	svc.r.HandleFunc("/debug/transformData/{transformData}", transformHandler).Methods("GET")
 }

--- a/devices.go
+++ b/devices.go
@@ -21,13 +21,13 @@ import (
 
 // deviceCache is a local cache of devices seeded from Core Metadata.
 type deviceCache struct {
-	devices     map[string]*models.Device
-	names       map[string]string
+	devices map[string]*models.Device
+	names   map[string]string
 }
 
 var (
-	dcOnce  sync.Once
-	dc      *deviceCache
+	dcOnce sync.Once
+	dc     *deviceCache
 )
 
 // Creates a singleton deviceCache instance.

--- a/profiles.go
+++ b/profiles.go
@@ -36,10 +36,9 @@ type profileCache struct {
 }
 
 var (
-	pcOnce   sync.Once
-	pc       *profileCache
+	pcOnce sync.Once
+	pc     *profileCache
 )
-
 
 func findProfile(name string, profiles []models.DeviceProfile) (found bool) {
 	for _, prof := range profiles {
@@ -448,9 +447,9 @@ func (p *profileCache) createDescriptor(name string, devObj models.DeviceObject)
 	svc.lc.Debug(fmt.Sprintf("ps: createDescriptor: %v value: %v units: %s\n", name, value, units))
 
 	desc := &models.ValueDescriptor{
-		Name: name,
-		Min:  value.Minimum,
-		Max:  value.Maximum,
+		Name:         name,
+		Min:          value.Minimum,
+		Max:          value.Maximum,
 		Type:         value.Type,
 		UomLabel:     units.DefaultValue,
 		DefaultValue: value.DefaultValue,

--- a/protocoldriver.go
+++ b/protocoldriver.go
@@ -11,8 +11,8 @@
 package device
 
 import (
-	"github.com/edgexfoundry/edgex-go/pkg/models"
 	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
 )
 
 // ProtocolDriver is a low-level device-specific interface used by

--- a/service.go
+++ b/service.go
@@ -13,7 +13,6 @@
 package device
 
 import (
-
 	"bytes"
 	"fmt"
 	"net/http"
@@ -22,10 +21,10 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/edgex-go/pkg/clients/coredata"
+	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/metadata"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	logger "github.com/edgexfoundry/edgex-go/pkg/clients/logging"
 	"github.com/gorilla/mux"
 
 	"gopkg.in/mgo.v2/bson"
@@ -78,14 +77,14 @@ type Service struct {
 	asyncCh       <-chan *CommandResult
 }
 
-func (s *Service) attemptInit(done chan<- struct{}) {
+func attemptInit(done chan<- struct{}) {
 	defer func() { done <- struct{}{} }()
 
-	s.lc.Debug("Trying to find ds: " + s.Name)
+	svc.lc.Debug("Trying to find ds: " + svc.Name)
 
-	ds, err := s.sc.DeviceServiceForName(s.Name)
+	ds, err := svc.sc.DeviceServiceForName(svc.Name)
 	if err != nil {
-		s.lc.Error(fmt.Sprintf("DeviceServicForName failed: %v", err))
+		svc.lc.Error(fmt.Sprintf("DeviceServicForName failed: %v", err))
 
 		// TODO: restore if/when the issue with detecting 'not-found'
 		// is resolves.  Otherwise, just log errors and move on.
@@ -94,18 +93,18 @@ func (s *Service) attemptInit(done chan<- struct{}) {
 		// return
 	}
 
-	s.lc.Debug("DeviceServiceForName returned: " + ds.Service.Name)
-	s.lc.Debug(fmt.Sprintf("DeviceServiceId is: %s", ds.Service.Id))
+	svc.lc.Debug("DeviceServiceForName returned: " + ds.Service.Name)
+	svc.lc.Debug(fmt.Sprintf("DeviceServiceId is: %s", ds.Service.Id))
 
 	// TODO: this checks if names are equal, not if the resulting ds is a valid instance
-	if ds.Service.Name != s.Name {
-		s.lc.Error(fmt.Sprintf("Failed to find ds: %s; attempts: %d", s.Name, s.initAttempts))
+	if ds.Service.Name != svc.Name {
+		svc.lc.Error(fmt.Sprintf("Failed to find ds: %s; attempts: %d", svc.Name, svc.initAttempts))
 
 		// check for addressable
-		s.lc.Error(fmt.Sprintf("Trying to find addressable for: %s", s.Name))
-		addr, err := s.ac.AddressableForName(s.Name)
+		svc.lc.Error(fmt.Sprintf("Trying to find addressable for: %s", svc.Name))
+		addr, err := svc.ac.AddressableForName(svc.Name)
 		if err != nil {
-			s.lc.Error(fmt.Sprintf("AddressableForName: %s; failed: %v", s.Name, err))
+			svc.lc.Error(fmt.Sprintf("AddressableForName: %s; failed: %v", svc.Name, err))
 
 			// don't quit, but instead try to create addressable & service
 		}
@@ -113,41 +112,40 @@ func (s *Service) attemptInit(done chan<- struct{}) {
 		millis := time.Now().UnixNano() * int64(time.Nanosecond) / int64(time.Microsecond)
 
 		// TODO: same as above
-		if addr.Name != s.Name {
+		if addr.Name != svc.Name {
 			addr = models.Addressable{
 				BaseObject: models.BaseObject{
 					Origin: millis,
 				},
-				Name:       s.Name,
+				Name:       svc.Name,
 				HTTPMethod: http.MethodPost,
 				Protocol:   httpProto,
-				Address:    s.c.Service.Host,
-				Port:       s.c.Service.Port,
+				Address:    svc.c.Service.Host,
+				Port:       svc.c.Service.Port,
 				Path:       v1Callback,
 			}
 			addr.Origin = millis
 
-			// use s.clientService to register Addressable
-			id, err := s.ac.Add(&addr)
+			id, err := svc.ac.Add(&addr)
 			if err != nil {
-				s.lc.Error(fmt.Sprintf("Add Addressable: %s; failed: %v", s.Name, err))
+				svc.lc.Error(fmt.Sprintf("Add Addressable: %s; failed: %v", svc.Name, err))
 				return
 			}
 
 			if len(id) != 24 || !bson.IsObjectIdHex(id) {
-				s.lc.Error("Add addressable returned invalid Id: " + id)
+				svc.lc.Error("Add addressable returned invalid Id: " + id)
 				return
 			}
 
 			addr.Id = bson.ObjectIdHex(id)
-			s.lc.Error("New addressable Id: " + addr.Id.Hex())
+			svc.lc.Error("New addressable Id: " + addr.Id.Hex())
 		}
 
 		// setup the service
 		ds = models.DeviceService{
 			Service: models.Service{
-				Name:           s.Name,
-				Labels:         s.c.Service.Labels,
+				Name:           svc.Name,
+				Labels:         svc.c.Service.Labels,
 				OperatingState: "ENABLED",
 				Addressable:    addr,
 			},
@@ -155,46 +153,46 @@ func (s *Service) attemptInit(done chan<- struct{}) {
 		}
 
 		ds.Service.Origin = millis
-		id, err := s.sc.Add(&ds)
+		id, err := svc.sc.Add(&ds)
 		if err != nil {
-			s.lc.Error(fmt.Sprintf("Add Deviceservice: %s; failed: %v", s.Name, err))
+			svc.lc.Error(fmt.Sprintf("Add Deviceservice: %s; failed: %v", svc.Name, err))
 			return
 		}
 
 		if len(id) != 24 || !bson.IsObjectIdHex(id) {
-			s.lc.Error("Add deviceservice returned invalid Id: %s", id)
+			svc.lc.Error("Add deviceservice returned invalid Id: %s", id)
 			return
 		}
 
 		// NOTE - this differs from Addressable and Device objects,
 		// neither of which require the '.Service'prefix
 		ds.Service.Id = bson.ObjectIdHex(id)
-		s.lc.Debug("New deviceservice Id: " + ds.Service.Id.Hex())
+		svc.lc.Debug("New deviceservice Id: " + ds.Service.Id.Hex())
 
-		s.initialized = true
-		s.ds = ds
+		svc.initialized = true
+		svc.ds = ds
 	} else {
-		s.lc.Debug(fmt.Sprintf("Found ds.Name: %s, s.Name: %s", ds.Service.Name, s.Name))
-		s.initialized = true
-		s.ds = ds
+		svc.lc.Debug(fmt.Sprintf("Found ds.Name: %s, svc.Name: %s", ds.Service.Name, svc.Name))
+		svc.initialized = true
+		svc.ds = ds
 	}
 }
 
-func (s *Service) validateClientConfig() error {
+func validateClientConfig() error {
 
-	if len(s.c.Clients[ClientMetadata].Host) == 0 {
+	if len(svc.c.Clients[ClientMetadata].Host) == 0 {
 		return fmt.Errorf("Fatal error; Host setting for Core Metadata client not configured")
 	}
 
-	if s.c.Clients[ClientMetadata].Port == 0 {
+	if svc.c.Clients[ClientMetadata].Port == 0 {
 		return fmt.Errorf("Fatal error; Port setting for Core Metadata client not configured")
 	}
 
-	if len(s.c.Clients[ClientData].Host) == 0 {
+	if len(svc.c.Clients[ClientData].Host) == 0 {
 		return fmt.Errorf("Fatal error; Host setting for Core Data client not configured")
 	}
 
-	if s.c.Clients[ClientData].Port == 0 {
+	if svc.c.Clients[ClientData].Port == 0 {
 		return fmt.Errorf("Fatal error; Port setting for Core Ddata client not configured")
 	}
 
@@ -231,7 +229,7 @@ func (s *Service) Start(useRegistry bool, profile string, confDir string) (err e
 	// TODO: add useRegistry logic
 
 	// TODO: validate that metadata and core config settings are set
-	err = s.validateClientConfig()
+	err = validateClientConfig()
 	if err != nil {
 		return err
 	}
@@ -307,7 +305,7 @@ func (s *Service) Start(useRegistry bool, profile string, confDir string) (err e
 			time.Sleep(30 * time.Second)
 		}
 
-		go s.attemptInit(done)
+		go attemptInit(done)
 		<-done // wait for background attempt to finish
 	}
 
@@ -327,7 +325,7 @@ func (s *Service) Start(useRegistry bool, profile string, confDir string) (err e
 		// TODO: make channel buffer size a setting
 		s.asyncCh = make(<-chan *CommandResult, 16)
 
-		go s.processAsyncResults()
+		go processAsyncResults()
 	}
 
 	err = s.proto.Initialize(s.lc, s.asyncCh)
@@ -338,10 +336,10 @@ func (s *Service) Start(useRegistry bool, profile string, confDir string) (err e
 
 	// Setup REST API
 	s.r = mux.NewRouter().PathPrefix(apiV1).Subrouter()
-	initStatus(s)
-	initCommand(s)
-	initService(s)
-	initUpdate(s)
+	initStatus()
+	initCommand()
+	initControl()
+	initUpdate()
 
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(s.c.Service.Timeout), "Request timed out")
 
@@ -364,6 +362,8 @@ func (s *Service) Stop(force bool) error {
 
 // NewService create a new device service instance with the given
 // name, version and ProtocolDriver, which cannot be nil.
+// Note - this function is a singleton, if called more than once,
+// it will alwayd return an error.
 func NewService(name string, version string, proto ProtocolDriver) (*Service, error) {
 
 	if svc != nil {

--- a/status.go
+++ b/status.go
@@ -15,6 +15,6 @@ func statusHandler(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, "pong")
 }
 
-func initStatus(s *Service) {
-	s.r.HandleFunc("/ping", statusHandler)
+func initStatus() {
+	svc.r.HandleFunc("/ping", statusHandler)
 }

--- a/update.go
+++ b/update.go
@@ -36,6 +36,6 @@ func callbackHandler(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, "OK")
 }
 
-func initUpdate(s *Service) {
-	s.r.HandleFunc("callback", callbackHandler)
+func initUpdate() {
+	svc.r.HandleFunc("callback", callbackHandler)
 }


### PR DESCRIPTION
Instead passing a pointer to the Service struct
around as a parameter, instead just use the package
global svc var to access the struct.

Signed-off-by: Tony Espy <espy@canonical.com>