### PR TITLE
Remove Device name in Readings when sending Event

### DIFF
--- a/async.go
+++ b/async.go
@@ -69,7 +69,7 @@ func processAsyncResults() {
 				}
 			}
 
-			reading := common.CommandValueToReading(cv, device.Name)
+			reading := common.CommandValueToReading(cv)
 			readings = append(readings, *reading)
 		}
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -31,8 +31,8 @@ func BuildAddr(host string, port string) string {
 	return buffer.String()
 }
 
-func CommandValueToReading(cv *dsModels.CommandValue, devName string) *contract.Reading {
-	reading := &contract.Reading{Name: cv.DeviceResourceName, Device: devName}
+func CommandValueToReading(cv *dsModels.CommandValue) *contract.Reading {
+	reading := &contract.Reading{Name: cv.DeviceResourceName}
 	if cv.Type == dsModels.Binary {
 		reading.BinaryValue = cv.BinValue
 	} else {

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -170,7 +170,7 @@ func execReadCmd(device *contract.Device, cmd string) (*dsModels.Event, common.A
 		// been implemened in gxds. TBD at the devices f2f whether this
 		// be killed completely.
 
-		reading := common.CommandValueToReading(cv, device.Name)
+		reading := common.CommandValueToReading(cv)
 		readings = append(readings, *reading)
 
 		common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: device: %s DeviceResource: %v reading: %v", device.Name, cv.DeviceResourceName, reading))


### PR DESCRIPTION
Device names in the Readings are redundant,
because they are the same name in the Event.
fix #269

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>