### PR TITLE
Remove ReadMaxLimit from configuration in Edinburgh release

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -7,7 +7,6 @@ Port = 49990
 ConnectRetries = 20
 Labels = []
 OpenMsg = "device simple started"
-ReadMaxLimit = 256
 Timeout = 5000
 EnableAsyncReadings = true
 AsyncBufferSize = 16

--- a/example/cmd/device-simple/res/docker/configuration.toml
+++ b/example/cmd/device-simple/res/docker/configuration.toml
@@ -7,7 +7,6 @@ Port = 49990
 ConnectRetries = 20
 Labels = []
 OpenMsg = "device simple started"
-ReadMaxLimit = 256
 Timeout = 5000
 EnableAsyncReadings = true
 AsyncBufferSize = 16

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -34,9 +34,6 @@ type ServiceInfo struct {
 	Labels []string
 	// OpenMsg specifies a string logged on DS startup.
 	OpenMsg string
-	// ReadMaxLimit specifies the maximum size list supported
-	// in response to REST calls to other services.
-	ReadMaxLimit int
 	// Timeout (in milliseconds) specifies both
 	// - timeout for processing REST calls and
 	// - interval time the DS will wait between each retry call.

--- a/internal/config/test/configuration.toml
+++ b/internal/config/test/configuration.toml
@@ -7,7 +7,6 @@ Port = 49990
 ConnectRetries = 20
 Labels = []
 OpenMsg = "device simple started"
-ReadMaxLimit = 256
 Timeout = 5000
 EnableAsyncReadings = true
 AsyncBufferSize = 16


### PR DESCRIPTION
ReadMaxLimit should be controlled by Core services, and we don't really use it in SDK
fix #303

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>