### PR TITLE
Fix the wrong Device Service Id data type

### DIFF
--- a/service.go
+++ b/service.go
@@ -27,7 +27,6 @@ import (
 	ds_models "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/edgex-go/pkg/clients/types"
 	"github.com/edgexfoundry/edgex-go/pkg/models"
-	"github.com/globalsign/mgo/bson"
 )
 
 var (
@@ -173,8 +172,8 @@ func createNewDeviceService() (models.DeviceService, error) {
 
 	// NOTE - this differs from Addressable and Device objects,
 	// neither of which require the '.Service'prefix
-	ds.Service.Id = bson.ObjectIdHex(id)
-	common.LoggingClient.Debug("New deviceservice Id: " + ds.Service.Id.Hex())
+	ds.Service.Id = id
+	common.LoggingClient.Debug("New deviceservice Id: " + ds.Service.Id)
 
 	return ds, nil
 }


### PR DESCRIPTION
Device Service Id was bson data type, and it has become
string according to the design change in edgex-go.
Modify its data type to string to meet edgex-go.
fix #152

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>