### PR TITLE
Make 0 is valid for Float32 and Float64 reading

### DIFF
--- a/internal/transformer/transformvaluechecker.go
+++ b/internal/transformer/transformvaluechecker.go
@@ -51,11 +51,11 @@ func checkTransformedValueInRange(origin interface{}, transformed float64) bool 
 			inRange = true
 		}
 	case float32:
-		if math.Abs(transformed) >= math.SmallestNonzeroFloat32 && math.Abs(transformed) <= math.MaxFloat32 {
+		if !math.IsNaN(float64(transformed)) && math.Abs(transformed) <= math.MaxFloat32 {
 			inRange = true
 		}
 	case float64:
-		if math.Abs(transformed) >= math.SmallestNonzeroFloat64 && math.Abs(transformed) <= math.MaxFloat64 {
+		if !math.IsNaN(transformed) && !math.IsInf(transformed, 0) {
 			inRange = true
 		}
 	default:


### PR DESCRIPTION
transformer.checkTransformedValueInRange limited Float32 and Float64
type cannot be zero value, but it should be valid.
fix https://github.com/edgexfoundry/device-sdk-go/issues/358

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>