### PR TITLE
Make log messages not dump entire objects

### DIFF
--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -104,7 +104,7 @@ func execReadCmd(device *contract.Device, cmd string) (*dsModels.Event, common.A
 		// instead of a device resource (see BoschXDK for reference).
 
 		dr, ok := cache.Profiles().DeviceResource(device.Profile.Name, drName)
-		common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: deviceResource: %v", dr))
+		common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: deviceResource: %s", drName))
 		if !ok {
 			msg := fmt.Sprintf("Handler - execReadCmd: no deviceResource: %s for dev: %s cmd: %s method: GET", drName, device.Name, cmd)
 			common.LoggingClient.Error(msg)
@@ -229,7 +229,7 @@ func execWriteCmd(device *contract.Device, cmd string, params string) common.App
 		// instead of a device resource (see BoschXDK for reference).
 
 		dr, ok := cache.Profiles().DeviceResource(device.Profile.Name, drName)
-		common.LoggingClient.Debug(fmt.Sprintf("Handler - execWriteCmd: putting deviceResource: %v", dr))
+		common.LoggingClient.Debug(fmt.Sprintf("Handler - execWriteCmd: putting deviceResource: %s", drName))
 		if !ok {
 			msg := fmt.Sprintf("Handler - execWriteCmd: no deviceResource: %s for dev: %s cmd: %s method: GET", drName, device.Name, cmd)
 			common.LoggingClient.Error(msg)
@@ -281,7 +281,7 @@ func parseWriteParams(profileName string, roMap map[string]*contract.ResourceOpe
 				if ok {
 					v = newV
 				} else {
-					msg := fmt.Sprintf("Handler - parseWriteParams: Resource Operation (%v) mapping value (%s) failed with the mapping table: %v", ro, v, ro.Mappings)
+					msg := fmt.Sprintf("Handler - parseWriteParams: Resource (%s) mapping value (%s) failed with the mapping table: %v", ro.Object, v, ro.Mappings)
 					common.LoggingClient.Warn(msg)
 					//return result, fmt.Errorf(msg) // issue #89 will discuss how to handle there is no mapping matched
 				}

--- a/internal/provision/devices.go
+++ b/internal/provision/devices.go
@@ -19,7 +19,7 @@ import (
 )
 
 func LoadDevices(deviceList []common.DeviceConfig) error {
-	common.LoggingClient.Debug(fmt.Sprintf("Loading pre-define Devices from configuration: %v", deviceList))
+	common.LoggingClient.Debug("Loading pre-define Devices from configuration")
 	for _, d := range deviceList {
 		if _, ok := cache.Devices().ForName(d.Name); ok {
 			common.LoggingClient.Debug(fmt.Sprintf("Device %s exists, using the existing one", d.Name))
@@ -28,7 +28,7 @@ func LoadDevices(deviceList []common.DeviceConfig) error {
 			common.LoggingClient.Debug(fmt.Sprintf("Device %s doesn't exist, creating a new one", d.Name))
 			err := createDevice(d)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("creating Device from config failed: %v", d))
+				common.LoggingClient.Error(fmt.Sprintf("creating Device from config failed: %s", d.Name))
 				return err
 			}
 		}
@@ -39,7 +39,7 @@ func LoadDevices(deviceList []common.DeviceConfig) error {
 func createDevice(dc common.DeviceConfig) error {
 	prf, ok := cache.Profiles().ForName(dc.Profile)
 	if !ok {
-		errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Device %v", dc.Profile, dc)
+		errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Device %s", dc.Profile, dc.Name)
 		common.LoggingClient.Error(errMsg)
 		return fmt.Errorf(errMsg)
 	}
@@ -61,7 +61,7 @@ func createDevice(dc common.DeviceConfig) error {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err := common.DeviceClient.Add(device, ctx)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Device failed %v, error: %v", device, err))
+		common.LoggingClient.Error(fmt.Sprintf("Add Device failed %s, error: %v", device.Name, err))
 		return err
 	}
 	if err = common.VerifyIdFormat(id, "Device"); err != nil {

--- a/manageddevices.go
+++ b/manageddevices.go
@@ -29,11 +29,11 @@ func (s *Service) AddDevice(device contract.Device) (id string, err error) {
 		return d.Id, fmt.Errorf("name conflicted, Device %s exists", device.Name)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Adding managed device: : %v\n", device))
+	common.LoggingClient.Debug(fmt.Sprintf("Adding managed device: : %s\n", device.Name))
 
 	prf, ok := cache.Profiles().ForName(device.Profile.Name)
 	if !ok {
-		errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Device %v", device.Profile.Name, device)
+		errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Device %s", device.Profile.Name, device.Name)
 		common.LoggingClient.Error(errMsg)
 		return "", fmt.Errorf(errMsg)
 	}
@@ -42,12 +42,12 @@ func (s *Service) AddDevice(device contract.Device) (id string, err error) {
 	device.Origin = millis
 	device.Service = common.CurrentDeviceService
 	device.Profile = prf
-	common.LoggingClient.Debug(fmt.Sprintf("Adding Device: %v", device))
+	common.LoggingClient.Debug(fmt.Sprintf("Adding Device: %s", device.Name))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err = common.DeviceClient.Add(&device, ctx)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Device failed %v, error: %v", device, err))
+		common.LoggingClient.Error(fmt.Sprintf("Add Device failed %s, error: %v", device.Name, err))
 		return "", err
 	}
 	if err = common.VerifyIdFormat(id, "Device"); err != nil {
@@ -85,7 +85,7 @@ func (s *Service) RemoveDevice(id string) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %v\n", device))
+	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceClient.Delete(id, ctx)
 	if err != nil {
@@ -107,7 +107,7 @@ func (s *Service) RemoveDeviceByName(name string) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %v\n", device))
+	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceClient.DeleteByName(name, ctx)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *Service) UpdateDevice(device contract.Device) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed Device: : %v\n", device))
+	common.LoggingClient.Debug(fmt.Sprintf("Updating managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceClient.Update(device, ctx)
 	if err != nil {

--- a/managedprofiles.go
+++ b/managedprofiles.go
@@ -26,15 +26,14 @@ func (s *Service) AddDeviceProfile(profile contract.DeviceProfile) (id string, e
 		return p.Id, fmt.Errorf("name conflicted, Profile %s exists", profile.Name)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Adding managed Profile: : %v\n", profile))
+	common.LoggingClient.Debug(fmt.Sprintf("Adding managed Profile: : %s", profile.Name))
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	profile.Origin = millis
-	common.LoggingClient.Debug(fmt.Sprintf("Adding Profile: %v", profile))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err = common.DeviceProfileClient.Add(&profile, ctx)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Profile failed %v, error: %v", profile, err))
+		common.LoggingClient.Error(fmt.Sprintf("Add Profile failed %s, error: %v", profile.Name, err))
 		return "", err
 	}
 	if err = common.VerifyIdFormat(id, "Device Profile"); err != nil {
@@ -63,7 +62,7 @@ func (s *Service) RemoveDeviceProfile(id string) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %v\n", profile))
+	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceProfileClient.Delete(id, ctx)
 	if err != nil {
@@ -85,7 +84,7 @@ func (*Service) RemoveDeviceProfileByName(name string) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %v\n", profile))
+	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceProfileClient.DeleteByName(name, ctx)
 	if err != nil {
@@ -107,7 +106,7 @@ func (*Service) UpdateDeviceProfile(profile contract.DeviceProfile) error {
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed DeviceProfile: : %v\n", profile))
+	common.LoggingClient.Debug(fmt.Sprintf("Updating managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	err := common.DeviceProfileClient.Update(profile, ctx)
 	if err != nil {

--- a/service.go
+++ b/service.go
@@ -146,7 +146,7 @@ func selfRegister() error {
 		common.LoggingClient.Info(fmt.Sprintf("Device Service %s exists", ds.Name))
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Device Service in Core MetaData: %v", ds))
+	common.LoggingClient.Debug(fmt.Sprintf("Device Service in Core MetaData: %s", ds.Name))
 	common.CurrentDeviceService = ds
 	svc.initialized = true
 	return nil
@@ -207,7 +207,7 @@ func makeNewAddressable() (*contract.Addressable, error) {
 			}
 			id, err := common.AddressableClient.Add(&addr, ctx)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("Add addressable failed %v, error: %v", addr, err))
+				common.LoggingClient.Error(fmt.Sprintf("Add addressable failed %s, error: %v", addr.Name, err))
 				return nil, err
 			}
 			if err = common.VerifyIdFormat(id, "Addressable"); err != nil {


### PR DESCRIPTION
Log messages shouldn't dump entire objects,
but some of them dump the large object.
Replace the object with its name, and remove
unnecessary message.
fix #202

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>