### PR TITLE
Use golang:1.11-alpine as the base image. Ingore go.sum for the moment.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignoring the go.sum file. There are checksum issues with
+# different versions of Golang. Remove once all Go versions
+# are in sync
+go.sum

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,18 +4,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM golang:1.11.2-alpine3.7 AS builder
+FROM golang:1.11-alpine AS builder
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2018: Intel'
 
-# The main mirrors are giving us timeout issues on builds periodically.
-# So we can try these.
-RUN echo http://nl.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories; \
-  echo http://nl.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories
+RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
 
 # add git for go modules
-RUN apk update && apk add --no-cache make git gcc libc-dev
+RUN apk add --update --no-cache make git gcc libc-dev
 
 WORKDIR /github.com/edgexfoundry/device-sdk-go
 


### PR DESCRIPTION
Changes made:

  - Ignore go.sum. Currently there is an issue with the way checksums are computed across patch versions of Go. We have observed that if a go.sum is generated from Go 1.11.2 it may not work with Go 1.11.5. Typically this is seen as a checksum mismatch error on specific modules (github.com/hashicorp/go-rootcerts for example). Until we can get some resolution on this, go.sum will be ignored.
  - Changed the base image to be golang:1.11-alpine as was discussed in the DevOps WG call.
  - Commented out APK repo pinning.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>