### PR TITLE
 Add /version API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.16
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -40,5 +40,5 @@ const (
 	SetCmdMethod string = "set"
 
 	CorrelationHeader = clients.CorrelationHeader
-	URLRawQuery = "urlRawQuery"
+	URLRawQuery       = "urlRawQuery"
 )

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -17,10 +17,9 @@ const (
 	ClientMetadata = "Metadata"
 	ClientLogging  = "Logging"
 
-	APIv1Prefix = "/api/v1"
-	Colon       = ":"
-	HttpScheme  = "http://"
-	HttpProto   = "HTTP"
+	Colon      = ":"
+	HttpScheme = "http://"
+	HttpProto  = "HTTP"
 
 	ConfigDirectory    = "./res"
 	ConfigFileName     = "configuration.toml"
@@ -28,10 +27,17 @@ const (
 	WritableKey        = "/Writable"
 	RegistryFailLimit  = 3
 
-	APICallbackRoute        = APIv1Prefix + "/callback"
-	APIValueDescriptorRoute = APIv1Prefix + "/valuedescriptor"
-	APIDiscoveryRoute       = APIv1Prefix + "/discovery"
-	APIPingRoute            = APIv1Prefix + "/ping"
+	APICallbackRoute        = clients.ApiCallbackRoute
+	APIValueDescriptorRoute = clients.ApiValueDescriptorRoute
+	APIPingRoute            = clients.ApiPingRoute
+	APIVersionRoute         = clients.ApiVersionRoute
+	APIMetricsRoute         = clients.ApiMetricsRoute
+	APIConfigRoute          = clients.ApiConfigRoute
+	APIAllCommandRoute      = clients.ApiDeviceRoute + "/all/{command}"
+	APIIdCommandRoute       = clients.ApiDeviceRoute + "/{id}/{command}"
+	APINameCommandRoute     = clients.ApiDeviceRoute + "/name/{name}/{command}"
+	APIDiscoveryRoute       = clients.ApiBase + "/discovery"
+	APITransformRoute       = clients.ApiBase + "/debug/transformData/{transformData}"
 
 	IdVar        string = "id"
 	NameVar      string = "name"

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -36,6 +36,15 @@ func statusFunc(w http.ResponseWriter, req *http.Request) {
 	io.WriteString(w, result)
 }
 
+func versionFunc(w http.ResponseWriter, req *http.Request) {
+	res := struct {
+		Version string `json:"version"`
+	}{handler.VersionHandler()}
+	w.Header().Add(clients.ContentType, clients.ContentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(&res)
+}
+
 func discoveryFunc(w http.ResponseWriter, req *http.Request) {
 	if checkServiceLocked(w, req) {
 		return

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -16,30 +16,29 @@ import (
 )
 
 func InitRestRoutes() *mux.Router {
-	r := mux.NewRouter().PathPrefix(common.APIv1Prefix).Subrouter()
+	r := mux.NewRouter()
 
 	common.LoggingClient.Debug("init status rest controller")
-	r.HandleFunc("/ping", statusFunc).Methods(http.MethodGet)
+	r.HandleFunc(common.APIPingRoute, statusFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init version rest controller")
-	r.HandleFunc("/version", versionFunc).Methods(http.MethodGet)
+	r.HandleFunc(common.APIVersionRoute, versionFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init command rest controller")
-	sr := r.PathPrefix("/device").Subrouter()
-	sr.HandleFunc("/all/{command}", commandAllFunc).Methods(http.MethodGet, http.MethodPut)
-	sr.HandleFunc("/{id}/{command}", commandFunc).Methods(http.MethodGet, http.MethodPut)
-	sr.HandleFunc("/name/{name}/{command}", commandFunc).Methods(http.MethodGet, http.MethodPut)
+	r.HandleFunc(common.APIAllCommandRoute, commandAllFunc).Methods(http.MethodGet, http.MethodPut)
+	r.HandleFunc(common.APIIdCommandRoute, commandFunc).Methods(http.MethodGet, http.MethodPut)
+	r.HandleFunc(common.APINameCommandRoute, commandFunc).Methods(http.MethodGet, http.MethodPut)
 
 	common.LoggingClient.Debug("init callback rest controller")
-	r.HandleFunc("/callback", callbackFunc)
+	r.HandleFunc(common.APICallbackRoute, callbackFunc)
 
 	common.LoggingClient.Debug("init other rest controller")
-	r.HandleFunc("/discovery", discoveryFunc).Methods(http.MethodPost)
-	r.HandleFunc("/debug/transformData/{transformData}", transformFunc).Methods(http.MethodGet)
+	r.HandleFunc(common.APIDiscoveryRoute, discoveryFunc).Methods(http.MethodPost)
+	r.HandleFunc(common.APITransformRoute, transformFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init the metrics and config rest controller each")
-	r.HandleFunc("/metrics", metricsHandler).Methods(http.MethodGet)
-	r.HandleFunc("/config", configHandler).Methods(http.MethodGet)
+	r.HandleFunc(common.APIMetricsRoute, metricsHandler).Methods(http.MethodGet)
+	r.HandleFunc(common.APIConfigRoute, configHandler).Methods(http.MethodGet)
 
 	r.Use(correlation.ManageHeader)
 	r.Use(correlation.OnResponseComplete)

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -19,10 +19,10 @@ func InitRestRoutes() *mux.Router {
 	r := mux.NewRouter().PathPrefix(common.APIv1Prefix).Subrouter()
 
 	common.LoggingClient.Debug("init status rest controller")
-	r.HandleFunc("/ping", statusFunc)
+	r.HandleFunc("/ping", statusFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init version rest controller")
-	r.HandleFunc("/version", versionFunc)
+	r.HandleFunc("/version", versionFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init command rest controller")
 	sr := r.PathPrefix("/device").Subrouter()
@@ -34,8 +34,8 @@ func InitRestRoutes() *mux.Router {
 	r.HandleFunc("/callback", callbackFunc)
 
 	common.LoggingClient.Debug("init other rest controller")
-	r.HandleFunc("/discovery", discoveryFunc).Methods("POST")
-	r.HandleFunc("/debug/transformData/{transformData}", transformFunc).Methods("GET")
+	r.HandleFunc("/discovery", discoveryFunc).Methods(http.MethodPost)
+	r.HandleFunc("/debug/transformData/{transformData}", transformFunc).Methods(http.MethodGet)
 
 	common.LoggingClient.Debug("init the metrics and config rest controller each")
 	r.HandleFunc("/metrics", metricsHandler).Methods(http.MethodGet)

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -21,6 +21,9 @@ func InitRestRoutes() *mux.Router {
 	common.LoggingClient.Debug("init status rest controller")
 	r.HandleFunc("/ping", statusFunc)
 
+	common.LoggingClient.Debug("init version rest controller")
+	r.HandleFunc("/version", versionFunc)
+
 	common.LoggingClient.Debug("init command rest controller")
 	sr := r.PathPrefix("/device").Subrouter()
 	sr.HandleFunc("/all/{command}", commandAllFunc).Methods(http.MethodGet, http.MethodPut)

--- a/internal/handler/version.go
+++ b/internal/handler/version.go
@@ -1,0 +1,13 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2018-2019 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handler
+
+import "github.com/edgexfoundry/device-sdk-go/internal/common"
+
+func VersionHandler() string {
+	return common.ServiceVersion
+}

--- a/internal/mock/mock_valuedescriptorclient.go
+++ b/internal/mock/mock_valuedescriptorclient.go
@@ -33,6 +33,10 @@ var (
 
 type ValueDescriptorMock struct{}
 
+func (ValueDescriptorMock) ValueDescriptorsUsage(names []string, ctx context.Context) (map[string]bool, error) {
+	panic("implement me")
+}
+
 func (ValueDescriptorMock) ValueDescriptors(ctx context.Context) ([]contract.ValueDescriptor, error) {
 	populateValueDescriptorMock()
 	return []contract.ValueDescriptor{


### PR DESCRIPTION
Add /version API to return version number to be consistent with other edgex services
Fix the http method filter in router 
fix #347