### PR TITLE
Update edgex modules to v0.1.0 pre-edinburgh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190521133417-c7e6b0d
-	github.com/edgexfoundry/go-mod-registry v0.0.0-20190401195203-552208258719
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
+	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
 	github.com/gorilla/mux v1.6.2


### PR DESCRIPTION
Fix #300

In preparation for cutting the edinburgh branch, we need to consume
v0.1.0 in the go.mod for edgex modules

- go-mod-core-contracts
- go-mod-registry

Signed-off-by: Trevor Conn <trevor_conn@dell.com>