### PR TITLE
Update file headers to fix godoc copyright leakage

### DIFF
--- a/async.go
+++ b/async.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/command.go
+++ b/command.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/command_test.go
+++ b/command_test.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/commandrequest.go
+++ b/commandrequest.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import "github.com/edgexfoundry/edgex-go/pkg/models"

--- a/commandresult.go
+++ b/commandresult.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/commandresult_test.go
+++ b/commandresult_test.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@
 // Copyright (C) 2018 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/control.go
+++ b/control.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/devices.go
+++ b/devices.go
@@ -8,7 +8,7 @@
 // This package provides management of device service related
 // objects that may be distributed across one or more EdgeX
 // core microservices.
-//
+
 package device
 
 import (

--- a/devices_test.go
+++ b/devices_test.go
@@ -4,7 +4,7 @@
 // Copyright (C) 2018 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/examples/simple/cmd/main.go
+++ b/examples/simple/cmd/main.go
@@ -3,9 +3,8 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 // This package provides a simple example of a device service.
-//
 package main
 
 import (

--- a/examples/simple/simpledriver.go
+++ b/examples/simple/simpledriver.go
@@ -3,10 +3,9 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 // This package provides a simple example implementation of
 // a ProtocolDriver interface.
-//
 package simple
 
 import (

--- a/profiles.go
+++ b/profiles.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/protocoldiscovery.go
+++ b/protocoldiscovery.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 // ProtocolDiscovery is a low-level device-specific interface implemented

--- a/protocoldriver.go
+++ b/protocoldriver.go
@@ -3,11 +3,7 @@
 // Copyright (C) 2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
-// This package defines an interface used to build an EdgeX Foundry device
-// service.  This interace provides an asbstraction layer for the device
-// or protocol specific logic of a device service.
-//
+
 package device
 
 import (

--- a/schedules.go
+++ b/schedules.go
@@ -4,7 +4,7 @@
 // Copyright (C) 2018 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/service.go
+++ b/service.go
@@ -4,13 +4,10 @@
 // Copyright (C) 2018 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
-// Package service(service?) implements the core logic of a device service,
-// which include loading configuration, handling service registration,
-// creation of object caches, REST APIs, and basic service functionality.
-// Clients of this package must provide concrete implementations of the
-// device-specific interfaces (e.g. ProtocolDriver).
-//
+
+// This package provides a basic EdgeX Foundry device service implementation
+// meant to be embedded in an application, similar in approach to the builtin
+// net/http package.
 package device
 
 import (

--- a/status.go
+++ b/status.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/update.go
+++ b/update.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/update_test.go
+++ b/update_test.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,7 @@
 // IOTech
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (

--- a/watchers.go
+++ b/watchers.go
@@ -3,7 +3,7 @@
 // Copyright (C) 2017-2018 Canonical Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
-//
+
 package device
 
 import (


### PR DESCRIPTION
This commit fixs leakage of copyright notices into generated godoc, the latest of which can be seen here:

https://godoc.org/github.com/edgexfoundry/device-sdk-go

Signed-off-by: Tony Espy <espy@canonical.com>