### PR TITLE
feature(query-params): Handle QueryParams from EdgeX Command Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ example/cmd/device-simple/device-simple
 glide.lock
 vendor
 .idea
+.vscode
 go.sum
 coverage.out
 *.snap

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -77,7 +77,7 @@ func readResource(e *executor) (*dsModels.Event, common.AppError) {
 	vars[common.NameVar] = e.deviceName
 	vars[common.CommandVar] = e.autoEvent.Resource
 
-	evt, appErr := handler.CommandHandler(vars, "", common.GetCmdMethod)
+	evt, appErr := handler.CommandHandler(vars, "", common.GetCmdMethod, "")
 	return evt, appErr
 }
 

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -40,4 +40,5 @@ const (
 	SetCmdMethod string = "set"
 
 	CorrelationHeader = clients.CorrelationHeader
+	URLRawQuery = "urlRawQuery"
 )

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -96,7 +96,7 @@ func commandFunc(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	event, appErr := handler.CommandHandler(vars, body, req.Method)
+	event, appErr := handler.CommandHandler(vars, body, req.Method, req.URL.RawQuery)
 
 	if appErr != nil {
 		http.Error(w, fmt.Sprintf("%s %s", appErr.Message(), req.URL.Path), appErr.Code())
@@ -140,7 +140,7 @@ func commandAllFunc(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	events, appErr := handler.CommandAllHandler(vars[common.CommandVar], body, req.Method)
+	events, appErr := handler.CommandAllHandler(vars[common.CommandVar], body, req.Method, req.URL.RawQuery)
 	if appErr != nil {
 		http.Error(w, appErr.Message(), appErr.Code())
 	} else if len(events) > 0 {


### PR DESCRIPTION
This is an example/POC of the second 1/2 from PR:  https://github.com/edgexfoundry/edgex-go/pull/1571 to address issue: https://github.com/edgexfoundry/edgex-go/issues/1564. 

In summary, we place the query params into the Attributes with a key of "query" so as to not create a breaking change to support this. For example if `test=test&test2=test2` came from a GET Command, then those would be put into Attributes like so: `Attributes["query"]  = "test=test&test2=test2"`.

Certainly we could break each param out into a separate attribute, this PR is just meant to get the discussion going on ways to accomplish this.