### PR TITLE
Use command line option to set the registry url

### DIFF
--- a/example/cmd/device-simple/Dockerfile
+++ b/example/cmd/device-simple/Dockerfile
@@ -38,4 +38,4 @@ WORKDIR /
 COPY --from=builder /go/src/github.com/edgexfoundry/device-sdk-go/example/cmd/device-simple/device-simple /usr/local/bin/device-simple
 COPY --from=builder /go/src/github.com/edgexfoundry/device-sdk-go/example/cmd/device-simple/res/docker/configuration.toml /res/docker/configuration.toml
 
-CMD [ "/usr/local/bin/device-simple","--registry","--profile=docker","--confdir=/res"]
+CMD [ "/usr/local/bin/device-simple","--profile=docker","--confdir=/res"]

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -26,6 +26,7 @@ const (
 	ConfigFileName     = "configuration.toml"
 	ConfigRegistryStem = "edgex/devices/1.0/"
 	WritableKey        = "/Writable"
+	RegistryFailLimit  = 3
 
 	APICallbackRoute        = APIv1Prefix + "/callback"
 	APIValueDescriptorRoute = APIv1Prefix + "/valuedescriptor"

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -21,14 +21,14 @@ import (
 var (
 	confProfile string
 	confDir     string
-	useRegistry bool
+	useRegistry string
 )
 
 // Bootstrap starts the Device Service in a default way
 func Bootstrap(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) {
 	//flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError) // clean up existing flag defined by other code
-	flag.BoolVar(&useRegistry, "registry", false, "Indicates the service should use the registry.")
-	flag.BoolVar(&useRegistry, "r", false, "Indicates the service should use registry.")
+	flag.StringVar(&useRegistry, "registry", "", "Indicates the service should use the registry and provide the registry url.")
+	flag.StringVar(&useRegistry, "r", "", "Indicates the service should use registry and provide the registry path.")
 	flag.StringVar(&confProfile, "profile", "", "Specify a profile other than default.")
 	flag.StringVar(&confProfile, "p", "", "Specify a profile other than default.")
 	flag.StringVar(&confDir, "confdir", "", "Specify an alternate configuration directory.")

--- a/service.go
+++ b/service.go
@@ -240,7 +240,7 @@ func (s *Service) Stop(force bool) error {
 // version number, config profile, config directory, whether to use registry, and Driver, which cannot be nil.
 // Note - this function is a singleton, if called more than once,
 // it will always return an error.
-func NewService(serviceName string, serviceVersion string, confProfile string, confDir string, useRegistry bool, proto dsModels.ProtocolDriver) (*Service, error) {
+func NewService(serviceName string, serviceVersion string, confProfile string, confDir string, useRegistry string, proto dsModels.ProtocolDriver) (*Service, error) {
 	startTime := time.Now()
 	if svc != nil {
 		err := fmt.Errorf("NewService: service already exists!\n")


### PR DESCRIPTION
Use command line option to set the registry url

To meet the behavior of C SDK and make users more easy to set up the registry, we suggest to make -r or --registry to input the path string instead of a simple boolean:
-r, --registry=[URL]
parse URL as [type]://[location]
eg, consul://localhost:8500
fix #253

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>