### PR TITLE
Remove the duplicated service name in config stem

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -53,15 +53,12 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 			return
 		}
 
-		// TODO: Verify this is correct.
-		stem := common.ConfigRegistryStem + common.ServiceName + "/"
-
 		registryMsg = "Register in registry..."
 		registryConfig := types.Config{
 			Host:       configuration.Registry.Host,
 			Port:       configuration.Registry.Port,
 			Type:       configuration.Registry.Type,
-			Stem:       stem,
+			Stem:       common.ConfigRegistryStem,
 			CheckRoute: common.APIPingRoute,
 			ServiceKey: common.ServiceName,
 		}
@@ -120,7 +117,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 			Host:          configuration.Registry.Host,
 			Port:          configuration.Registry.Port,
 			Type:          configuration.Registry.Type,
-			Stem:          stem,
+			Stem:          common.ConfigRegistryStem,
 			CheckInterval: configuration.Registry.CheckInterval,
 			CheckRoute:    common.APIPingRoute,
 			ServiceKey:    common.ServiceName,


### PR DESCRIPTION
go-mod-registry will assign the service name into the config path, so
device-sdk doesn't need to do it
fix https://github.com/edgexfoundry/device-sdk-go/issues/350

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>