### PR TITLE
Update device-simple AutoEvents example

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -66,6 +66,10 @@ File = "./device-simple.log"
       Address = "simple01"
       Port = "300"
   [[DeviceList.AutoEvents]]
-    Frequency = "1s"
+    Frequency = "5s"
     OnChange = false
     Resource = "Switch"
+  [[DeviceList.AutoEvents]]
+    Frequency = "15s"
+    OnChange = false
+    Resource = "Image"

--- a/example/cmd/device-simple/res/docker/configuration.toml
+++ b/example/cmd/device-simple/res/docker/configuration.toml
@@ -66,6 +66,10 @@ File = "/edgex/logs/device-simple.log"
       Address = "simple01"
       Port = "300"
   [[DeviceList.AutoEvents]]
-    Frequency = "1s"
+    Frequency = "5s"
     OnChange = false
     Resource = "Switch"
+  [[DeviceList.AutoEvents]]
+    Frequency = "15s"
+    OnChange = false
+    Resource = "Image"


### PR DESCRIPTION
add the following to res/configuration.toml to highlight how two simple commands
- One triggers boolean application/json event (switch)
- Second triggers binary application/cbor event (image)
Also changing the frequency of the AutoEvent to publish a Switch event each 5 seconds
fix #285

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>