### PR TITLE
Fixed bug in getDeviceObjectByName(). DeviceObject always was empty

### DIFF
--- a/profiles.go
+++ b/profiles.go
@@ -159,7 +159,8 @@ func (p *profileCache) getDeviceObjectByName(devName string, op *models.Resource
 	devObjs := p.getDeviceObjects(devName)
 
 	if op != nil && devObjs != nil {
-		devObj, ok := devObjs[op.Object]
+		var ok bool
+		devObj, ok = devObjs[op.Object]
 
 		if !ok {
 			return nil


### PR DESCRIPTION
Fix #68 

Signed-off-by: Joan Duran <jduran@circutor.com>