### PR TITLE
Ignore the Device Post callback if cache exists

### DIFF
--- a/internal/controller/restfuncs_test.go
+++ b/internal/controller/restfuncs_test.go
@@ -46,6 +46,8 @@ func TestCallback(t *testing.T) {
 	lc := logger.NewClient("update_test", false, "./device-simple.log", "DEBUG")
 	common.LoggingClient = lc
 	common.DeviceClient = &mock.DeviceClientMock{}
+	common.DeviceProfileClient = &mock.DeviceProfileClientMock{}
+	common.ValueDescriptorClient = &mock.ValueDescriptorMock{}
 	r := InitRestRoutes()
 
 	for _, tt := range tests {

--- a/internal/handler/callback/device.go
+++ b/internal/handler/callback/device.go
@@ -22,6 +22,11 @@ import (
 func handleDevice(method string, id string) common.AppError {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	if method == http.MethodPost {
+		if _, ok := cache.Devices().ForId(id); ok {
+			common.LoggingClient.Debug(fmt.Sprintf("Device id %s has been in cahce, ignoring this callback", id))
+			return nil
+		}
+
 		device, err := common.DeviceClient.Device(id, ctx)
 		if err != nil {
 			appErr := common.NewBadRequestError(err.Error(), err)


### PR DESCRIPTION
Add a check to ignore the Device creation callback
if the Device has been added by Provision.
Modify the unit test to meet this change.

Fix https://github.com/edgexfoundry/device-sdk-go/issues/317

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>