### PR TITLE
Refactor callback.go to different go files

### DIFF
--- a/internal/handler/callback/device.go
+++ b/internal/handler/callback/device.go
@@ -16,27 +16,8 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/internal/provision"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
 )
-
-func CallbackHandler(cbAlert contract.CallbackAlert, method string) common.AppError {
-	if (cbAlert.Id == "") || (cbAlert.ActionType == "") {
-		appErr := common.NewBadRequestError("Missing parameters", nil)
-		common.LoggingClient.Error(fmt.Sprintf("Missing callback parameters"))
-		return appErr
-	}
-
-	if cbAlert.ActionType == contract.DEVICE {
-		return handleDevice(method, cbAlert.Id)
-	} else if cbAlert.ActionType == contract.PROFILE {
-		return handleProfile(method, cbAlert.Id)
-	}
-
-	common.LoggingClient.Error(fmt.Sprintf("Invalid callback action type: %s", cbAlert.ActionType))
-	appErr := common.NewBadRequestError("Invalid callback action type", nil)
-	return appErr
-}
 
 func handleDevice(method string, id string) common.AppError {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
@@ -108,34 +89,6 @@ func handleDevice(method string, id string) common.AppError {
 	} else {
 		common.LoggingClient.Error(fmt.Sprintf("Invalid device method type: %s", method))
 		appErr := common.NewBadRequestError("Invalid device method", nil)
-		return appErr
-	}
-
-	return nil
-}
-
-func handleProfile(method string, id string) common.AppError {
-	if method == http.MethodPut {
-		ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-		profile, err := common.DeviceProfileClient.DeviceProfile(id, ctx)
-		if err != nil {
-			appErr := common.NewBadRequestError(err.Error(), err)
-			common.LoggingClient.Error(fmt.Sprintf("Cannot find the device profile %s from Core Metadata: %v", id, err))
-			return appErr
-		}
-
-		err = cache.Profiles().Update(profile)
-		if err == nil {
-			provision.CreateDescriptorsFromProfile(&profile)
-			common.LoggingClient.Info(fmt.Sprintf("Updated device profile %s", id))
-		} else {
-			appErr := common.NewServerError(err.Error(), err)
-			common.LoggingClient.Error(fmt.Sprintf("Couldn't update device profile %s: %v", id, err.Error()))
-			return appErr
-		}
-	} else {
-		common.LoggingClient.Error(fmt.Sprintf("Invalid device profile method: %s", method))
-		appErr := common.NewBadRequestError("Invalid device profile method", nil)
 		return appErr
 	}
 

--- a/internal/handler/callback/general.go
+++ b/internal/handler/callback/general.go
@@ -1,0 +1,33 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2017-2018 Canonical Ltd
+// Copyright (C) 2018-2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package callback
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+func CallbackHandler(cbAlert contract.CallbackAlert, method string) common.AppError {
+	if (cbAlert.Id == "") || (cbAlert.ActionType == "") {
+		appErr := common.NewBadRequestError("Missing parameters", nil)
+		common.LoggingClient.Error(fmt.Sprintf("Missing callback parameters"))
+		return appErr
+	}
+
+	if cbAlert.ActionType == contract.DEVICE {
+		return handleDevice(method, cbAlert.Id)
+	} else if cbAlert.ActionType == contract.PROFILE {
+		return handleProfile(method, cbAlert.Id)
+	}
+
+	common.LoggingClient.Error(fmt.Sprintf("Invalid callback action type: %s", cbAlert.ActionType))
+	appErr := common.NewBadRequestError("Invalid callback action type", nil)
+	return appErr
+}

--- a/internal/handler/callback/profile.go
+++ b/internal/handler/callback/profile.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2017-2018 Canonical Ltd
+// Copyright (C) 2018-2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package callback
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/cache"
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/provision"
+	"github.com/google/uuid"
+)
+
+func handleProfile(method string, id string) common.AppError {
+	if method == http.MethodPut {
+		ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
+		profile, err := common.DeviceProfileClient.DeviceProfile(id, ctx)
+		if err != nil {
+			appErr := common.NewBadRequestError(err.Error(), err)
+			common.LoggingClient.Error(fmt.Sprintf("Cannot find the device profile %s from Core Metadata: %v", id, err))
+			return appErr
+		}
+
+		err = cache.Profiles().Update(profile)
+		if err == nil {
+			provision.CreateDescriptorsFromProfile(&profile)
+			common.LoggingClient.Info(fmt.Sprintf("Updated device profile %s", id))
+		} else {
+			appErr := common.NewServerError(err.Error(), err)
+			common.LoggingClient.Error(fmt.Sprintf("Couldn't update device profile %s: %v", id, err.Error()))
+			return appErr
+		}
+	} else {
+		common.LoggingClient.Error(fmt.Sprintf("Invalid device profile method: %s", method))
+		appErr := common.NewBadRequestError("Invalid device profile method", nil)
+		return appErr
+	}
+
+	return nil
+}


### PR DESCRIPTION
to prevent the file name is the same as package name,
separating the function to three different go files.
fix #237

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>