### PR TITLE
Add CUD callbacks into ProtocolDriver

### DIFF
--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -135,3 +135,24 @@ func (s *SimpleDriver) Stop(force bool) error {
 	}
 	return nil
 }
+
+// AddDevice is a callback function that is invoked
+// when a new Device associated with this Device Service is added
+func (s *SimpleDriver) AddDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
+	s.lc.Debug(fmt.Sprintf("a new Device is added: %s", deviceName))
+	return nil
+}
+
+// UpdateDevice is a callback function that is invoked
+// when a Device associated with this Device Service is updated
+func (s *SimpleDriver) UpdateDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
+	s.lc.Debug(fmt.Sprintf("Device %s is updated", deviceName))
+	return nil
+}
+
+// RemoveDevice is a callback function that is invoked
+// when a Device associated with this Device Service is removed
+func (s *SimpleDriver) RemoveDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error {
+	s.lc.Debug(fmt.Sprintf("Device %s is removed", deviceName))
+	return nil
+}

--- a/internal/config/environment_test.go
+++ b/internal/config/environment_test.go
@@ -108,7 +108,7 @@ func TestOverrideUseRegistryFromEnvironment(t *testing.T) {
 		env      map[string]string
 		expected string
 	}{
-		{"valid", map[string]string{envKeyUrl: urlValue}, urlValue },
+		{"valid", map[string]string{envKeyUrl: urlValue}, urlValue},
 		{"no variable", map[string]string{}, useRegistryValue},
 	}
 

--- a/internal/mock/mock_devicevirtualdriver.go
+++ b/internal/mock/mock_devicevirtualdriver.go
@@ -79,3 +79,15 @@ func (DriverMock) HandleWriteCommands(deviceName string, protocols map[string]co
 func (DriverMock) Stop(force bool) error {
 	panic("implement me")
 }
+
+func (DriverMock) AddDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
+	return nil
+}
+
+func (DriverMock) UpdateDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
+	return nil
+}
+
+func (DriverMock) RemoveDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error {
+	return nil
+}

--- a/pkg/models/protocoldriver.go
+++ b/pkg/models/protocoldriver.go
@@ -41,4 +41,16 @@ type ProtocolDriver interface {
 	// for closing any in-use channels, including the channel used to send async
 	// readings (if supported).
 	Stop(force bool) error
+
+	// AddDevice is a callback function that is invoked
+	// when a new Device associated with this Device Service is added
+	AddDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error
+
+	// UpdateDevice is a callback function that is invoked
+	// when a Device associated with this Device Service is updated
+	UpdateDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error
+
+	// RemoveDevice is a callback function that is invoked
+	// when a Device associated with this Device Service is removed
+	RemoveDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error
 }


### PR DESCRIPTION
Add the following callbacks into ProtocolDriver interface:
AddDevice, UpdateDevice, and RemoveDevice
Modify device-simple to fit the interface change
Modify DriverMock to fit the interface change
Invoke the driver callbacks when Device Service callback and Provision
is executed

fix https://github.com/edgexfoundry/device-sdk-go/issues/276

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>