### PR TITLE
feat(server): Add API to allow adding additional routes to internal Webserver

### DIFF
--- a/internal/controller/restfuncs_test.go
+++ b/internal/controller/restfuncs_test.go
@@ -46,7 +46,8 @@ func TestCallback(t *testing.T) {
 	lc := logger.NewClient("update_test", false, "./device-simple.log", "DEBUG")
 	common.LoggingClient = lc
 	common.DeviceClient = &mock.DeviceClientMock{}
-	r := InitRestRoutes()
+	controller := NewRestController()
+	controller.InitRestRoutes()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -55,7 +56,7 @@ func TestCallback(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			rr := httptest.NewRecorder()
-			r.ServeHTTP(rr, req)
+			controller.router.ServeHTTP(rr, req)
 			fmt.Printf("rr.code = %v\n", rr.Code)
 			if status := rr.Code; status != tt.code {
 				t.Errorf("CallbackHandler: handler returned wrong status code: got %v want %v",
@@ -71,13 +72,14 @@ func TestCommandServiceLocked(t *testing.T) {
 	common.LoggingClient = lc
 	common.ServiceLocked = true
 	common.ServiceName = deviceCommandTest
-	r := InitRestRoutes()
+	controller := NewRestController()
+	controller.InitRestRoutes()
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", clients.ApiDeviceRoute, "nil", "nil"), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": "nil", "cmd": "nil"})
 
 	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
+	controller.router.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusLocked {
 		t.Errorf("ServiceLocked: handler returned wrong status code: got %v want %v",
 			status, http.StatusLocked)
@@ -98,13 +100,14 @@ func TestCommandNoDevice(t *testing.T) {
 	common.LoggingClient = lc
 	common.ServiceLocked = false
 	common.ValueDescriptorClient = &mock.ValueDescriptorMock{}
-	r := InitRestRoutes()
+	controller := NewRestController()
+	controller.InitRestRoutes()
 
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s/%s/%s", clients.ApiDeviceRoute, badDeviceId, testCmd), nil)
 	req = mux.SetURLVars(req, map[string]string{"deviceId": badDeviceId, "cmd": testCmd})
 
 	rr := httptest.NewRecorder()
-	r.ServeHTTP(rr, req)
+	controller.router.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusNotFound {
 		t.Errorf("NoDevice: handler returned wrong status code: got %v want %v",

--- a/internal/controller/restrouter_test.go
+++ b/internal/controller/restrouter_test.go
@@ -1,0 +1,103 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+)
+
+func init() {
+	lc := logger.NewClient("update_test", false, "./device-simple.log", "DEBUG")
+	common.LoggingClient = lc
+}
+
+func TestAddRoute(t *testing.T) {
+
+	tests := []struct {
+		Name          string
+		Route         string
+		ErrorExpected bool
+	}{
+		{"Success", "/api/v1/test", false},
+		{"Reserved Route", common.APIVersionRoute, true},
+	}
+
+	for _, test := range tests {
+		controller := NewRestController()
+		controller.InitRestRoutes()
+
+		err := controller.AddRoute(test.Route, func(http.ResponseWriter, *http.Request) {}, http.MethodPost)
+		if test.ErrorExpected {
+			assert.Error(t, err, "Expected an error")
+		} else {
+			if !assert.NoError(t, err, "Unexpected an error") {
+				t.Fatal()
+			}
+
+			err = controller.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+				path, err := route.GetPathTemplate()
+				if err != nil {
+					return err
+				}
+
+				// Have to skip all the reserved routes that have previously been added.
+				if controller.reservedRoutes[path] {
+					return nil
+				}
+
+				routeMethods, err := route.GetMethods()
+				if err != nil {
+					return err
+				}
+
+				assert.Equal(t, test.Route, path)
+				assert.Equal(t, http.MethodPost, routeMethods[0], "Expected POST Method")
+				return nil
+			})
+
+			assert.NoError(t, err, "Unexpected error examining route")
+		}
+	}
+}
+
+func TestInitRestRoutes(t *testing.T) {
+	controller := NewRestController()
+
+	controller.InitRestRoutes()
+	err := controller.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err != nil {
+			return err
+		}
+
+		// Verify the route is reserved by attempting to add it as 'external' route.
+		// If tests fails then the route was not added to the reserved list
+		err = controller.AddRoute(path, func(http.ResponseWriter, *http.Request) {})
+		assert.Error(t, err, path, fmt.Sprintf("Expected error for '%s'", path))
+		return nil
+	})
+
+	assert.NoError(t, err, "Unexpected error examining route")
+}


### PR DESCRIPTION
Some device services (new rest DS) need to have their own REST endpoints. Currently these services have to run a second webserver and configure a separate port. This is not desirable. Adding an API which adds endpoint to existing webservice would make this much cleaner and removes need to specify a second port for the service.

closes #373
