### PR TITLE
Remove redundant messages from log

### DIFF
--- a/internal/cache/profiles.go
+++ b/internal/cache/profiles.go
@@ -155,7 +155,7 @@ func (p *profileCache) DeviceResource(profileName string, resourceName string) (
 func (p *profileCache) CommandExists(profileName string, cmd string) (bool, error) {
 	commands, ok := p.ccMap[profileName]
 	if !ok {
-		err := fmt.Errorf("profiles: CommandExists: specified profile: %s not found", profileName)
+		err := fmt.Errorf("specified profile: %s not found", profileName)
 		return false, err
 	}
 
@@ -173,16 +173,16 @@ func (p *profileCache) ResourceOperations(profileName string, cmd string, method
 	var ok bool
 	if strings.ToLower(method) == common.GetCmdMethod {
 		if rosMap, ok = p.dcMap[profileName]; !ok {
-			return nil, fmt.Errorf("profiles: ResourceOperations: specified profile: %s not found", profileName)
+			return nil, fmt.Errorf("specified profile: %s not found", profileName)
 		}
 	} else if strings.ToLower(method) == common.SetCmdMethod {
 		if rosMap, ok = p.setOpMap[profileName]; !ok {
-			return nil, fmt.Errorf("profiles: ResourceOperations: specified profile: %s not found", profileName)
+			return nil, fmt.Errorf("specified profile: %s not found", profileName)
 		}
 	}
 
 	if resOps, ok = rosMap[cmd]; !ok {
-		return nil, fmt.Errorf("profiles: ResourceOperations: specified cmd: %s not found", cmd)
+		return nil, fmt.Errorf("specified cmd: %s not found", cmd)
 	}
 	return resOps, nil
 }
@@ -194,16 +194,16 @@ func (p *profileCache) ResourceOperation(profileName string, object string, meth
 	var ok bool
 	if strings.ToLower(method) == common.GetCmdMethod {
 		if rosMap, ok = p.dcMap[profileName]; !ok {
-			return ro, fmt.Errorf("profiles: ResourceOperation: specified profile: %s not found", profileName)
+			return ro, fmt.Errorf("specified profile: %s not found", profileName)
 		}
 	} else if strings.ToLower(method) == common.SetCmdMethod {
 		if rosMap, ok = p.setOpMap[profileName]; !ok {
-			return ro, fmt.Errorf("profiles: ResourceOperations: specified profile: %s not found", profileName)
+			return ro, fmt.Errorf("specified profile: %s not found", profileName)
 		}
 	}
 
 	if ro, ok = retrieveFirstRObyObject(rosMap, object); !ok {
-		return ro, fmt.Errorf("profiles: specified ResourceOperation by object %s not found", object)
+		return ro, fmt.Errorf("specified ResourceOperation by object %s not found", object)
 	}
 	return ro, nil
 }

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -129,7 +129,7 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 
 func commandAllFunc(w http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
-	common.LoggingClient.Debug(fmt.Sprintf("Controller - Command: execute the Get command %s from all operational devices", vars[common.CommandVar]))
+	common.LoggingClient.Debug(fmt.Sprintf("execute the Get command %s from all operational devices", vars[common.CommandVar]))
 
 	if checkServiceLocked(w, req) {
 		return
@@ -169,7 +169,7 @@ func readBodyAsString(w http.ResponseWriter, req *http.Request) (string, bool) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		msg := fmt.Sprintf("commandFunc: error reading request body for: %s %s", req.Method, req.URL)
+		msg := fmt.Sprintf("error reading request body for: %s %s", req.Method, req.URL)
 		common.LoggingClient.Error(msg)
 		return "", false
 	}

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -36,12 +36,12 @@ func LoadProfiles(path string) error {
 		common.LoggingClient.Error(fmt.Sprintf("profiles: couldn't create absolute path for: %s; %v", path, err))
 		return err
 	}
-	common.LoggingClient.Debug(fmt.Sprintf("profiles: created absolute path for loading pre-defined Device Profiles: %s", absPath))
+	common.LoggingClient.Debug(fmt.Sprintf("created absolute path for loading pre-defined Device Profiles: %s", absPath))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	profiles, err := common.DeviceProfileClient.DeviceProfiles(ctx)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("profiles: couldn't read Device Profile from Core Metadata: %v", err))
+		common.LoggingClient.Error(fmt.Sprintf("couldn't read Device Profile from Core Metadata: %v", err))
 		return err
 	}
 	pMap := profileSliceToMap(profiles)
@@ -67,7 +67,7 @@ func LoadProfiles(path string) error {
 
 			err = yaml.Unmarshal(yamlFile, &profile)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("profiles: invalid Device Profile: %s; %v", fullPath, err))
+				common.LoggingClient.Error(fmt.Sprintf("invalid Device Profile: %s; %v", fullPath, err))
 				continue
 			}
 
@@ -81,7 +81,7 @@ func LoadProfiles(path string) error {
 			ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 			id, err := common.DeviceProfileClient.Add(&profile, ctx)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("profiles: Add Device Profile: %s to Core Metadata failed: %v", fullPath, err))
+				common.LoggingClient.Error(fmt.Sprintf("Add Device Profile: %s to Core Metadata failed: %v", fullPath, err))
 				continue
 			}
 			if err = common.VerifyIdFormat(id, "Device Profile"); err != nil {


### PR DESCRIPTION
The $package and $func in log messages are unnecessary because of the current logger prints out the file name and line number.

Fix #76 