### PR TITLE
Implement default values for parameters to SET cmd

### DIFF
--- a/example/cmd/device-simple/res/Simple-Driver.yaml
+++ b/example/cmd/device-simple/res/Simple-Driver.yaml
@@ -11,7 +11,7 @@ deviceResources:
         description: "Switch On/Off."
         properties:
             value:
-                { type: "Bool", readWrite: "RW" }
+                { type: "Bool", readWrite: "RW", defaultValue: "true" }
             units:
                 { type: "String", readWrite: "R", defaultValue: "On/Off" }
     -
@@ -29,7 +29,7 @@ deviceCommands:
         get:
             - { operation: "get", object: "SwitchButton" }
         set:
-            - { operation: "set", object: "SwitchButton" }
+            - { operation: "set", object: "SwitchButton", parameter: "false" }
     -
         name: "Image"
         get:

--- a/internal/mock/data/deviceprofile/New-Device.json
+++ b/internal/mock/data/deviceprofile/New-Device.json
@@ -37,8 +37,7 @@
         {
           "index": "1",
           "operation": "get",
-          "object": "randfloat32",
-          "parameter": "randfloat32"
+          "object": "randfloat32"
         }
       ]
     }

--- a/internal/mock/data/deviceprofile/Random-Boolean-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Boolean-Generator.json
@@ -49,20 +49,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Bool",
-          "parameter": "RandomValue_Bool"
+          "object": "RandomValue_Bool"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "EnableRandomization_Bool",
-          "parameter": "EnableRandomization_Bool"
+          "parameter": "false"
         },
         {
           "operation": "set",
           "object": "RandomValue_Bool",
-          "parameter": "RandomValue_Bool"
+          "parameter": "false"
         }
       ]
     }

--- a/internal/mock/data/deviceprofile/Random-Float-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Float-Generator.json
@@ -83,20 +83,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Float32",
-          "parameter": "RandomValue_Float32"
+          "object": "RandomValue_Float32"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Float32",
-          "parameter": "RandomValue_Float32"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Float32",
-          "parameter": "EnableRandomization_Float32"
+          "parameter": "false"
         }
       ]
     },
@@ -105,20 +104,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Float64",
-          "parameter": "RandomValue_Float64"
+          "object": "RandomValue_Float64"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Float64",
-          "parameter": "RandomValue_Float64"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Float64",
-          "parameter": "EnableRandomization_Float64"
+          "parameter": "false"
         }
       ]
     }

--- a/internal/mock/data/deviceprofile/Random-Integer-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Integer-Generator.json
@@ -80,8 +80,7 @@
       "properties": {
         "value": {
           "type": "Int8",
-          "readWrite": "R",
-          "defaultValue": "0"
+          "readWrite": "R"
         },
         "units": {
           "type": "String",
@@ -96,8 +95,7 @@
       "properties": {
         "value": {
           "type": "Int16",
-          "readWrite": "R",
-          "defaultValue": "0"
+          "readWrite": "R"
         },
         "units": {
           "type": "String",
@@ -267,20 +265,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int8",
-          "parameter": "RandomValue_Int8"
+          "object": "RandomValue_Int8"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int8",
-          "parameter": "RandomValue_Int8"
+          "object": "RandomValue_Int8"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Int8",
-          "parameter": "EnableRandomization_Int8"
+          "parameter": "false"
         }
       ]
     },
@@ -289,20 +285,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int16",
-          "parameter": "RandomValue_Int16"
+          "object": "RandomValue_Int16"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Int16",
-          "parameter": "RandomValue_Int16"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Int16",
-          "parameter": "EnableRandomization_Int16"
+          "parameter": "false"
         }
       ]
     },
@@ -311,20 +306,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int32",
-          "parameter": "RandomValue_Int32"
+          "object": "RandomValue_Int32"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int32",
-          "parameter": "RandomValue_Int32"
+          "object": "RandomValue_Int32"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Int32",
-          "parameter": "EnableRandomization_Int32"
+          "parameter": "false"
         }
       ]
     },
@@ -333,20 +326,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int64",
-          "parameter": "RandomValue_Int64"
+          "object": "RandomValue_Int64"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Int64",
-          "parameter": "RandomValue_Int64"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Int64",
-          "parameter": "EnableRandomization_Int64"
+          "parameter": "false"
         }
       ]
     },
@@ -355,15 +347,14 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestTransform_Fail",
-          "parameter": "ResourceTestTransform_Fail"
+          "object": "ResourceTestTransform_Fail"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "ResourceTestTransform_Fail",
-          "parameter": "ResourceTestTransform_Fail"
+          "parameter": "0"
         }
       ]
     },
