### PR TITLE
Update to Go Codec module v1.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190501042311-65beb1e99b02
+	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190521133417-c7e6b0d
 	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
@@ -9,6 +9,6 @@ require (
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
-	github.com/ugorji/go/codec v0.0.0-20190316192920-e2bddce071ad
+	github.com/ugorji/go v1.1.4
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/internal/mock/mock_eventclient.go
+++ b/internal/mock/mock_eventclient.go
@@ -65,7 +65,9 @@ func (EventClientMock) DeleteOld(age int, ctx context.Context) error {
 func (EventClientMock) Delete(id string, ctx context.Context) error {
 	panic("implement me")
 }
-
 func (EventClientMock) MarkPushed(id string, ctx context.Context) error {
+	panic("implement me")
+}
+func (EventClientMock) MarkPushedByChecksum(id string, ctx context.Context) error {
 	panic("implement me")
 }


### PR DESCRIPTION
Updates modules Go Codec to v1.1.4 and go-mod-core-contracts to latest.
Updates mock EventClient from go-mod-core-contracts which now has MarkPushedByChecksum method.


Signed-off-by: tobiasmo1 <tobias.mosby@intel.com>