### PR TITLE
Override Configuration Using Environment Variables

### DIFF
--- a/internal/config/environment.go
+++ b/internal/config/environment.go
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	"github.com/pelletier/go-toml"
+	"os"
+	"strings"
+)
+
+const (
+	envKeyPrefix = "edgex_registry_"
+	envKeyHost   = envKeyPrefix + "host"
+	envKeyPort   = envKeyPrefix + "port"
+	envKeyType   = envKeyPrefix + "type"
+)
+
+// environment is receiver that holds environment variables and encapsulates toml.Tree-based configuration field
+// overrides.  Assumes "_" embedded in environment variable key separates substructs; e.g. foo_bar_baz might refer to
+//
+// 		type foo struct {
+// 			bar struct {
+//          	baz string
+//  		}
+//		}
+type environment struct {
+	env map[string]interface{}
+}
+
+// NewEnvironment constructor reads/stores os.Environ() for use by environment receiver methods.
+func NewEnvironment() *environment {
+	osEnv := os.Environ()
+	e := &environment{
+		env: make(map[string]interface{}, len(osEnv)),
+	}
+	for _, env := range osEnv {
+		kv := strings.Split(env, "=")
+		if len(kv) == 2 && len(kv[0]) > 0 && len(kv[1]) > 0 {
+			e.env[kv[0]] = kv[1]
+		}
+	}
+	return e
+}
+
+// OverrideUseRegistryFromEnvironment method replaces useRegistry content with environment variable override content
+// (when it exists).
+func (e *environment) OverrideUseRegistryFromEnvironment(useRegistry string) string {
+	registryHost, registryHostOk := e.env[envKeyHost]
+	registryPort, registryPortOk := e.env[envKeyPort]
+	registryType, registryTypeOk := e.env[envKeyType]
+	if registryHostOk && registryHost != "" &&
+		registryPortOk && registryPort != "" &&
+		registryTypeOk && registryType != "" {
+		useRegistry = registryType.(string) + "://" + registryHost.(string) + ":" + registryPort.(string)
+	}
+	return useRegistry
+}
+
+// OverrideRegistryConfigFromEnvironment method replaces values in the toml.Tree for matching environment variable keys.
+func (e *environment) OverrideFromEnvironment(tree *toml.Tree) *toml.Tree {
+	for k, v := range e.env {
+		k = strings.Replace(k, "_", ".", -1)
+		switch {
+		case tree.Has(k):
+			// global key
+			tree.Set(k, v)
+		default:
+			// do nothing
+		}
+	}
+	return tree
+}

--- a/internal/config/environment_test.go
+++ b/internal/config/environment_test.go
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	"github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+const (
+	envValue  = "envValue"
+	rootKey   = "rootKey"
+	rootValue = "rootValue"
+	sub       = "sub"
+	subKey    = "subKey"
+	subValue  = "subValue"
+
+	useRegistryValue = "useRegistry"
+	hostValue        = "host"
+	portValue        = "port"
+	typeValue        = "type"
+
+	testToml = `
+` + rootKey + `="` + rootValue + `"
+[` + sub + `]
+` + subKey + `="` + subValue + `"`
+)
+
+func newSUT(t *testing.T, env map[string]string) *environment {
+	os.Clearenv()
+	for k, v := range env {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fail()
+		}
+	}
+	return NewEnvironment()
+}
+
+func newOverrideFromEnvironmentSUT(t *testing.T, envKey string, envValue string) (*toml.Tree, *environment) {
+	tree, err := toml.Load(testToml)
+	if err != nil {
+		t.Fail()
+	}
+	return tree, newSUT(t, map[string]string{envKey: envValue})
+}
+
+func TestKeyMatchOverwritesValue(t *testing.T) {
+	var tests = []struct {
+		name          string
+		key           string
+		envKey        string
+		envValue      string
+		expectedValue string
+	}{
+		{"generic root", rootKey, rootKey, envValue, envValue},
+		{"generic sub", sub + "." + subKey, sub + "." + subKey, envValue, envValue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, sut := newOverrideFromEnvironmentSUT(t, test.key, test.envValue)
+
+			result := sut.OverrideFromEnvironment(tree)
+
+			assert.Equal(t, result.Get(test.key), test.envValue)
+		})
+	}
+}
+
+func TestNonMatchingKeyDoesNotOverwritesValue(t *testing.T) {
+	var tests = []struct {
+		name          string
+		key           string
+		envKey        string
+		envValue      string
+		expectedValue string
+	}{
+		{"root", rootKey, rootKey, envValue, rootValue},
+		{"sub", sub + "." + subKey, sub + "." + subKey, envValue, rootValue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, sut := newOverrideFromEnvironmentSUT(t, test.key, test.envValue)
+
+			result := sut.OverrideFromEnvironment(tree)
+
+			assert.Equal(t, result.Get(test.key), test.envValue)
+		})
+	}
+}
+
+func TestOverrideUseRegistryFromEnvironment(t *testing.T) {
+	var tests = []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{"valid", map[string]string{envKeyHost: hostValue, envKeyPort: portValue, envKeyType: typeValue}, typeValue + "://" + hostValue + ":" + portValue},
+		{"missing Host", map[string]string{envKeyPort: portValue, envKeyType: typeValue}, useRegistryValue},
+		{"missing Port", map[string]string{envKeyHost: hostValue, envKeyType: typeValue}, useRegistryValue},
+		{"missing Type", map[string]string{envKeyHost: hostValue, envKeyPort: portValue}, useRegistryValue},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sut := newSUT(t, test.env)
+
+			result := sut.OverrideUseRegistryFromEnvironment(useRegistryValue)
+
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -110,7 +110,7 @@ func TestLoadDriverConfigFromFile(t *testing.T) {
 	expectedProperty2 := "Port"
 	expectedValue2 := "1883"
 
-	config, err := loadConfigFromFile("", "./test")
+	config, _, err := loadConfigFromFile("", "./test")
 
 	if err != nil {
 		t.Errorf("Fail to load config from file, %v", err)


### PR DESCRIPTION
Added ability to override command-line provided useRegistry url with
environment variables -- edgex_registry_host, edgex_registry_port, and
edgex_registry_type to be consistent with edgex-go core implementation
(see https://github.com/edgexfoundry/edgex-go/issues/1450).

Added ability to override any configuration value with environment
variables for the use case where a command line registry value is
provided, the referenced registry does not have configuration for this
service, and this service pushes a copy of its local configuration into
the registry. The key in an environment variable specifies the
configuration value to override; e.g. Clients_Logging_Host=<someNewValue>

https://github.com/edgexfoundry/device-sdk-go/issues/323
Signed-off-by: Michael W. Estrin <me@michaelestrin.com>