### PR TITLE
Fix client ErrNotFound logic regression

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	ds_models "github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -215,7 +214,7 @@ func MakeAddressable(name string, addr *models.Addressable) (*models.Addressable
 	ctx := context.WithValue(context.Background(), CorrelationHeader, uuid.New().String())
 	addressable, err := AddressableClient.AddressableForName(name, ctx)
 	if err != nil {
-		if errsc, ok := err.(*types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
+		if _, ok := err.(types.ErrNotFound); ok {
 			LoggingClient.Debug(fmt.Sprintf("Addressable %s doesn't exist, creating a new one", addr.Name))
 			millis := time.Now().UnixNano() / int64(time.Millisecond)
 			addressable = *addr

--- a/service.go
+++ b/service.go
@@ -127,9 +127,8 @@ func selfRegister() error {
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	ds, err := common.DeviceServiceClient.DeviceServiceForName(common.ServiceName, ctx)
-
 	if err != nil {
-		if errsc, ok := err.(*types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
+		if _, ok := err.(types.ErrNotFound); ok {
 			common.LoggingClient.Info(fmt.Sprintf("Device Service %s doesn't exist, creating a new one", ds.Name))
 			ds, err = createNewDeviceService()
 		} else {
@@ -187,7 +186,7 @@ func makeNewAddressable() (*models.Addressable, error) {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	addr, err := common.AddressableClient.AddressableForName(common.ServiceName, ctx)
 	if err != nil {
-		if errsc, ok := err.(*types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
+		if _, ok := err.(types.ErrNotFound); ok {
 			common.LoggingClient.Info(fmt.Sprintf("Addressable %s doesn't exist, creating a new one", common.ServiceName))
 			millis := time.Now().UnixNano() / int64(time.Millisecond)
 			addr = models.Addressable{


### PR DESCRIPTION
This commit reverses commit 05bfa53 which modified the
NotFound error logic for calls to AddressableClient and
DeviceServiceClient. Both clients in fact are still
returning types.ErrNotFound instances.

Fixes issue #182 