### PR TITLE
Add Consul registry support

### DIFF
--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -22,6 +22,8 @@ const (
 	HttpProto         = "HTTP"
 	StatusResponse    = "pong"
 	ServiceStatusPass = "passing"
+	ConfigFileName    = "configuration.toml"
+	ConfigV2Stem      = "config/V2/"
 
 	APICallbackRoute        = APIv1Prefix + "/callback"
 	APIValueDescriptorRoute = APIv1Prefix + "/valuedescriptor"

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -23,7 +23,7 @@ const (
 	StatusResponse    = "pong"
 	ServiceStatusPass = "passing"
 	ConfigFileName    = "configuration.toml"
-	ConfigV2Stem      = "config/V2/"
+	ConfigStem        = "edgex/devices/1.0/"
 
 	APICallbackRoute        = APIv1Prefix + "/callback"
 	APIValueDescriptorRoute = APIv1Prefix + "/valuedescriptor"

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -126,13 +126,13 @@ type Config struct {
 	// Logging contains logging-specific configuration settings.
 	Logging LoggingInfo
 	// Schedules is created on startup.
-	Schedules []models.Schedule
+	Schedules []models.Schedule `consul:"-"`
 	// SchedulesEvents is created on startup.
-	ScheduleEvents []models.ScheduleEvent
+	ScheduleEvents []models.ScheduleEvent `consul:"-"`
 	// Watchers is a map provisionwatchers to be created on startup.
 	Watchers map[string]WatcherInfo
 	// DeviceList is the list of pre-define Devices
-	DeviceList []DeviceConfig
+	DeviceList []DeviceConfig `consul:"-"`
 }
 
 // DeviceConfig is the definition of Devices which will be auto created when the Device Service starts up

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -53,6 +53,7 @@ func LoadConfig(useRegistry bool, profile string, confDir string) (config *commo
 			config, err = RegistryClient.LoadConfig(config)
 			if err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "Load config from Consul failed... %v \n", err)
+				return nil, err
 			}
 		} else {
 			err = RegistryClient.PopulateConfig(*config)

--- a/internal/registry/consul.go
+++ b/internal/registry/consul.go
@@ -92,7 +92,7 @@ func (c *ConsulClient) CheckConfigExistence() bool {
 		return false
 	}
 
-	stem := common.ConfigV2Stem + c.config.ServiceName
+	stem := common.ConfigStem + c.config.ServiceName
 	if stemKeys, _, err := c.Consul.KV().Keys(stem, "", nil); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Retrieving KV from Consul failed...\n")
 		return false
@@ -109,7 +109,7 @@ func (c *ConsulClient) PopulateConfig(config common.Config) error {
 	}
 
 	_, _ = fmt.Fprintf(os.Stdout, "populating config from file to Consul\n")
-	stem := fmt.Sprintf("%s%s", common.ConfigV2Stem, c.config.ServiceName)
+	stem := fmt.Sprintf("%s%s", common.ConfigStem, c.config.ServiceName)
 	err := populateValue(stem, reflect.ValueOf(config), c.Consul)
 
 	return err
@@ -126,7 +126,7 @@ func (c *ConsulClient) LoadConfig(config *common.Config) (*common.Config, error)
 	dec := &consulstructure.Decoder{
 		Consul:   cfg,
 		Target:   &common.Config{},
-		Prefix:   common.ConfigV2Stem + common.ServiceName,
+		Prefix:   common.ConfigStem + common.ServiceName,
 		UpdateCh: updateCh,
 		ErrCh:    errCh,
 	}

--- a/internal/registry/populate.go
+++ b/internal/registry/populate.go
@@ -1,0 +1,133 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+
+	consulapi "github.com/hashicorp/consul/api"
+)
+
+func populateValue(key string, value reflect.Value, consul *consulapi.Client) error {
+	var err error
+	for i := 0; i < value.NumField(); i++ {
+		fieldName := value.Type().Field(i).Name
+		fieldValue := value.Field(i)
+		keyPath := key + "/" + fieldName
+		switch fieldValue.Kind() {
+		case reflect.Slice:
+			for j := 0; j < fieldValue.Len(); j++ {
+				if err = populateSliceValue(keyPath, fieldValue.Index(j), consul); err != nil {
+					break
+				}
+			}
+		case reflect.Map:
+			mapKeys := fieldValue.MapKeys()
+			for _, k := range mapKeys {
+				if err = populateMapValue(keyPath+"/"+k.String(), fieldValue.MapIndex(k), consul); err != nil {
+					break
+				}
+			}
+		case reflect.Struct:
+			err = populateValue(keyPath, fieldValue, consul)
+		case reflect.String:
+			err = populateKVPair(keyPath, fieldValue.String(), consul)
+		case reflect.Int:
+			err = populateKVPair(keyPath, strconv.FormatInt(fieldValue.Int(), 10), consul)
+		case reflect.Bool:
+			err = populateKVPair(keyPath, strconv.FormatBool(fieldValue.Bool()), consul)
+		default:
+			errMsg := fmt.Sprintf("Unexpected fieldValue: %v for key: %s", fieldValue, keyPath)
+			fmt.Println(errMsg)
+			err = fmt.Errorf(errMsg)
+		}
+	}
+	return err
+}
+
+func populateSliceValue(key string, value reflect.Value, consul *consulapi.Client) error {
+	var err error
+	switch value.Kind() {
+	case reflect.Struct:
+		//valueName := value.FieldByName(common.NameField).String()
+		//if valueName != "" {
+		//	err = populateValue(key+"/"+valueName, value, consul)
+		//} else {
+		//	err = populateValue(key, value, consul)
+		//}
+		// ignore struct in slice
+		return nil
+	case reflect.String:
+		err = populateKVPair(key, value.String(), consul)
+	case reflect.Int:
+		err = populateKVPair(key, strconv.FormatInt(value.Int(), 10), consul)
+	case reflect.Bool:
+		err = populateKVPair(key, strconv.FormatBool(value.Bool()), consul)
+	case reflect.Slice:
+		for j := 0; j < value.Len(); j++ {
+			if err = populateSliceValue(key, value.Index(j), consul); err != nil {
+				break
+			}
+		}
+	case reflect.Map:
+		mapKeys := value.MapKeys()
+		for _, k := range mapKeys {
+			if err = populateMapValue(key, value.MapIndex(k), consul); err != nil {
+				break
+			}
+		}
+	default:
+		err = populateValue(key, value, consul)
+	}
+	return err
+}
+
+func populateMapValue(key string, value reflect.Value, consul *consulapi.Client) error {
+	var err error
+	switch value.Kind() {
+	case reflect.String:
+		err = populateKVPair(key, value.String(), consul)
+	case reflect.Int:
+		err = populateKVPair(key, strconv.FormatInt(value.Int(), 10), consul)
+	case reflect.Bool:
+		err = populateKVPair(key, strconv.FormatBool(value.Bool()), consul)
+	case reflect.Slice:
+		for j := 0; j < value.Len(); j++ {
+			if err = populateSliceValue(key, value.Index(j), consul); err != nil {
+				break
+			}
+		}
+	case reflect.Map:
+		mapKeys := value.MapKeys()
+		for _, k := range mapKeys {
+			if err = populateMapValue(key, value.MapIndex(k), consul); err != nil {
+				break
+			}
+		}
+	default:
+		err = populateValue(key, value, consul)
+	}
+	return err
+}
+
+func populateKVPair(key string, value string, consul *consulapi.Client) error {
+	fmt.Fprintf(os.Stdout, "populating %v to %s \n", value, key)
+	if value == "" {
+		return nil
+	}
+
+	// Get a handle to the KV API
+	kv := consul.KV()
+
+	// PUT a new KV pair
+	p := &consulapi.KVPair{Key: key, Value: []byte(value)}
+	_, err := kv.Put(p, nil)
+	return err
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -6,14 +6,20 @@
 
 package registry
 
+import "github.com/edgexfoundry/device-sdk-go/internal/common"
+
 type Client interface {
 	// Initialize Consul by connecting to the agent and registering the service/check
 	Init(config RegistryConfig) error
 
 	GetServiceEndpoint(serviceKey string) (ServiceEndpoint, error)
 
+	CheckConfigExistence() bool
+
+	PopulateConfig(config common.Config) error
+
 	// Look at the key/value pairs to update configuration
-	CheckKeyValuePairs(configurationStruct interface{}, applicationName string, profiles []string) error
+	LoadConfig(config *common.Config) (*common.Config, error)
 }
 
 type ServiceEndpoint struct {


### PR DESCRIPTION
Make config file name as constant
If useRegistry is true and there is no data on Consul,
populate the config from TOML file.
If useRegistry is true and config data exists on Consul,
load config from Consul
Exclude DeviceList, Schedules, and ScheduleEvents from Consul
fix #6

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>