### PR TITLE
Update edgex-go license version in Attribution.txt

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -42,5 +42,5 @@ https://github.com/globalsign/mgo/blob/master/LICENSE
 gopkg.in/yaml v2 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v2
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
 
-edgexfoundry/edgex-go (Apache) https://github.com/edgexfoundry/edgex-go
+edgexfoundry/edgex-go (Apache 2.0) https://github.com/edgexfoundry/edgex-go
 https://github.com/edgexfoundry/edgex-go/blob/master/LICENSE


### PR DESCRIPTION
It should be Apache 2.0, but it was stated Apache only
fix #147

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>