### PR TITLE
Created error return condition for wrong parameter name.

### DIFF
--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -280,7 +280,8 @@ func parseWriteParams(profileName string, roMap map[string]*models.ResourceOpera
 				return result, err
 			}
 		} else {
-			common.LoggingClient.Warn(fmt.Sprintf("Handler - parseWriteParams: The parameter %s cannot find the matched ResourceOperation", k))
+			err := fmt.Errorf("the parameter %s cannot find the matched ResourceOperation", k)
+			return []*ds_models.CommandValue{}, err
 		}
 	}
 

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -259,6 +259,11 @@ func parseWriteParams(profileName string, roMap map[string]*models.ResourceOpera
 		return []*ds_models.CommandValue{}, err
 	}
 
+	if len(paramMap) == 0 {
+		err := fmt.Errorf("no parameters specified")
+		return []*ds_models.CommandValue{}, err
+	}
+
 	result := make([]*ds_models.CommandValue, 0, len(paramMap))
 	for k, v := range paramMap {
 		ro, ok := roMap[k]

--- a/internal/handler/command_test.go
+++ b/internal/handler/command_test.go
@@ -22,3 +22,15 @@ func TestParseWriteParamsWrongParamName(t *testing.T) {
 		t.Error("expected error")
 	}
 }
+
+func TestParseWriteParamsNoParams(t *testing.T) {
+	profileName := "notFound"
+	roMap := roSliceToMap([]models.ResourceOperation{{Index: ""}})
+	params := "{ }"
+
+	_, err := parseWriteParams(profileName, roMap, params)
+
+	if  err == nil {
+		t.Error("expected error")
+	}
+}

--- a/internal/handler/command_test.go
+++ b/internal/handler/command_test.go
@@ -1,0 +1,24 @@
+package handler
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func TestParseWriteParamsWrongParamName(t *testing.T) {
+	profileName := "notFound"
+	roMap := roSliceToMap([]models.ResourceOperation{{Index: ""}})
+	params := "{ \"key\": \"value\" }"
+
+	_, err := parseWriteParams(profileName, roMap, params)
+
+	if  err == nil {
+		t.Error("expected error")
+	}
+}


### PR DESCRIPTION
Issue #123. 400 error is handled by the overriding application logic.

Signed-off-by: Brandon Forster <brandonforster@gmail.com>