### PR TITLE
Add correlation-id for API tracing

### DIFF
--- a/internal/controller/correlation/handler.go
+++ b/internal/controller/correlation/handler.go
@@ -1,0 +1,21 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package correlation
+
+import (
+	"context"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+)
+
+func FromContext(ctx context.Context) string {
+	hdr, ok := ctx.Value(clients.CorrelationHeader).(string)
+	if !ok {
+		hdr = ""
+	}
+	return hdr
+}

--- a/internal/controller/correlation/middleware.go
+++ b/internal/controller/correlation/middleware.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package correlation
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/google/uuid"
+)
+
+func ManageHeader(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hdr := r.Header.Get(clients.CorrelationHeader)
+		if hdr == "" {
+			hdr = uuid.New().String()
+		}
+		ctx := context.WithValue(r.Context(), clients.CorrelationHeader, hdr)
+		r = r.WithContext(ctx)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func OnResponseComplete(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		begin := time.Now()
+		next.ServeHTTP(w, r)
+		correlationId := FromContext(r.Context())
+		if common.LoggingClient != nil {
+			common.LoggingClient.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
+		}
+	})
+}
+
+func OnRequestBegin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		correlationId := FromContext(r.Context())
+		if common.LoggingClient != nil {
+			common.LoggingClient.Trace("Begin request", clients.CorrelationHeader, correlationId, "path", r.URL.Path)
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018 IOTech Ltd
+// Copyright (C) 2018-2019 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import (
 	"net/http"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/controller/correlation"
 	"github.com/gorilla/mux"
 )
 
@@ -36,6 +37,10 @@ func InitRestRoutes() *mux.Router {
 	common.LoggingClient.Debug("init the metrics and config rest controller each")
 	r.HandleFunc("/metrics", metricsHandler).Methods(http.MethodGet)
 	r.HandleFunc("/config", configHandler).Methods(http.MethodGet)
+
+	r.Use(correlation.ManageHeader)
+	r.Use(correlation.OnResponseComplete)
+	r.Use(correlation.OnRequestBegin)
 
 	return r
 }


### PR DESCRIPTION
Fix #278 

```
...
level=INFO ts=2019-05-16T01:30:04.900013Z app=device-simple source=service.go:117 msg="*Service Start() called, name=device-simple, version=1.0.0"
level=INFO ts=2019-05-16T01:30:04.900169Z app=device-simple source=service.go:123 msg="Listening on port: 49990"
level=INFO ts=2019-05-16T01:30:04.900342Z app=device-simple source=service.go:124 msg="Service started in: 30.4246ms"
level=DEBUG ts=2019-05-16T01:30:04.900487Z app=device-simple source=service.go:126 msg="*Service Start() exit"
level=TRACE ts=2019-05-16T01:30:06.925118Z app=device-simple source=middleware.go:40 correlation-id=121f95a6-610f-4605-a1a8-03fc24c7f919 path=/api/v1/ping msg="Begin request"
level=TRACE ts=2019-05-16T01:30:06.925507Z app=device-simple source=middleware.go:31 correlation-id=121f95a6-610f-4605-a1a8-03fc24c7f919 duration=389.713µs msg="Response complete"
level=TRACE ts=2019-05-16T01:30:29.532681Z app=device-simple source=middleware.go:40 correlation-id=9f3131bf-d26d-4b34-9bde-282b601fa899 path=/api/v1/config msg="Begin request"
level=TRACE ts=2019-05-16T01:30:29.533376Z app=device-simple source=middleware.go:31 correlation-id=9f3131bf-d26d-4b34-9bde-282b601fa899 duration=694.326µs msg="Response complete"
```