### PR TITLE
Update Device-Simple example

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -66,6 +66,10 @@ File = "./device-simple.log"
       Address = "simple01"
       Port = "300"
   [[DeviceList.AutoEvents]]
-    Frequency = "1s"
+    Frequency = "10s"
     OnChange = false
     Resource = "Switch"
+  [[DeviceList.AutoEvents]]
+    Frequency = "30s"
+    OnChange = false
+    Resource = "Image"

--- a/example/cmd/device-simple/res/docker/configuration.toml
+++ b/example/cmd/device-simple/res/docker/configuration.toml
@@ -66,6 +66,10 @@ File = "/edgex/logs/device-simple.log"
       Address = "simple01"
       Port = "300"
   [[DeviceList.AutoEvents]]
-    Frequency = "1s"
+    Frequency = "10s"
     OnChange = false
     Resource = "Switch"
+  [[DeviceList.AutoEvents]]
+    Frequency = "30s"
+    OnChange = false
+    Resource = "Image"


### PR DESCRIPTION
This extends the device-simple example, updating the AutoEvents configuration to trigger a simple JSON and CBOR event for the `Simple-Device01` device.

AutoEvent now triggers `Image` command. This allows a manual PUT using curl or Postman to the `Switch` command, toggling SwitchButton value to true or false. This demonstrates how the subsequent events emitted from both `Switch` (JSON) and `Image `(CBOR) reflect the updated device state.

Ref issue #285

