### PR TITLE
Refactor handle operation

### DIFF
--- a/commandrequest.go
+++ b/commandrequest.go
@@ -1,0 +1,18 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2018 Canonical Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package device
+
+import "github.com/edgexfoundry/edgex-go/pkg/models"
+
+type CommandRequest struct {
+	// RO is a ResourceOperation
+	RO models.ResourceOperation
+	// DeviceObject (aka device resource) represents the device resource
+	// to be read or set. It can be used to access the attributes map,
+	// PropertyValue, and PropertyUnit structs.
+	DeviceObject models.DeviceObject
+}

--- a/examples/simple/simpledriver.go
+++ b/examples/simple/simpledriver.go
@@ -31,7 +31,7 @@ func (s *SimpleDriver) DisconnectDevice(address *models.Addressable) error {
 // service.  If the DS supports asynchronous data pushed from devices/sensors,
 // then a valid receive' channel must be created and returned, otherwise nil
 // is returned.
-func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh <-chan *device.CommandResult) error {
+func (s *SimpleDriver) Initialize(svc *device.Service, lc logger.LoggingClient, asyncCh <-chan *device.CommandResult) error {
 	s.lc = lc
 	s.lc.Debug(fmt.Sprintf("SimpleHandler.Initialize called!"))
 	return nil

--- a/examples/simple/simpledriver.go
+++ b/examples/simple/simpledriver.go
@@ -37,25 +37,26 @@ func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh <-chan *devic
 	return nil
 }
 
-// HandleOperation triggers an asynchronous protocol specific GET or SET operation
-// for the specified device. Device profile attributes are passed as part
-// of the *models.DeviceObject. The parameter 'value' must be provided for
-// a SET operation, otherwise it should be 'nil'.
-//
-// This function is always called in a new goroutine. The driver is responsible
-// for writing the CommandResults to the send channel.
-//
-// Note - DeviceObject represents a deviceResource defined in deviceprofile.
-//
-func (s *SimpleDriver) HandleOperation(ro *models.ResourceOperation,
-	d *models.Device, do *models.DeviceObject, desc *models.ValueDescriptor,
-	value string, send chan<- *device.CommandResult) {
+// HandleCommand triggers an asynchronous protocol specific GET or SET operation
+// for the specified device.
+func (s *SimpleDriver) HandleCommands(d models.Device, reqs []device.CommandRequest,
+	params string) (res []device.CommandResult, err error) {
 
-	s.lc.Debug(fmt.Sprintf("HandleCommand: dev: %s op: %v attrs: %v", d.Name, ro.Operation, do.Attributes))
+	if len(reqs) != 1 {
+		err = fmt.Errorf("SimpleDriver.HandleCommands; too many command requests; only one supported")
+		return
+	}
 
-	cr := &device.CommandResult{RO: ro, Type: device.Bool, BoolResult: true}
+	s.lc.Debug(fmt.Sprintf("HandleCommand: dev: %s op: %v attrs: %v", d.Name, reqs[0].RO.Operation, reqs[0].DeviceObject.Attributes))
 
-	send <- cr
+	res = make([]device.CommandResult, 1)
+
+	// TODO: change CommandResult to get rid of pointer to RO
+	res[0].RO = &reqs[0].RO
+	res[0].Type = device.Bool
+	res[0].BoolResult = true
+
+	return
 }
 
 // Stop the protocol-specific DS code to shutdown gracefully, or

--- a/protocoldriver.go
+++ b/protocoldriver.go
@@ -33,10 +33,9 @@ type ProtocolDriver interface {
 	DisconnectDevice(address *models.Addressable) error
 
 	// Initialize performs protocol-specific initialization for the device
-	// service.  If the DS supports asynchronous data pushed from devices/sensors,
-	// then a valid receive' channel will be given, otherwise the channel is nil
-	// and must not be used.
-	Initialize(lc logger.LoggingClient, asyncCh <-chan *CommandResult) error
+	// service. The given *CommandResult channel can be used to push asynchronous
+	// events and readings to Core Data.
+	Initialize(s *Service, lc logger.LoggingClient, asyncCh <-chan *CommandResult) error
 
 	// HandleCommands passes a slice of CommandRequest structs each representing
 	// a ResourceOperation for a specific device resource (aka DeviceObject).

--- a/protocoldriver.go
+++ b/protocoldriver.go
@@ -38,24 +38,14 @@ type ProtocolDriver interface {
 	// and must not be used.
 	Initialize(lc logger.LoggingClient, asyncCh <-chan *CommandResult) error
 
-	// HandleOperation triggers an asynchronous protocol specific GET or SET operation
-	// for the specified device. Device profile attributes are passed as part
-	// of the *models.DeviceObject. The parameter 'value' must be provided for
-	// a SET operation, otherwise it should be 'nil'.
+	// HandleCommands passes a slice of CommandRequest structs each representing
+	// a ResourceOperation for a specific device resource (aka DeviceObject).
+	// If commands are actuation commands, then params may be used to provide
+	// an optional JSON encoded string specifying paramters for the individual
+	// commands.
 	//
-	// This function is always called in a new goroutine. The driver is responsible
-	// for writing the CommandResults to the send channel. The driver is also
-	// responsible for closing send channel if/when Stop is called.
-	//
-	// NOTE - the Java-based device-virtual includes an additional parameter called
-	// operations which is used to optimize how virtual resources are saved for SETs.
-	//
-	HandleOperation(ro *models.ResourceOperation,
-		device *models.Device,
-		object *models.DeviceObject,
-		desc *models.ValueDescriptor,
-		value string,
-		send chan<- *CommandResult)
+	// TODO: add param to CommandRequest and have command endpoint parse the params.
+	HandleCommands(d models.Device, reqs []CommandRequest, params string) ([]CommandResult, error)
 
 	// Stop instructs the protocol-specific DS code to shutdown gracefully, or
 	// if the force parameter is 'true', immediately. The driver is responsible

--- a/service.go
+++ b/service.go
@@ -328,7 +328,7 @@ func (s *Service) Start(useRegistry bool, profile string, confDir string) (err e
 		go processAsyncResults()
 	}
 
-	err = s.proto.Initialize(s.lc, s.asyncCh)
+	err = s.proto.Initialize(s, s.lc, s.asyncCh)
 	if err != nil {
 		s.lc.Error(fmt.Sprintf("ProtocolDriver.Initialize failure: %v; exiting.", err))
 		return err


### PR DESCRIPTION
This change re-factors the way the command endpoint requests processing of a related set of ResourceOperations from a concrete type which implements the **ProtocolDriver** interface.  The original code was based on the Java SDK. Each **ResourceOperation** was a single call the the protocol layer. This has been changed instead such that all of the **ResourceOperations** are passed in a single **CommandRequest** slice.  The call now is also synchronous, and returns a slice of **CommandResults** (and an error).

The only change I didn't make, was to change the **ResourceOperation** and **ValueDescriptor** fields in CommandResult from pointers to structs, this would be consistent with **CommandRequest**. I think the original justification of using pointers was efficiency, however it seems that unless these structs actually not to be modified, passing by value follows best golang practices...

Fixes #4 