### PR TITLE
Remove RO 'property=value' from example devprof

### DIFF
--- a/example/cmd/device-simple/res/Simple-Driver.yaml
+++ b/example/cmd/device-simple/res/Simple-Driver.yaml
@@ -27,13 +27,13 @@ deviceCommands:
     -
         name: "Switch"
         get:
-            - { operation: "get", object: "SwitchButton", property: "value", parameter: "Switch" }
+            - { operation: "get", object: "SwitchButton", parameter: "Switch" }
         set:
-            - { operation: "set", object: "SwitchButton", property: "value", parameter: "Switch" }
+            - { operation: "set", object: "SwitchButton", parameter: "Switch" }
     -
         name: "Image"
         get:
-          - { operation: "get", object: "Image", property: "value", parameter: "Image" }
+          - { operation: "get", object: "Image", parameter: "Image" }
 
 coreCommands:
   -


### PR DESCRIPTION
The original EdgeX device profile required an attribute ('property')
in a device profile ResourceOperation that was always set to 'value'.
As such, this attribute was removed from the model, but still exists
in the example device profile YAML.

Fixes issue #247 