### PR TITLE
Fix command test

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -32,7 +32,7 @@ const (
 func TestMain(m *testing.M) {
 	lc := logger.NewClient("command_test", false, "./command_test.log")
 	r := mux.NewRouter().PathPrefix(apiV1).Subrouter()
-	svc = &Service{lc: lc, r: r}
+	svc = &Service{Name: deviceCommandTest, lc: lc, r: r}
 	initCommand()
 	os.Exit(m.Run())
 }
@@ -65,8 +65,7 @@ func TestCommandServiceLocked(t *testing.T) {
 func TestCommandNoDevice(t *testing.T) {
 	reset()
 
-	newDeviceCache("fakeID")
-
+	dc = &deviceCache{}
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", v1Device, badDeviceId, testCmd), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": badDeviceId, "cmd": testCmd})
 
@@ -79,7 +78,7 @@ func TestCommandNoDevice(t *testing.T) {
 	}
 
 	body := strings.TrimSpace(rr.Body.String())
-	expected := "device: " + badDeviceId + " not found; GET " + v1Device + "/" + badDeviceId + "/" + testCmd
+	expected := "dev: " + badDeviceId + " not found; GET " + v1Device + "/" + badDeviceId + "/" + testCmd
 
 	if body != expected {
 		t.Errorf("ServiceLocked: handler returned wrong body:\nexpected: %s\ngot:      %s", expected, body)
@@ -92,7 +91,7 @@ func TestCommandDeviceLocked(t *testing.T) {
 	reset()
 
 	// Empty cache will by default have no devices.
-	newDeviceCache("fakeID")
+	dc = &deviceCache{}
 
 	/* TODO: adding a device to the devices cache requires a live metadata instance. We need
 	 * create interfaces for all of the caches, so that they can be mocked in unit tests.


### PR DESCRIPTION
Current test module failed during `make test` command. Current pull request do next:

Fix creation of mock Service instance with proper name
Fix mock device cache
Fix inconsistency in tests output

Signed-off-by: Andriy Popovych <popovych.andrey@gmail.com>