### PR TITLE
Integrate Core-Contracts Changes from Model Validation Work

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190408185438-838c1e45fef1
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190424163605-a546376dd35a
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -83,7 +83,7 @@ func CompareCoreCommands(a []contract.Command, b []contract.Command) bool {
 	}
 
 	for i := range a {
-		if a[i] != b[i] {
+		if a[i].String() != b[i].String() {
 			return false
 		}
 	}
@@ -149,7 +149,7 @@ func CompareDeviceResources(a []contract.DeviceResource, b []contract.DeviceReso
 }
 
 func CompareDeviceServices(a contract.DeviceService, b contract.DeviceService) bool {
-	serviceOk := CompareServices(a.Service, b.Service)
+	serviceOk := CompareServices(a, b)
 	return a.AdminState == b.AdminState && serviceOk
 }
 
@@ -193,7 +193,7 @@ func CompareResourceOperations(a []contract.ResourceOperation, b []contract.Reso
 	return true
 }
 
-func CompareServices(a contract.Service, b contract.Service) bool {
+func CompareServices(a contract.DeviceService, b contract.DeviceService) bool {
 	labelsOk := CompareStrings(a.Labels, b.Labels)
 
 	return a.DescribedObject == b.DescribedObject &&

--- a/service.go
+++ b/service.go
@@ -160,15 +160,13 @@ func createNewDeviceService() (contract.DeviceService, error) {
 	}
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	ds := contract.DeviceService{
-		Service: contract.Service{
-			Name:           common.ServiceName,
-			Labels:         svc.svcInfo.Labels,
-			OperatingState: "ENABLED",
-			Addressable:    *addr,
-		},
-		AdminState: "UNLOCKED",
+		Name:           common.ServiceName,
+		Labels:         svc.svcInfo.Labels,
+		OperatingState: "ENABLED",
+		Addressable:    *addr,
+		AdminState:     "UNLOCKED",
 	}
-	ds.Service.Origin = millis
+	ds.Origin = millis
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err := common.DeviceServiceClient.Add(&ds, ctx)
@@ -182,8 +180,8 @@ func createNewDeviceService() (contract.DeviceService, error) {
 
 	// NOTE - this differs from Addressable and Device objects,
 	// neither of which require the '.Service'prefix
-	ds.Service.Id = id
-	common.LoggingClient.Debug("New deviceservice Id: " + ds.Service.Id)
+	ds.Id = id
+	common.LoggingClient.Debug("New deviceservice Id: " + ds.Id)
 
 	return ds, nil
 }


### PR DESCRIPTION
#254 

These changes are all related to the fact that the models.Service struct type in the core-contracts module went away. It was a hold-over from an inheritance relationship in the Java codebase and nothing else was using it except for DeviceService. Most of the DeviceService properties were found on the Service type, and have been moved.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>