### PR TITLE
Replace Addressable with string map in Device

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -61,7 +61,7 @@ File = "./device-simple.log"
   Profile = "Simple-Device"
   Description = "Example of Simple Device"
   Labels = [ "industrial" ]
-  [DeviceList.Addressable]
-    Address = "simple01"
-    Port = 300
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "simple01"
+      Port = "300"

--- a/example/cmd/device-simple/res/docker/configuration.toml
+++ b/example/cmd/device-simple/res/docker/configuration.toml
@@ -61,7 +61,7 @@ File = "/edgex/logs/device-simple.log"
   Profile = "Simple-Device"
   Description = "Example of Simple Device"
   Labels = [ "industrial" ]
-  [DeviceList.Addressable]
-    Address = "simple01"
-    Port = 300
-    Protocol = "OTHER"
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.other]
+      Address = "simple01"
+      Port = "300"

--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -16,7 +16,6 @@ import (
 
 	ds_models "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logging"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 type SimpleDriver struct {
@@ -27,7 +26,7 @@ type SimpleDriver struct {
 
 // DisconnectDevice handles protocol-specific cleanup when a device
 // is removed.
-func (s *SimpleDriver) DisconnectDevice(address *models.Addressable) error {
+func (s *SimpleDriver) DisconnectDevice(deviceName string, protocols map[string]map[string]string) error {
 	return nil
 }
 
@@ -40,14 +39,14 @@ func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh chan<- *ds_mo
 }
 
 // HandleReadCommands triggers a protocol Read operation for the specified device.
-func (s *SimpleDriver) HandleReadCommands(addr *models.Addressable, reqs []ds_models.CommandRequest) (res []*ds_models.CommandValue, err error) {
+func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[string]map[string]string, reqs []ds_models.CommandRequest) (res []*ds_models.CommandValue, err error) {
 
 	if len(reqs) != 1 {
 		err = fmt.Errorf("SimpleDriver.HandleReadCommands; too many command requests; only one supported")
 		return
 	}
 
-	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleReadCommands: device: %s operation: %v attributes: %v", addr.Name, reqs[0].RO.Operation, reqs[0].DeviceResource.Attributes))
+	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleReadCommands: protocols: %v operation: %v attributes: %v", protocols, reqs[0].RO.Operation, reqs[0].DeviceResource.Attributes))
 
 	res = make([]*ds_models.CommandValue, 1)
 	now := time.Now().UnixNano() / int64(time.Millisecond)
@@ -61,7 +60,7 @@ func (s *SimpleDriver) HandleReadCommands(addr *models.Addressable, reqs []ds_mo
 // a ResourceOperation for a specific device resource.
 // Since the commands are actuation commands, params provide parameters for the individual
 // command.
-func (s *SimpleDriver) HandleWriteCommands(addr *models.Addressable, reqs []ds_models.CommandRequest,
+func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[string]map[string]string, reqs []ds_models.CommandRequest,
 	params []*ds_models.CommandValue) error {
 
 	if len(reqs) != 1 {
@@ -73,7 +72,7 @@ func (s *SimpleDriver) HandleWriteCommands(addr *models.Addressable, reqs []ds_m
 		return err
 	}
 
-	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleWriteCommands: device: %s, operation: %v, parameters: %v", addr.Name, reqs[0].RO.Operation, params))
+	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleWriteCommands: protocols: %v, operation: %v, parameters: %v", protocols, reqs[0].RO.Operation, params))
 	var err error
 	if s.switchButton, err = params[0].BoolValue(); err != nil {
 		err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Boolean, parameter: %s", params[0].String())

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-sdk-go
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190222195937-d11dc767d321
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190306124903-4425df9b51ed
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190221211212-171439dc16f8
 	github.com/globalsign/mgo v0.0.0-20180615134936-113d3961e731
 	github.com/go-kit/kit v0.8.0

--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -23,7 +23,6 @@ type DeviceCache interface {
 	All() []models.Device
 	Add(device models.Device) error
 	Update(device models.Device) error
-	UpdateAddressable(addressable models.Addressable) error
 	Remove(id string) error
 	RemoveByName(name string) error
 	UpdateAdminState(id string, state models.AdminState) error
@@ -86,23 +85,6 @@ func (d *deviceCache) Update(device models.Device) error {
 		return err
 	}
 	return d.Add(device)
-}
-
-// UpdateAddressable updates the device addressable in the cache
-func (d *deviceCache) UpdateAddressable(add models.Addressable) error {
-	found := false
-	for _, device := range d.dMap {
-		if device.Addressable.Id == add.Id {
-			device.Addressable = add
-			found = true
-		}
-	}
-
-	if found == false {
-		return fmt.Errorf("addressable %s does not exist in cache", add.Id)
-	}
-
-	return nil
 }
 
 // Remove removes the specified device by id from the cache.

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -10,8 +10,6 @@ package common
 
 import (
 	"fmt"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // WritableInfo is a struct which contains configuration settings that can be changed in the Registry .
@@ -138,8 +136,8 @@ type DeviceConfig struct {
 	Description string
 	// Other labels applied to the device to help with searching
 	Labels []string
-	// Addressable for the device - stores information about it's address
-	Addressable models.Addressable
+	// Protocols for the device - stores protocol properties
+	Protocols map[string]map[string]string
 }
 
 // ClientInfo provides the host and port of another service in the eco-system.

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	ds_models "github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -72,7 +73,7 @@ func CompareDevices(a models.Device, b models.Device) bool {
 	profileOk := CompareDeviceProfiles(a.Profile, b.Profile)
 	serviceOk := CompareDeviceServices(a.Service, b.Service)
 
-	return a.Addressable == b.Addressable &&
+	return reflect.DeepEqual(a.Protocols, b.Protocols) &&
 		a.AdminState == b.AdminState &&
 		a.Description == b.Description &&
 		a.Id == b.Id &&

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -11,8 +11,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-registry"
-	"github.com/edgexfoundry/go-mod-registry/pkg/factory"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -21,6 +19,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/go-mod-registry"
+	"github.com/edgexfoundry/go-mod-registry/pkg/factory"
 	"github.com/pelletier/go-toml"
 )
 

--- a/internal/handler/callback.go
+++ b/internal/handler/callback.go
@@ -28,14 +28,8 @@ func CallbackHandler(cbAlert models.CallbackAlert, method string) common.AppErro
 
 	if cbAlert.ActionType == models.DEVICE {
 		return handleDevice(method, cbAlert.Id)
-	} else if cbAlert.ActionType == models.ADDRESSABLE {
-		return handleAddresssable(method, cbAlert.Id)
 	} else if cbAlert.ActionType == models.PROFILE {
 		return handleProfile(method, cbAlert.Id)
-	} else if cbAlert.ActionType == models.SCHEDULE {
-		return handleSchedule(method, cbAlert.Id)
-	} else if cbAlert.ActionType == models.SCHEDULEEVENT {
-		return handleScheduleEvent(method, cbAlert.Id)
 	}
 
 	common.LoggingClient.Error(fmt.Sprintf("Invalid callback action type: %s", cbAlert.ActionType))
@@ -108,33 +102,6 @@ func handleDevice(method string, id string) common.AppError {
 	return nil
 }
 
-func handleAddresssable(method string, id string) common.AppError {
-	if method == http.MethodPut {
-		ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-		add, err := common.AddressableClient.Addressable(id, ctx)
-		if err != nil {
-			appErr := common.NewBadRequestError(err.Error(), err)
-			common.LoggingClient.Error(fmt.Sprintf("Cannot find the addressable %s from Core Metadata: %v", id, err))
-			return appErr
-		}
-
-		err = cache.Devices().UpdateAddressable(add)
-		if err == nil {
-			common.LoggingClient.Info(fmt.Sprintf("Updated addressable %s", id))
-		} else {
-			appErr := common.NewServerError(err.Error(), err)
-			common.LoggingClient.Error(fmt.Sprintf("Couldn't update addressable %s: %v", id, err.Error()))
-			return appErr
-		}
-	} else {
-		common.LoggingClient.Error(fmt.Sprintf("Invalid addressable method: %s", method))
-		appErr := common.NewBadRequestError("Invalid addressable method", nil)
-		return appErr
-	}
-
-	return nil
-}
-
 func handleProfile(method string, id string) common.AppError {
 	if method == http.MethodPut {
 		ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
@@ -161,16 +128,4 @@ func handleProfile(method string, id string) common.AppError {
 	}
 
 	return nil
-}
-
-func handleSchedule(method string, id string) common.AppError {
-	common.LoggingClient.Error(fmt.Sprintf("Schedule callback action not implemented"))
-	appErr := common.NewServerError("Schedule callback action not implemented", nil)
-	return appErr
-}
-
-func handleScheduleEvent(method string, id string) common.AppError {
-	common.LoggingClient.Error(fmt.Sprintf("Schedule event callback action not implemented"))
-	appErr := common.NewServerError("Schedule event callback action not implemented", nil)
-	return appErr
 }

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -115,7 +115,7 @@ func execReadCmd(device *models.Device, cmd string) (*models.Event, common.AppEr
 		reqs[i].DeviceResource = dr
 	}
 
-	results, err := common.Driver.HandleReadCommands(&device.Addressable, reqs)
+	results, err := common.Driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
 		msg := fmt.Sprintf("Handler - execReadCmd: error for Device: %s cmd: %s, %v", device.Name, cmd, err)
 		return nil, common.NewServerError(msg, err)
@@ -242,7 +242,7 @@ func execWriteCmd(device *models.Device, cmd string, params string) common.AppEr
 		}
 	}
 
-	err = common.Driver.HandleWriteCommands(&device.Addressable, reqs, cvs)
+	err = common.Driver.HandleWriteCommands(device.Name, device.Protocols, reqs, cvs)
 	if err != nil {
 		msg := fmt.Sprintf("Handler - execWriteCmd: error for Device: %s cmd: %s, %v", device.Name, cmd, err)
 		return common.NewServerError(msg, err)

--- a/internal/mock/mock_deviceclient.go
+++ b/internal/mock/mock_deviceclient.go
@@ -61,14 +61,6 @@ func (dc *DeviceClientMock) DevicesByLabel(label string, ctx context.Context) ([
 	panic("implement me")
 }
 
-func (dc *DeviceClientMock) DevicesForAddressable(addressableid string, ctx context.Context) ([]models.Device, error) {
-	panic("implement me")
-}
-
-func (dc *DeviceClientMock) DevicesForAddressableByName(addressableName string, ctx context.Context) ([]models.Device, error) {
-	panic("implement me")
-}
-
 func (dc *DeviceClientMock) DevicesForProfile(profileid string, ctx context.Context) ([]models.Device, error) {
 	panic("implement me")
 }

--- a/internal/provision/devices.go
+++ b/internal/provision/devices.go
@@ -44,17 +44,11 @@ func createDevice(dc common.DeviceConfig) error {
 		return fmt.Errorf(errMsg)
 	}
 
-	addr, err := common.MakeAddressable(dc.Name, &dc.Addressable)
-	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("makeAddressable failed: %v", err))
-		return err
-	}
-
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	device := &models.Device{
 		Name:           dc.Name,
 		Profile:        prf,
-		Addressable:    *addr,
+		Protocols:      dc.Protocols,
 		Labels:         dc.Labels,
 		Service:        common.CurrentDeviceService,
 		AdminState:     models.Unlocked,

--- a/manageddevices.go
+++ b/manageddevices.go
@@ -38,17 +38,10 @@ func (s *Service) AddDevice(device models.Device) (id string, err error) {
 		return "", fmt.Errorf(errMsg)
 	}
 
-	addr, err := common.MakeAddressable(device.Name, &device.Addressable)
-	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("makeAddressable failed: %v", err))
-		return "", err
-	}
-
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	device.Origin = millis
 	device.Service = common.CurrentDeviceService
 	device.Profile = prf
-	device.Addressable = *addr
 	common.LoggingClient.Debug(fmt.Sprintf("Adding Device: %v", device))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())

--- a/pkg/models/protocoldriver.go
+++ b/pkg/models/protocoldriver.go
@@ -13,7 +13,6 @@ package models
 
 import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logging"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // ProtocolDriver is a low-level device-specific interface used by
@@ -26,12 +25,7 @@ type ProtocolDriver interface {
 	// logic to be performed.  Device services which don't require this
 	// function should just return 'nil'.
 	//
-	// TODO: the Java code uses this signature, with the addressable
-	// appearing to be that of the device service itself. I'm not sure
-	// how this gets tied by the driver code to an actual device. Maybe
-	// this should be *models.Device?
-	//
-	DisconnectDevice(address *models.Addressable) error
+	DisconnectDevice(deviceName string, protocols map[string]map[string]string) error
 
 	// Initialize performs protocol-specific initialization for the device
 	// service. The given *AsyncValues channel can be used to push asynchronous
@@ -40,13 +34,13 @@ type ProtocolDriver interface {
 
 	// HandleReadCommands passes a slice of CommandRequest struct each representing
 	// a ResourceOperation for a specific device resource.
-	HandleReadCommands(addr *models.Addressable, reqs []CommandRequest) ([]*CommandValue, error)
+	HandleReadCommands(deviceName string, protocols map[string]map[string]string, reqs []CommandRequest) ([]*CommandValue, error)
 
 	// HandleWriteCommands passes a slice of CommandRequest struct each representing
 	// a ResourceOperation for a specific device resource.
 	// Since the commands are actuation commands, params provide parameters for the individual
 	// command.
-	HandleWriteCommands(addr *models.Addressable, reqs []CommandRequest, params []*CommandValue) error
+	HandleWriteCommands(deviceName string, protocols map[string]map[string]string, reqs []CommandRequest, params []*CommandValue) error
 
 	// Stop instructs the protocol-specific DS code to shutdown gracefully, or
 	// if the force parameter is 'true', immediately. The driver is responsible


### PR DESCRIPTION
Addressable in Device data model is replaced by map[string]map[string]string (protocols and protocolProperty)
fix #188

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>