### PR TITLE
Adopt nanoseconds in origin of Event and Reading

### DIFF
--- a/async.go
+++ b/async.go
@@ -76,7 +76,7 @@ func processAsyncResults() {
 		// push to Core Data
 		cevent := contract.Event{Device: device.Name, Readings: readings}
 		event := &dsModels.Event{Event: cevent}
-		event.Origin = time.Now().UnixNano() / int64(time.Millisecond)
+		event.Origin = time.Now().UnixNano()
 		common.SendEvent(event)
 	}
 }

--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -80,7 +80,7 @@ func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[strin
 	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols, reqs[0].DeviceResourceName, reqs[0].Attributes))
 
 	res = make([]*dsModels.CommandValue, 1)
-	now := time.Now().UnixNano() / int64(time.Millisecond)
+	now := time.Now().UnixNano()
 	if reqs[0].DeviceResourceName == "SwitchButton" {
 		cv, _ := dsModels.NewBoolValue(reqs[0].DeviceResourceName, now, s.switchButton)
 		res[0] = cv

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -57,7 +57,7 @@ func (e *executor) Run() {
 			event := &dsModels.Event{Event: evt.Event}
 			// Attach origin timestamp for readings if none yet specified
 			if event.Origin == 0 {
-				event.Origin = time.Now().UnixNano() / int64(time.Millisecond)
+				event.Origin = time.Now().UnixNano()
 			}
 			go common.SendEvent(event)
 		}

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -43,7 +43,7 @@ func CommandValueToReading(cv *dsModels.CommandValue, devName string, encoding s
 	if cv.Origin > 0 {
 		reading.Origin = cv.Origin
 	} else {
-		reading.Origin = time.Now().UnixNano() / int64(time.Millisecond)
+		reading.Origin = time.Now().UnixNano()
 	}
 
 	return reading

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -169,7 +169,7 @@ func cvsToEvent(device *contract.Device, cvs []*dsModels.CommandValue, cmd strin
 	// push to Core Data
 	cevent := contract.Event{Device: device.Name, Readings: readings}
 	event := &dsModels.Event{Event: cevent}
-	event.Origin = time.Now().UnixNano() / int64(time.Millisecond)
+	event.Origin = time.Now().UnixNano()
 
 	// TODO: enforce config.MaxCmdValueLen; need to include overhead for
 	// the rest of the reading JSON + Event JSON length?  Should there be
@@ -403,7 +403,7 @@ func createCommandValueFromDR(dr *contract.DeviceResource, v string) (*dsModels.
 	var err error
 	var value interface{}
 	var t dsModels.ValueType
-	origin := time.Now().UnixNano() / int64(time.Millisecond)
+	origin := time.Now().UnixNano()
 
 	switch strings.ToLower(dr.Properties.Value.Type) {
 	case "bool":

--- a/internal/mock/mock_devicevirtualdriver.go
+++ b/internal/mock/mock_devicevirtualdriver.go
@@ -29,7 +29,7 @@ func (DriverMock) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsModels.A
 
 func (DriverMock) HandleReadCommands(deviceName string, protocols map[string]contract.ProtocolProperties, reqs []dsModels.CommandRequest) (res []*dsModels.CommandValue, err error) {
 	res = make([]*dsModels.CommandValue, len(reqs))
-	now := time.Now().UnixNano() / int64(time.Millisecond)
+	now := time.Now().UnixNano()
 	var v *dsModels.CommandValue
 	for i, req := range reqs {
 		switch deviceName {

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -474,7 +474,7 @@ func TestNewInt64Value(t *testing.T) {
 // Test NewFloat32Value function.
 func TestNewFloat32Value(t *testing.T) {
 	var value float32 = math.SmallestNonzeroFloat32
-	var origin int64 = time.Now().UnixNano() / int64(time.Millisecond)
+	var origin int64 = time.Now().UnixNano()
 	cv, _ := NewFloat32Value("resource", origin, value)
 	if cv.Type != Float32 {
 		t.Errorf("NewFloat32Value: invalid Type: %v", cv.Type)
@@ -525,7 +525,7 @@ func TestNewFloat32Value(t *testing.T) {
 // Test NewFloat64Value function.
 func TestNewFloat64Value(t *testing.T) {
 	var value float64 = math.SmallestNonzeroFloat64
-	var origin int64 = time.Now().UnixNano() / int64(time.Millisecond)
+	var origin int64 = time.Now().UnixNano()
 	cv, _ := NewFloat64Value("resource", origin, value)
 	if cv.Type != Float64 {
 		t.Errorf("NewFloat64Value: invalid Type: %v", cv.Type)
@@ -596,7 +596,7 @@ func createMockPayload(size int) ([]byte, error) {
 
 // Test NewBinaryValue function and associated methods for binary encode/decode.
 func TestNewBinaryValue(t *testing.T) {
-	var origin int64 = time.Now().UnixNano() / int64(time.Millisecond)
+	var origin int64 = time.Now().UnixNano()
 	// assign instance of mockStructB as a CBOR encoded CommandValue payload
 	var mock1 contract.Event
 	var mock2 contract.Event
@@ -649,7 +649,7 @@ func TestNewBinaryValue(t *testing.T) {
 
 // Test NewBinaryValueConstraints function and associated methods for binary encode/decode.
 func TestNewBinaryValueWithinConstraints(t *testing.T) {
-	var origin int64 = time.Now().UnixNano() / int64(time.Millisecond)
+	var origin int64 = time.Now().UnixNano()
 	// Confirm we receive error if arbitrary binary value exceeds policy limit (currently 16MB)
 	payloadLimit := MaxBinaryBytes
 	payloadSize := MaxBinaryBytes
@@ -676,7 +676,7 @@ func TestNewBinaryValueWithinConstraints(t *testing.T) {
 
 // Test NewBinaryValueConstraints function and associated methods for binary encode/decode.
 func TestNewBinaryValueExceedsConstraints(t *testing.T) {
-	var origin int64 = time.Now().UnixNano() / int64(time.Millisecond)
+	var origin int64 = time.Now().UnixNano()
 	// Confirm we receive error if arbitrary binary value exceeds policy limit (currently 16MB)
 	payloadLimit := MaxBinaryBytes
 	payloadSize := MaxBinaryBytes + 1


### PR DESCRIPTION
Use nanoseconds for all the Even, Reading, and Command Value in SDK
fix #273

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>