### PR TITLE
Make sure all the event.origin are unique

### DIFF
--- a/async.go
+++ b/async.go
@@ -9,7 +9,6 @@ package device
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
@@ -76,7 +75,7 @@ func processAsyncResults() {
 		// push to Core Data
 		cevent := contract.Event{Device: device.Name, Readings: readings}
 		event := &dsModels.Event{Event: cevent}
-		event.Origin = time.Now().UnixNano()
+		event.Origin = common.GetUniqueOrigin()
 		common.SendEvent(event)
 	}
 }

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -57,9 +57,9 @@ func (e *executor) Run() {
 			}
 			common.LoggingClient.Debug(fmt.Sprintf("AutoEvent - pushing event %s", evt.String()))
 			event := &dsModels.Event{Event: evt.Event}
-			// Attach origin timestamp for readings if none yet specified
+			// Attach origin timestamp for events if none yet specified
 			if event.Origin == 0 {
-				event.Origin = time.Now().UnixNano()
+				event.Origin = common.GetUniqueOrigin()
 			}
 			go common.SendEvent(event)
 		}

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -12,12 +12,18 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
+)
+
+var (
+	previousOrigin int64
+	originMutex    sync.Mutex
 )
 
 func BuildAddr(host string, port string) string {
@@ -243,4 +249,15 @@ func VerifyIdFormat(id string, drName string) error {
 		return fmt.Errorf(errMsg)
 	}
 	return nil
+}
+
+func GetUniqueOrigin() int64 {
+	originMutex.Lock()
+	defer originMutex.Unlock()
+	now := time.Now().UnixNano()
+	if now <= previousOrigin {
+		now = previousOrigin + 1
+	}
+	previousOrigin = now
+	return now
 }

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -76,3 +76,12 @@ func TestCompareStrStrMap(t *testing.T) {
 		t.Error("Maps with different content are OK!")
 	}
 }
+
+func TestGetUniqueOrigin(t *testing.T) {
+	origin1 := GetUniqueOrigin()
+	origin2 := GetUniqueOrigin()
+
+	if origin1 >= origin2 {
+		t.Errorf("origin1: %d should <= origin2: %d", origin1, origin2)
+	}
+}

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -169,7 +169,7 @@ func cvsToEvent(device *contract.Device, cvs []*dsModels.CommandValue, cmd strin
 	// push to Core Data
 	cevent := contract.Event{Device: device.Name, Readings: readings}
 	event := &dsModels.Event{Event: cevent}
-	event.Origin = time.Now().UnixNano()
+	event.Origin = common.GetUniqueOrigin()
 
 	// TODO: enforce config.MaxCmdValueLen; need to include overhead for
 	// the rest of the reading JSON + Event JSON length?  Should there be


### PR DESCRIPTION
Cache the previous timestamp, and plus 1 nanosecond if the new one
is not greater than the previous one
fix #314

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>