### PR TITLE
Remove DisconnectDevice from ProtocolDriver

### DIFF
--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -62,12 +62,6 @@ func getImageBytes(imgFile string, buf *bytes.Buffer) error {
 	return nil
 }
 
-// DisconnectDevice handles protocol-specific cleanup when a device
-// is removed.
-func (s *SimpleDriver) DisconnectDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error {
-	return nil
-}
-
 // Initialize performs protocol-specific initialization for the device
 // service.
 func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsModels.AsyncValues) error {

--- a/pkg/models/protocoldriver.go
+++ b/pkg/models/protocoldriver.go
@@ -21,14 +21,6 @@ import (
 // by other components of an EdgeX Device Service to interact with
 // a specific class of devices.
 type ProtocolDriver interface {
-
-	// DisconnectDevice is when a device is removed from the device
-	// service. This function allows for protocol specific disconnection
-	// logic to be performed.  Device services which don't require this
-	// function should just return 'nil'.
-	//
-	DisconnectDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error
-
 	// Initialize performs protocol-specific initialization for the device
 	// service. The given *AsyncValues channel can be used to push asynchronous
 	// events and readings to Core Data.


### PR DESCRIPTION
Remove DisconnectDevice for now, and will re-design the whole add, update, delete callback methods to meet the discovery mechanism in next release
fix #286

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>