### PR TITLE
Add option to overwrite registry with local config

### DIFF
--- a/internal/common/globalvars.go
+++ b/internal/common/globalvars.go
@@ -20,6 +20,7 @@ var (
 	CurrentConfig         *Config
 	CurrentDeviceService  contract.DeviceService
 	UseRegistry           bool
+	OverwriteConfig       bool
 	ServiceLocked         bool
 	Driver                dsModels.ProtocolDriver
 	EventClient           coredata.EventClient

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -78,7 +78,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 			return nil, fmt.Errorf("could not verify that Registry already has configuration: %v", err.Error())
 		}
 
-		if hasConfiguration {
+		if hasConfiguration && !common.OverwriteConfig {
 			// Get the configuration values from the Registry
 			rawConfig, err := RegistryClient.GetConfiguration(configuration)
 			if err != nil {
@@ -100,7 +100,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 				return nil, err
 			}
 
-			err = RegistryClient.PutConfigurationToml(e.OverrideFromEnvironment(configTree), true)
+			err = RegistryClient.PutConfigurationToml(e.OverrideFromEnvironment(configTree), common.OverwriteConfig)
 			if err != nil {
 				return nil, fmt.Errorf("could not push configuration to Registry: %v", err.Error())
 			}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -143,7 +143,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 		}
 	}
 
-	fmt.Println(registryMsg)
+	fmt.Fprintln(os.Stdout, registryMsg)
 	return configuration, nil
 }
 

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/edgexfoundry/device-sdk-go"
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 )
 
@@ -33,6 +34,8 @@ func Bootstrap(serviceName string, serviceVersion string, driver dsModels.Protoc
 	flag.StringVar(&confProfile, "p", "", "Specify a profile other than default.")
 	flag.StringVar(&confDir, "confdir", "", "Specify an alternate configuration directory.")
 	flag.StringVar(&confDir, "c", "", "Specify an alternate configuration directory.")
+	flag.BoolVar(&common.OverwriteConfig, "overwrite", false, "Overwrite configuration in the registry")
+	flag.BoolVar(&common.OverwriteConfig, "o", false, "Overwrite configuration in the registry")
 	flag.Parse()
 
 	if err := startService(serviceName, serviceVersion, driver); err != nil {


### PR DESCRIPTION
Add -o and --overwrite flag to indicate whether the service should
reload the configuration from local file to overide the one on registry
fix https://github.com/edgexfoundry/device-sdk-go/issues/342

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>