### PR TITLE
 Make float encoding according to PropertyValue 

### DIFF
--- a/async.go
+++ b/async.go
@@ -69,7 +69,7 @@ func processAsyncResults() {
 				}
 			}
 
-			reading := common.CommandValueToReading(cv)
+			reading := common.CommandValueToReading(cv, device.Name, dr.Properties.Value.FloatEncoding)
 			readings = append(readings, *reading)
 		}
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -31,12 +31,12 @@ func BuildAddr(host string, port string) string {
 	return buffer.String()
 }
 
-func CommandValueToReading(cv *dsModels.CommandValue) *contract.Reading {
-	reading := &contract.Reading{Name: cv.DeviceResourceName}
+func CommandValueToReading(cv *dsModels.CommandValue, devName string, encoding string) *contract.Reading {
+	reading := &contract.Reading{Name: cv.DeviceResourceName, Device: devName}
 	if cv.Type == dsModels.Binary {
 		reading.BinaryValue = cv.BinValue
 	} else {
-		reading.Value = cv.ValueToString()
+		reading.Value = cv.ValueToString(encoding)
 	}
 
 	// if value has a non-zero Origin, use it

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -170,7 +170,7 @@ func execReadCmd(device *contract.Device, cmd string) (*dsModels.Event, common.A
 		// been implemened in gxds. TBD at the devices f2f whether this
 		// be killed completely.
 
-		reading := common.CommandValueToReading(cv)
+		reading := common.CommandValueToReading(cv, device.Name, dr.Properties.Value.FloatEncoding)
 		readings = append(readings, *reading)
 
 		common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: device: %s DeviceResource: %v reading: %v", device.Name, cv.DeviceResourceName, reading))

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -142,14 +142,16 @@ func createDescriptor(name string, dr contract.DeviceResource) (*contract.ValueD
 	common.LoggingClient.Debug(fmt.Sprintf("ps: createDescriptor: %s, value: %v, units: %v", name, value, units))
 
 	desc := &contract.ValueDescriptor{
-		Name:         name,
-		Min:          value.Minimum,
-		Max:          value.Maximum,
-		Type:         value.Type,
-		UomLabel:     units.DefaultValue,
-		DefaultValue: value.DefaultValue,
-		Formatting:   "%s",
-		Description:  dr.Description,
+		Name:          name,
+		Min:           value.Minimum,
+		Max:           value.Maximum,
+		Type:          value.Type,
+		UomLabel:      units.DefaultValue,
+		DefaultValue:  value.DefaultValue,
+		Formatting:    "%s",
+		Description:   dr.Description,
+		FloatEncoding: value.FloatEncoding,
+		MediaType:     value.MediaType,
 	}
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -14,6 +14,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // Test NewBoolValue function.
@@ -490,7 +492,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString() != "AAAAAQ==" {
+	if cv.ValueToString(contract.Base64Encoding) != "AAAAAQ==" {
 		t.Errorf("NewFloat32Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -512,7 +514,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString() != "f3///w==" {
+	if cv.ValueToString(contract.Base64Encoding) != "f3///w==" {
 		t.Errorf("NewFloat32Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }
@@ -541,7 +543,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString() != "AAAAAAAAAAE=" {
+	if cv.ValueToString(contract.Base64Encoding) != "AAAAAAAAAAE=" {
 		t.Errorf("NewFloat64Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -563,7 +565,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString() != "f+////////8=" {
+	if cv.ValueToString(contract.Base64Encoding) != "f+////////8=" {
 		t.Errorf("NewFloat64Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }


### PR DESCRIPTION
The float value of reading was base64 encoding only.
This commit makes it configurable by PropertyValue.
fix #107

Add new fields when careating ValueDescriptor