### PR TITLE
Update core-contracts reference to v0.1.30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.16
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.30
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
@@ -12,3 +12,5 @@ require (
 	github.com/ugorji/go v1.1.4
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.12

--- a/service.go
+++ b/service.go
@@ -146,7 +146,7 @@ func selfRegister() error {
 	ds, err := common.DeviceServiceClient.DeviceServiceForName(common.ServiceName, ctx)
 
 	if err != nil {
-		if errsc, ok := err.(*types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
+		if errsc, ok := err.(types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
 			common.LoggingClient.Info(fmt.Sprintf("Device Service %s doesn't exist, creating a new one", ds.Name))
 			ds, err = createNewDeviceService()
 		} else {
@@ -202,7 +202,7 @@ func makeNewAddressable() (*contract.Addressable, error) {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	addr, err := common.AddressableClient.AddressableForName(common.ServiceName, ctx)
 	if err != nil {
-		if errsc, ok := err.(*types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
+		if errsc, ok := err.(types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
 			common.LoggingClient.Info(fmt.Sprintf("Addressable %s doesn't exist, creating a new one", common.ServiceName))
 			millis := time.Now().UnixNano() / int64(time.Millisecond)
 			addr = contract.Addressable{


### PR DESCRIPTION
Fix #372

* ErrServiceClient is no longer a pointer
* Added min-supported Go version to go.mod (1.12 currently)
* Added Fetch() implementation to local Endpointer implementation

Signed-off-by: Trevor Conn <trevor_conn@dell.com>