### PR TITLE
Address #230 device simple startup crash

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -123,7 +123,11 @@ func loadConfigFromFile(profile string, confDir string) (config *common.Config, 
 		confDir = confDir + "/" + profile
 	}
 
-	path := confDir + "/" + common.ConfigFileName
+	appPath, err := os.Getwd()
+	if err != nil {
+		err = fmt.Errorf("could not get application working directory for configuration", err.Error())
+	}
+	path := path.Join(filepath.Dir(appPath), confDir, common.ConfigFileName)
 	_, _ = fmt.Fprintf(os.Stdout, "Loading configuration from: %s\n", path)
 
 	// As the toml package can panic if TOML is invalid,

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -14,6 +14,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"path"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -119,16 +121,13 @@ func loadConfigFromFile(profile string, confDir string) (config *common.Config, 
 		confDir = common.ConfigDirectory
 	}
 
-	if len(profile) > 0 {
-		confDir = confDir + "/" + profile
-	}
-
-	appPath, err := os.Getwd()
+	path := path.Join(confDir, common.ConfigFileName)
+	absPath, err := filepath.Abs(path)
 	if err != nil {
-		err = fmt.Errorf("could not get application working directory for configuration", err.Error())
+		err = fmt.Errorf("Could not create absolute path to load configuration: %s; %v", path, err.Error())
+		return nil, err
 	}
-	path := path.Join(filepath.Dir(appPath), confDir, common.ConfigFileName)
-	_, _ = fmt.Fprintf(os.Stdout, "Loading configuration from: %s\n", path)
+	fmt.Fprintln(os.Stdout, fmt.Sprintf("Loading configuration from: %s\n", absPath))
 
 	// As the toml package can panic if TOML is invalid,
 	// or elements are found that don't match members of
@@ -143,7 +142,7 @@ func loadConfigFromFile(profile string, confDir string) (config *common.Config, 
 	config = &common.Config{}
 	contents, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("could not load configuration file (%s): %v", path, err.Error())
+		return nil, fmt.Errorf("Could not load configuration file (%s): %v\nBe sure to change to program folder or set working directory.", path, err.Error())
 	}
 
 	// Decode the configuration from TOML

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -40,6 +40,9 @@ func LoadConfig(useRegistry bool, profile string, confDir string) (*common.Confi
 		useRegistry, profile, confDir)
 
 	configuration, err := loadConfigFromFile(profile, confDir)
+	if err != nil {
+		return nil, err
+	}
 
 	// TODO: Verify this is correct.
 	stem := common.ConfigRegistryStem + common.ServiceName + "/"


### PR DESCRIPTION
Adds error check to resolve segfault.
Publishes absolute path indicating from where we are attempting to load configuration.toml.