### PR TITLE
MVP tests for new binary command values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ glide.lock
 vendor
 .idea
 go.sum
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ docker:
 		.
 
 test:
-	$(GO) test ./... -cover
 	$(GO) vet ./...
 	gofmt -l .
+	$(GO) test -coverprofile=coverage.out ./...
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ docker:
 
 test:
 	$(GO) test ./... -cover
+	$(GO) vet ./...
+	gofmt -l .
 
 clean:
 	rm -f $(MICROSERVICES)

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -11,12 +11,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"reflect"
 	"time"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/google/uuid"
 )
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -60,21 +60,19 @@ func SendEvent(event *dsModels.Event) {
 	// Call MarshalEvent to encode as byte array whether event contains binary or JSON readings
 	var err error
 	if len(event.EncodedEvent) <= 0 {
-		event.EncodedEvent, err = event.GetEncodedEvent(&event.Event)
+		event.EncodedEvent, err = EventClient.MarshalEvent(event.Event)
 		if err != nil {
 			LoggingClient.Error(fmt.Sprintf("SendEvent [correlationid %s] Error encoding event for device %s: %v", correlation, event.Device, err))
 		} else {
-			LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EventClient.MarshalEvent encoded event: %v", correlation, string(event.EncodedEvent[:200])))
+			LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EventClient.MarshalEvent encoded event: %.200v", correlation, event))
 		}
 	} else {
-		LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EncodedEvent already prepared: %v", correlation, string(event.EncodedEvent[:200])))
+		LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EncodedEvent already prepared: %.200v", correlation, event))
 	}
 	// Call AddBytes to post event to core data
 	responseBody, errPost := EventClient.AddBytes(event.EncodedEvent, ctx)
 	if errPost != nil {
 		LoggingClient.Error(fmt.Sprintf("SendEvent Failed to push event for device %s. Response [%s]: %v", event.Device, responseBody, errPost))
-		// TODO: Increase resilience - retry with alternate interface?
-		//  _, err = EventClient.Add(&event.Event, ctx)
 	}
 }
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
 )
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -62,17 +62,20 @@ func SendEvent(event *dsModels.Event) {
 	if len(event.EncodedEvent) <= 0 {
 		event.EncodedEvent, err = EventClient.MarshalEvent(event.Event)
 		if err != nil {
-			LoggingClient.Error(fmt.Sprintf("SendEvent [correlationid %s] Error encoding event for device %s: %v", correlation, event.Device, err))
+			LoggingClient.Error(fmt.Sprintf("SendEvent: Error encoding event", "device", event.Device, clients.CorrelationHeader, correlation, "error", err))
 		} else {
-			LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EventClient.MarshalEvent encoded event: %.200v", correlation, event))
+			LoggingClient.Debug(fmt.Sprintf("SendEvent: EventClient.MarshalEvent encoded event", clients.CorrelationHeader, correlation))
 		}
 	} else {
-		LoggingClient.Info(fmt.Sprintf("SendEvent [correlationid %s] EncodedEvent already prepared: %.200v", correlation, event))
+		LoggingClient.Debug(fmt.Sprintf("SendEvent: EventClient.MarshalEvent passed through encoded event", clients.CorrelationHeader, correlation))
 	}
 	// Call AddBytes to post event to core data
 	responseBody, errPost := EventClient.AddBytes(event.EncodedEvent, ctx)
 	if errPost != nil {
-		LoggingClient.Error(fmt.Sprintf("SendEvent Failed to push event for device %s. Response [%s]: %v", event.Device, responseBody, errPost))
+		LoggingClient.Error(fmt.Sprintf("SendEvent Failed to push event", "device", event.Device, "response", responseBody, "error", errPost))
+	} else {
+		LoggingClient.Info(fmt.Sprintf("SendEvent: Pushed event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation))
+		LoggingClient.Trace(fmt.Sprintf("SendEvent: Pushed this event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation, "event", event))
 	}
 }
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -62,20 +62,20 @@ func SendEvent(event *dsModels.Event) {
 	if len(event.EncodedEvent) <= 0 {
 		event.EncodedEvent, err = EventClient.MarshalEvent(event.Event)
 		if err != nil {
-			LoggingClient.Error(fmt.Sprintf("SendEvent: Error encoding event", "device", event.Device, clients.CorrelationHeader, correlation, "error", err))
+			LoggingClient.Error("SendEvent: Error encoding event", "device", event.Device, clients.CorrelationHeader, correlation, "error", err)
 		} else {
-			LoggingClient.Debug(fmt.Sprintf("SendEvent: EventClient.MarshalEvent encoded event", clients.CorrelationHeader, correlation))
+			LoggingClient.Debug("SendEvent: EventClient.MarshalEvent encoded event", clients.CorrelationHeader, correlation)
 		}
 	} else {
-		LoggingClient.Debug(fmt.Sprintf("SendEvent: EventClient.MarshalEvent passed through encoded event", clients.CorrelationHeader, correlation))
+		LoggingClient.Debug("SendEvent: EventClient.MarshalEvent passed through encoded event", clients.CorrelationHeader, correlation)
 	}
 	// Call AddBytes to post event to core data
 	responseBody, errPost := EventClient.AddBytes(event.EncodedEvent, ctx)
 	if errPost != nil {
-		LoggingClient.Error(fmt.Sprintf("SendEvent Failed to push event", "device", event.Device, "response", responseBody, "error", errPost))
+		LoggingClient.Error("SendEvent Failed to push event", "device", event.Device, "response", responseBody, "error", errPost)
 	} else {
-		LoggingClient.Info(fmt.Sprintf("SendEvent: Pushed event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation))
-		LoggingClient.Trace(fmt.Sprintf("SendEvent: Pushed this event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation, "event", event))
+		LoggingClient.Info("SendEvent: Pushed event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation)
+		LoggingClient.Trace("SendEvent: Pushed this event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation, "event", event)
 	}
 }
 

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -108,12 +108,12 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 				var err error
 				event.EncodedEvent, err = common.EventClient.MarshalEvent(event.Event)
 				if err != nil {
-					common.LoggingClient.Error(fmt.Sprintf("Error encoding event for device %s: %v", event.Device, err))
+					common.LoggingClient.Error(fmt.Sprintf("DeviceCommand: Error encoding event", "device", event.Device, "error", err))
 				} else {
-					common.LoggingClient.Info(fmt.Sprintf("EventClient.MarshalEvent encoded event for device %s: %.200v", event.Device, event))
+					common.LoggingClient.Trace(fmt.Sprintf("DeviceCommand: EventClient.MarshalEvent encoded event", "device", event.Device, "event", event))
 				}
 			} else {
-				common.LoggingClient.Info(fmt.Sprintf("EncodedEvent was already prepared for device %s: %.200v", event.Device, event))
+				common.LoggingClient.Trace(fmt.Sprintf("DeviceCommand: EventClient.MarshalEvent passed through encoded event", "device", event.Device, "event", event))
 			}
 			// TODO: Resolve why this header is not included in response from Core-Command to originating caller (while the written body is).
 			w.Header().Set(clients.ContentType, clients.ContentTypeCBOR)

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -102,13 +102,18 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, fmt.Sprintf("%s %s", appErr.Message(), req.URL.Path), appErr.Code())
 	} else if event != nil {
 		if event.HasBinaryValue() {
+			// TODO: Add conditional toggle in case caller of command does not require this response.
+			// Encode response as application/CBOR.
 			if len(event.EncodedEvent) <= 0 {
 				var err error
-				event.EncodedEvent, err = event.EncodeBinaryEvent(&event.Event)
+				event.EncodedEvent, err = event.GetEncodedEvent(&event.Event)
 				if err != nil {
-					common.LoggingClient.Error("ERROR encoding binary event!")
+					common.LoggingClient.Error(fmt.Sprintf("Error encoding event for device %s: %v", event.Device, err))
+				} else {
+					common.LoggingClient.Info(fmt.Sprintf("EventClient.MarshalEvent encoded event after CommandHandler returned: %v", string(event.EncodedEvent[:200])))
 				}
-				common.LoggingClient.Info(fmt.Sprintf("EncodedEvent after CommandHandler returned: %v", string(event.EncodedEvent[:20])))
+			} else {
+				common.LoggingClient.Info(fmt.Sprintf("EncodedEvent is already prepared: %v", string(event.EncodedEvent[:200])))
 			}
 			// TODO: Resolve why this header is not included in response from Core-Command to originating caller (while the written body is).
 			w.Header().Set(clients.ContentType, clients.ContentTypeCBOR)

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -106,14 +106,14 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 			// Encode response as application/CBOR.
 			if len(event.EncodedEvent) <= 0 {
 				var err error
-				event.EncodedEvent, err = event.GetEncodedEvent(&event.Event)
+				event.EncodedEvent, err = common.EventClient.MarshalEvent(event.Event)
 				if err != nil {
 					common.LoggingClient.Error(fmt.Sprintf("Error encoding event for device %s: %v", event.Device, err))
 				} else {
-					common.LoggingClient.Info(fmt.Sprintf("EventClient.MarshalEvent encoded event after CommandHandler returned: %v", string(event.EncodedEvent[:200])))
+					common.LoggingClient.Info(fmt.Sprintf("EventClient.MarshalEvent encoded event for device %s: %.200v", event.Device, event))
 				}
 			} else {
-				common.LoggingClient.Info(fmt.Sprintf("EncodedEvent is already prepared: %v", string(event.EncodedEvent[:200])))
+				common.LoggingClient.Info(fmt.Sprintf("EncodedEvent was already prepared for device %s: %.200v", event.Device, event))
 			}
 			// TODO: Resolve why this header is not included in response from Core-Command to originating caller (while the written body is).
 			w.Header().Set(clients.ContentType, clients.ContentTypeCBOR)

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -108,12 +108,12 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 				var err error
 				event.EncodedEvent, err = common.EventClient.MarshalEvent(event.Event)
 				if err != nil {
-					common.LoggingClient.Error(fmt.Sprintf("DeviceCommand: Error encoding event", "device", event.Device, "error", err))
+					common.LoggingClient.Error("DeviceCommand: Error encoding event", "device", event.Device, "error", err)
 				} else {
-					common.LoggingClient.Trace(fmt.Sprintf("DeviceCommand: EventClient.MarshalEvent encoded event", "device", event.Device, "event", event))
+					common.LoggingClient.Trace("DeviceCommand: EventClient.MarshalEvent encoded event", "device", event.Device, "event", event)
 				}
 			} else {
-				common.LoggingClient.Trace(fmt.Sprintf("DeviceCommand: EventClient.MarshalEvent passed through encoded event", "device", event.Device, "event", event))
+				common.LoggingClient.Trace("DeviceCommand: EventClient.MarshalEvent passed through encoded event", "device", event.Device, "event", event)
 			}
 			// TODO: Resolve why this header is not included in response from Core-Command to originating caller (while the written body is).
 			w.Header().Set(clients.ContentType, clients.ContentTypeCBOR)

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -87,7 +87,7 @@ func execReadDeviceResource(device *contract.Device, dr *contract.DeviceResource
 	var reqs []dsModels.CommandRequest
 	var req dsModels.CommandRequest
 	common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: deviceResource: %s", dr.Name))
-	
+
 	req.DeviceResourceName = dr.Name
 	req.Attributes = dr.Attributes
 	req.Type = dsModels.ParseValueType(dr.Properties.Value.Type)

--- a/internal/mock/mock_eventclient.go
+++ b/internal/mock/mock_eventclient.go
@@ -65,7 +65,9 @@ func (EventClientMock) DeleteOld(age int, ctx context.Context) error {
 func (EventClientMock) Delete(id string, ctx context.Context) error {
 	panic("implement me")
 }
-
 func (EventClientMock) MarkPushed(id string, ctx context.Context) error {
+	panic("implement me")
+}
+func (EventClientMock) MarkPushedByChecksum(id string, ctx context.Context) error {
 	panic("implement me")
 }

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -7,10 +7,8 @@
 package models
 
 import (
-	"bytes"
-
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	"github.com/ugorji/go/codec"
 )
 
 // Event is a wrapper of contract.Event to provide more Binary related operation in Device Service.
@@ -32,14 +30,11 @@ func (e Event) HasBinaryValue() bool {
 	return false
 }
 
-// TODO: Add as method of dsModels.event or contract.event/client
-func (e Event) EncodeBinaryEvent(ev *contract.Event) ([]byte, error) {
-	buf := new(bytes.Buffer)
-	hCbor := new(codec.CborHandle)
-	enc := codec.NewEncoder(buf, hCbor)
-	err := enc.Encode(ev)
-	if err == nil {
-		return buf.Bytes(), nil
+func (e Event) GetEncodedEvent(ev *contract.Event) ([]byte, error) {
+	var err error
+	var ec coredata.EventClient
+	if len(e.EncodedEvent) <= 0 {
+		e.EncodedEvent, err = ec.MarshalEvent(e.Event)
 	}
-	return nil, err
+	return e.EncodedEvent, err
 }

--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -7,7 +7,6 @@
 package models
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
@@ -28,13 +27,4 @@ func (e Event) HasBinaryValue() bool {
 		}
 	}
 	return false
-}
-
-func (e Event) GetEncodedEvent(ev *contract.Event) ([]byte, error) {
-	var err error
-	var ec coredata.EventClient
-	if len(e.EncodedEvent) <= 0 {
-		e.EncodedEvent, err = ec.MarshalEvent(e.Event)
-	}
-	return e.EncodedEvent, err
 }


### PR DESCRIPTION
Added a test to prove out CommandValue assigned a struct whose properties match after encode/decode to CBOR.
Also added test for assigning arbitrary binary value that exceeds CommandValue payload limit (currently 16MB) and another just within the bounds of that constraint.