@@ -372,15 +363,14 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestAssertion_Pass",
-          "parameter": "ResourceTestAssertion_Pass"
+          "object": "ResourceTestAssertion_Pass"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "ResourceTestAssertion_Pass",
-          "parameter": "ResourceTestAssertion_Pass"
+          "parameter": "0"
         }
       ]
     },
@@ -389,15 +379,14 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestAssertion_Fail",
-          "parameter": "ResourceTestAssertion_Fail"
+          "object": "ResourceTestAssertion_Fail"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "ResourceTestAssertion_Fail",
-          "parameter": "ResourceTestAssertion_Fail"
+          "parameter": "0"
         }
       ]
     },
@@ -407,7 +396,6 @@
         {
           "operation": "get",
           "object": "ResourceTestMapping_Pass",
-          "parameter": "ResourceTestMapping_Pass",
           "mappings": {
             "123": "Pass"
           }
@@ -417,7 +405,7 @@
         {
           "operation": "set",
           "object": "ResourceTestMapping_Pass",
-          "parameter": "ResourceTestMapping_Pass",
+          "parameter": "0",
           "mappings": {
             "Pass": "123"
           }
@@ -430,7 +418,6 @@
         {
           "operation": "get",
           "object": "ResourceTestMapping_Fail",
-          "parameter": "ResourceTestMapping_Fail",
           "mappings": {
             "12": "Pass"
           }
@@ -440,7 +427,7 @@
         {
           "operation": "set",
           "object": "ResourceTestMapping_Fail",
-          "parameter": "ResourceTestMapping_Fail",
+          "parameter": "0",
           "mappings": {
             "Pass": "12"
           }
@@ -452,15 +439,13 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceNotFound",
-          "parameter": "Error"
+          "object": "ResourceNotFound"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "ResourceNotFound",
-          "parameter": "Error"
+          "object": "ResourceNotFound"
         }
       ]
     },
@@ -469,8 +454,7 @@
       "get": [
         {
           "operation": "get",
-          "object": "NoDeviceResourceForResult",
-          "parameter": "NoDeviceResourceForResult"
+          "object": "NoDeviceResourceForResult"
         }
       ]
     },
@@ -480,14 +464,12 @@
         {
           "index": "1",
           "operation": "get",
-          "object": "Error",
-          "parameter": "Error"
+          "object": "Error"
         },
         {
           "index": "2",
           "operation": "get",
-          "object": "Error",
-          "parameter": "Error"
+          "object": "Error"
         }
       ],
       "set": [

--- a/internal/mock/data/deviceprofile/Random-UnsignedInteger-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-UnsignedInteger-Generator.json
@@ -145,20 +145,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint8",
-          "parameter": "RandomValue_Uint8"
+          "object": "RandomValue_Uint8"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Uint8",
-          "parameter": "RandomValue_Uint8"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Uint8",
-          "parameter": "EnableRandomization_Uint8"
+          "parameter": "false"
         }
       ]
     },
@@ -167,20 +166,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint16",
-          "parameter": "RandomValue_Uint16"
+          "object": "RandomValue_Uint16"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Uint16",
-          "parameter": "RandomValue_Uint16"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Uint16",
-          "parameter": "EnableRandomization_Uint16"
+          "parameter": "false"
         }
       ]
     },
@@ -189,20 +187,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint32",
-          "parameter": "RandomValue_Uint32"
+          "object": "RandomValue_Uint32"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Uint32",
-          "parameter": "RandomValue_Uint32"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Uint32",
-          "parameter": "EnableRandomization_Uint32"
+          "parameter": "false"
         }
       ]
     },
@@ -211,20 +208,19 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint64",
-          "parameter": "RandomValue_Uint64"
+          "object": "RandomValue_Uint64"
         }
       ],
       "set": [
         {
           "operation": "set",
           "object": "RandomValue_Uint64",
-          "parameter": "RandomValue_Uint64"
+          "parameter": "0"
         },
         {
           "operation": "set",
           "object": "EnableRandomization_Uint64",
-          "parameter": "EnableRandomization_Uint64"
+          "parameter": "false"
         }
       ]
     }


### PR DESCRIPTION
When performing a SET / PUT to a device resource, the value passed to the driver should be:
    1. Parsed out of the JSON payload, otherwise
    2. If this is part of a deviceCommand, the value of "parameter" in the resource operation, otherwise
    3. The value of "defaultValue" in the deviceResource
    If none of these are available, the operation fails (http 400)
    fix https://github.com/edgexfoundry/device-sdk-go/issues/356

Since the implementation has become based on ResourceOperation loop, not parameters loop, the RO slice doesn't need to convert to map anymore

command_test.go needs to be refactored, so remove it for now
Related issue opened: https://github.com/edgexfoundry/device-sdk-go/issues/361