### PR TITLE
Fix fails to run with confdir flag confict

### DIFF
--- a/examples/simple/cmd/main.go
+++ b/examples/simple/cmd/main.go
@@ -33,6 +33,7 @@ func main() {
 	var profile string
 	var confDir string
 
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use the registry.")
 	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry.")
 	flag.StringVar(&profile, "profile", "", "Specify a profile other than default.")


### PR DESCRIPTION
Initialize the flag sets. Reference https://golang.org/pkg/flag/#pkg-variables.