### PR TITLE
Make wait/retry params configurable

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -4,7 +4,7 @@ LogLevel = 'INFO'
 [Service]
 Host = "localhost"
 Port = 49990
-ConnectRetries = 3
+ConnectRetries = 20
 Labels = []
 OpenMsg = "device simple started"
 ReadMaxLimit = 256

--- a/example/cmd/device-simple/res/docker/configuration.toml
+++ b/example/cmd/device-simple/res/docker/configuration.toml
@@ -4,7 +4,7 @@ LogLevel = 'INFO'
 [Service]
 Host = "device-simple"
 Port = 49990
-ConnectRetries = 3
+ConnectRetries = 20
 Labels = []
 OpenMsg = "device simple started"
 ReadMaxLimit = 256

--- a/internal/clients/init.go
+++ b/internal/clients/init.go
@@ -113,7 +113,7 @@ func checkDependencyServices() error {
 }
 
 func checkServiceAvailable(serviceId string) error {
-	for i := 0; i < 50; i++ {
+	for i := 0; i < common.CurrentConfig.Service.ConnectRetries; i++ {
 		if common.UseRegistry {
 			if checkServiceAvailableViaRegistry(common.CurrentConfig.Clients[serviceId].Name) == true {
 				return nil
@@ -123,7 +123,7 @@ func checkServiceAvailable(serviceId string) error {
 				return nil
 			}
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(time.Duration(common.CurrentConfig.Service.Timeout) * time.Millisecond)
 		common.LoggingClient.Debug(fmt.Sprintf("Checked %d times for %s availibility", i+1, serviceId))
 	}
 

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -27,10 +27,8 @@ type ServiceInfo struct {
 	Host string
 	// Port is the HTTP port of the service.
 	Port int
-	// ConnectRetries is the number of times the DS will try
-	// to connect to Core Metadata to either register itself
-	// and provision it's objects, or use existing data. If
-	// this limit is exceeded, the DS will exit.
+	// ConnectRetries is the number of times the DS will try to connect to all dependent services.
+	// If exceeded for even one dependent service, the DS will exit.
 	ConnectRetries int
 	// Labels are...
 	Labels []string
@@ -39,8 +37,9 @@ type ServiceInfo struct {
 	// ReadMaxLimit specifies the maximum size list supported
 	// in response to REST calls to other services.
 	ReadMaxLimit int
-	// Timeout specifies a timeout (in milliseconds) for
-	// processing REST calls from other services.
+	// Timeout (in milliseconds) specifies both
+	// - timeout for processing REST calls and
+	// - interval time the DS will wait between each retry call.
 	Timeout int
 	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
 	EnableAsyncReadings bool


### PR DESCRIPTION
On validate that all dependant services are available use already existing params in configuration.tolm file
Service/ConnectRetries
Service/Timeout

Signed-off-by: difince <dianaa@vmware.com>