### PR TITLE
Add versions to glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,18 +1,25 @@
 package: github.com/edgexfoundry/device-sdk-go
 import:
 - package: github.com/edgexfoundry/edgex-go
+  version: delhi
   subpackages:
   - /pkg/models
   - /pkg/clients/coredata
   - /pkg/clients/metadata
   - /pkg/clients/logging
 - package: github.com/BurntSushi/toml
+  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
 - package: github.com/gorilla/mux
+  version: =1.6.2
 - package: github.com/hashicorp/consul
+  version: =1.1.0
   subpackages:
   - api
 - package: github.com/robfig/cron
+  version: =1.1.0
 - package: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
 - package: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f


### PR DESCRIPTION
fix #44
The version numbers are consistent with the same ones in edgex-go

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>