### PR TITLE
Replace Addressable Id data type to string

### DIFF
--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -99,7 +99,7 @@ func (d *deviceCache) UpdateAddressable(add models.Addressable) error {
 	}
 
 	if found == false {
-		return fmt.Errorf("addressable %s does not exist in cache", add.Id.Hex())
+		return fmt.Errorf("addressable %s does not exist in cache", add.Id)
 	}
 
 	return nil

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -228,7 +228,7 @@ func MakeAddressable(name string, addr *models.Addressable) (*models.Addressable
 			if err = VerifyIdFormat(id, "Addressable"); err != nil {
 				return nil, err
 			}
-			addressable.Id = bson.ObjectIdHex(id)
+			addressable.Id = id
 		} else {
 			LoggingClient.Error(fmt.Sprintf("AddressableForName failed: %v", err))
 			return nil, err

--- a/internal/mock/mock_addressableclient.go
+++ b/internal/mock/mock_addressableclient.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/globalsign/mgo/bson"
 )
 
 type AddressableClientMock struct {
@@ -26,7 +25,7 @@ func (AddressableClientMock) Add(addr *models.Addressable) (string, error) {
 }
 
 func (AddressableClientMock) AddressableForName(name string) (models.Addressable, error) {
-	var addressable = models.Addressable{Id: bson.ObjectIdHex("5b977c62f37ba10e36673802"), Name: name}
+	var addressable = models.Addressable{Id: "5b977c62f37ba10e36673802", Name: name}
 	var err error = nil
 	if name == "" {
 		err = types.NewErrServiceClient(http.StatusNotFound, nil)

--- a/internal/provision/schedules.go
+++ b/internal/provision/schedules.go
@@ -124,7 +124,7 @@ func createScheduleEventAddressable(scheduleEvent *models.ScheduleEvent) error {
 	if err = common.VerifyIdFormat(addressableId, "Addressable"); err != nil {
 		return err
 	}
-	scheduleEvent.Addressable.Id = bson.ObjectIdHex(addressableId)
+	scheduleEvent.Addressable.Id = addressableId
 
 	return nil
 }

--- a/service.go
+++ b/service.go
@@ -205,7 +205,7 @@ func makeNewAddressable() (*models.Addressable, error) {
 			if err = common.VerifyIdFormat(id, "Addressable"); err != nil {
 				return nil, err
 			}
-			addr.Id = bson.ObjectIdHex(id)
+			addr.Id = id
 		} else {
 			common.LoggingClient.Error(fmt.Sprintf("AddressableForName failed: %v", err))
 			return nil, err


### PR DESCRIPTION
The data type of Addressable Id was bson, and
it has been changed to string
Please see the change in edgex-go#938
fix #146

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>