### PR TITLE
Add start up option -profile back to config path

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -121,6 +121,10 @@ func loadConfigFromFile(profile string, confDir string) (config *common.Config, 
 		confDir = common.ConfigDirectory
 	}
 
+	if len(profile) > 0 {
+		confDir = confDir + "/" + profile
+	}
+
 	path := path.Join(confDir, common.ConfigFileName)
 	absPath, err := filepath.Abs(path)
 	if err != nil {


### PR DESCRIPTION
the profile was removed from config path in #231,
so add it back to meet the behavior of edgex-go
fix #257

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>