### PR TITLE
Listen to the OS signal during service startup

### DIFF
--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -129,6 +129,9 @@ func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[stri
 // for closing any in-use channels, including the channel used to send async
 // readings (if supported).
 func (s *SimpleDriver) Stop(force bool) error {
-	s.lc.Debug(fmt.Sprintf("SimpleDriver.Stop called: force=%v", force))
+	// Then Logging Client might not be initialized
+	if s.lc != nil {
+		s.lc.Debug(fmt.Sprintf("SimpleDriver.Stop called: force=%v", force))
+	}
 	return nil
 }

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -48,14 +48,9 @@ func startService(serviceName string, serviceVersion string, driver dsModels.Pro
 	}
 
 	fmt.Fprintf(os.Stdout, "Calling service.Start.\n")
-
 	errChan := make(chan error, 2)
 	listenForInterrupt(errChan)
-
-	err = s.Start(errChan)
-	if err != nil {
-		return err
-	}
+	go s.Start(errChan)
 
 	err = <-errChan
 	fmt.Fprintf(os.Stdout, "Terminating: %v.\n", err)


### PR DESCRIPTION
Use async call to start the service and listen to the OS signal in bootstrap.
fix #242

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>