### PR TITLE
Rename fields within ResourceOperation

### DIFF
--- a/async.go
+++ b/async.go
@@ -64,7 +64,7 @@ func processAsyncResults() {
 				if ok {
 					cv = newCV
 				} else {
-					common.LoggingClient.Warn(fmt.Sprintf("processAsyncResults - Mapping failed for Device Resource Operation: %s, with value: %s, %v", ro.Resource, cv.String(), err))
+					common.LoggingClient.Warn(fmt.Sprintf("processAsyncResults - Mapping failed for Device Resource Operation: %s, with value: %s, %v", ro.DeviceCommand, cv.String(), err))
 				}
 			}
 

--- a/example/cmd/device-simple/res/Simple-Driver.yaml
+++ b/example/cmd/device-simple/res/Simple-Driver.yaml
@@ -51,23 +51,23 @@ deviceCommands:
   -
     name: "Switch"
     get:
-      - { operation: "get", object: "SwitchButton" }
+      - { operation: "get", deviceResource: "SwitchButton" }
     set:
-      - { operation: "set", object: "SwitchButton", parameter: "false" }
+      - { operation: "set", deviceResource: "SwitchButton", parameter: "false" }
   -
     name: "Image"
     get:
-      - { operation: "get", object: "Image" }
+      - { operation: "get", deviceResource: "Image" }
   -
     name: "Rotation"
     get:
-      - { operation: "get", object: "Xrotation" }
-      - { operation: "get", object: "Yrotation" }
-      - { operation: "get", object: "Zrotation" }
+      - { operation: "get", deviceResource: "Xrotation" }
+      - { operation: "get", deviceResource: "Yrotation" }
+      - { operation: "get", deviceResource: "Zrotation" }
     set:
-      - { operation: "set", object: "Xrotation", parameter: "0" }
-      - { operation: "set", object: "Yrotation", parameter: "0" }
-      - { operation: "set", object: "Zrotation", parameter: "0" }
+      - { operation: "set", deviceResource: "Xrotation", parameter: "0" }
+      - { operation: "set", deviceResource: "Yrotation", parameter: "0" }
+      - { operation: "set", deviceResource: "Zrotation", parameter: "0" }
 
 coreCommands:
   -

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.30
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect

--- a/internal/cache/profiles.go
+++ b/internal/cache/profiles.go
@@ -31,7 +31,7 @@ type ProfileCache interface {
 	DeviceResource(profileName string, resourceName string) (contract.DeviceResource, bool)
 	CommandExists(profileName string, cmd string) (bool, error)
 	ResourceOperations(profileName string, cmd string, method string) ([]contract.ResourceOperation, error)
-	ResourceOperation(profileName string, object string, method string) (contract.ResourceOperation, error)
+	ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, error)
 }
 
 type profileCache struct {
@@ -232,7 +232,7 @@ func (p *profileCache) ResourceOperations(profileName string, cmd string, method
 }
 
 // Return the first matched ResourceOperation
-func (p *profileCache) ResourceOperation(profileName string, object string, method string) (contract.ResourceOperation, error) {
+func (p *profileCache) ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -249,16 +249,16 @@ func (p *profileCache) ResourceOperation(profileName string, object string, meth
 		}
 	}
 
-	if ro, ok = retrieveFirstRObyObject(rosMap, object); !ok {
-		return ro, fmt.Errorf("specified ResourceOperation by object %s not found", object)
+	if ro, ok = retrieveFirstRObyDeviceResource(rosMap, deviceResource); !ok {
+		return ro, fmt.Errorf("specified ResourceOperation by deviceResource %s not found", deviceResource)
 	}
 	return ro, nil
 }
 
-func retrieveFirstRObyObject(rosMap map[string][]contract.ResourceOperation, object string) (contract.ResourceOperation, bool) {
+func retrieveFirstRObyDeviceResource(rosMap map[string][]contract.ResourceOperation, deviceResource string) (contract.ResourceOperation, bool) {
 	for _, ros := range rosMap {
 		for _, ro := range ros {
-			if ro.Object == object {
+			if ro.DeviceResource == deviceResource {
 				return ro, true
 			}
 		}

--- a/internal/cache/profiles_test.go
+++ b/internal/cache/profiles_test.go
@@ -190,25 +190,25 @@ func TestProfileCache_ResourceOperations(t *testing.T) {
 func TestProfileCache_ResourceOperation(t *testing.T) {
 	dpc := newProfileCache(dps)
 
-	if _, err := dpc.ResourceOperation(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.DeviceCommands[0].Get[0].Object, common.GetCmdMethod); err == nil {
+	if _, err := dpc.ResourceOperation(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.DeviceCommands[0].Get[0].DeviceResource, common.GetCmdMethod); err == nil {
 		t.Error("DeviceProfileRandomFloatGenerator is not in cache, supposed to get an error")
 	}
-	if _, err := dpc.ResourceOperation(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.DeviceCommands[0].Get[0].Object, common.SetCmdMethod); err == nil {
+	if _, err := dpc.ResourceOperation(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.DeviceCommands[0].Get[0].DeviceResource, common.SetCmdMethod); err == nil {
 		t.Error("DeviceProfileRandomFloatGenerator is not in cache, supposed to get an error")
 	}
 
-	if ro, err := dpc.ResourceOperation(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0].Object, common.GetCmdMethod); err != nil {
+	if ro, err := dpc.ResourceOperation(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0].DeviceResource, common.GetCmdMethod); err != nil {
 		t.Error("DeviceProfileRandomBoolGenerator exists in cache, not supposed to get an error")
 	} else {
 		assert.Equal(t, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0], ro)
 	}
-	if ro, err := dpc.ResourceOperation(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0].Object, common.GetCmdMethod); err != nil {
+	if ro, err := dpc.ResourceOperation(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0].DeviceResource, common.GetCmdMethod); err != nil {
 		t.Error("DeviceProfileRandomBoolGenerator exists in cache, not supposed to get an error")
 	} else {
 		assert.Equal(t, mock.DeviceProfileRandomBoolGenerator.DeviceCommands[0].Get[0], ro)
 	}
 
 	if _, err := dpc.ResourceOperation(mock.DeviceProfileRandomBoolGenerator.Name, "arbitaryNameXXX", common.GetCmdMethod); err == nil {
-		t.Error("the input object name of resource operation is not belong to DeviceProfileRandomBoolGenerator, supposed to get an error")
+		t.Error("the input deviceResource name of resource operation is not belong to DeviceProfileRandomBoolGenerator, supposed to get an error")
 	}
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -122,8 +122,8 @@ func CompareDeviceProfiles(a contract.DeviceProfile, b contract.DeviceProfile) b
 	devResourcesOk := CompareDeviceResources(a.DeviceResources, b.DeviceResources)
 	resourcesOk := CompareDeviceCommands(a.DeviceCommands, b.DeviceCommands)
 
-	// TODO: Objects fields aren't compared as to dr properly
-	// requires introspection as Obects is a slice of interface{}
+	// TODO: DeviceResource fields aren't compared as to dr properly
+	// requires introspection as DeviceResource is a slice of interface{}
 
 	return a.DescribedObject == b.DescribedObject &&
 		a.Id == b.Id &&
@@ -189,9 +189,9 @@ func CompareResourceOperations(a []contract.ResourceOperation, b []contract.Reso
 
 		if a[i].Index != b[i].Index ||
 			a[i].Operation != b[i].Operation ||
-			a[i].Object != b[i].Object ||
+			a[i].DeviceResource != b[i].DeviceResource ||
 			a[i].Parameter != b[i].Parameter ||
-			a[i].Resource != b[i].Resource ||
+			a[i].DeviceCommand != b[i].DeviceCommand ||
 			!secondaryOk ||
 			!mappingsOk {
 			return false

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -147,14 +147,14 @@ func cvsToEvent(device *contract.Device, cvs []*dsModels.CommandValue, cmd strin
 			if ok {
 				cv = newCV
 			} else {
-				common.LoggingClient.Warn(fmt.Sprintf("Handler - execReadCmd: Resource Operation (%s) mapping value (%s) failed with the mapping table: %v", ro.Resource, cv.String(), ro.Mappings))
+				common.LoggingClient.Warn(fmt.Sprintf("Handler - execReadCmd: Resource Operation (%s) mapping value (%s) failed with the mapping table: %v", ro.DeviceCommand, cv.String(), ro.Mappings))
 				//transformsOK = false  // issue #89 will discuss how to handle there is no mapping matched
 			}
 		}
 
-		// TODO: the Java SDK supports a RO secondary device resource(object).
+		// TODO: the Java SDK supports a RO secondary device resource.
 		// If defined, then a RO result will generate a reading for the
-		// secondary object. As this use case isn't defined and/or used in
+		// secondary device resource. As this use case isn't defined and/or used in
 		// any of the existing Java device services, this concept hasn't
 		// been implemened in gxds. TBD at the devices f2f whether this
 		// be killed completely.
@@ -202,7 +202,7 @@ func execReadCmd(device *contract.Device, cmd string, queryParams string) (*dsMo
 	reqs := make([]dsModels.CommandRequest, len(ros))
 
 	for i, op := range ros {
-		drName := op.Object
+		drName := op.DeviceResource
 		common.LoggingClient.Debug(fmt.Sprintf("Handler - execReadCmd: deviceResource: %s", drName))
 
 		// TODO: add recursive support for resource command chaining. This occurs when a
@@ -413,9 +413,9 @@ func parseParams(params string) (paramMap map[string]string, err error) {
 }
 
 func createCommandValueFromRO(profileName string, ro *contract.ResourceOperation, v string) (*dsModels.CommandValue, error) {
-	dr, ok := cache.Profiles().DeviceResource(profileName, ro.Object)
+	dr, ok := cache.Profiles().DeviceResource(profileName, ro.DeviceResource)
 	if !ok {
-		msg := fmt.Sprintf("createCommandValueForParam: no deviceResource: %s", ro.Object)
+		msg := fmt.Sprintf("createCommandValueForParam: no deviceResource: %s", ro.DeviceResource)
 		common.LoggingClient.Error(msg)
 		return nil, fmt.Errorf(msg)
 	}

--- a/internal/mock/data/deviceprofile/New-Device.json
+++ b/internal/mock/data/deviceprofile/New-Device.json
@@ -37,7 +37,7 @@
         {
           "index": "1",
           "operation": "get",
-          "object": "randfloat32"
+          "deviceResource": "randfloat32"
         }
       ]
     }

--- a/internal/mock/data/deviceprofile/Random-Boolean-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Boolean-Generator.json
@@ -49,18 +49,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Bool"
+          "deviceResource": "RandomValue_Bool"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "EnableRandomization_Bool",
+          "deviceResource": "EnableRandomization_Bool",
           "parameter": "false"
         },
         {
           "operation": "set",
-          "object": "RandomValue_Bool",
+          "deviceResource": "RandomValue_Bool",
           "parameter": "false"
         }
       ]

--- a/internal/mock/data/deviceprofile/Random-Float-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Float-Generator.json
@@ -83,18 +83,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Float32"
+          "deviceResource": "RandomValue_Float32"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Float32",
+          "deviceResource": "RandomValue_Float32",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Float32",
+          "deviceResource": "EnableRandomization_Float32",
           "parameter": "false"
         }
       ]
@@ -104,18 +104,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Float64"
+          "deviceResource": "RandomValue_Float64"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Float64",
+          "deviceResource": "RandomValue_Float64",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Float64",
+          "deviceResource": "EnableRandomization_Float64",
           "parameter": "false"
         }
       ]

--- a/internal/mock/data/deviceprofile/Random-Integer-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Integer-Generator.json
@@ -265,17 +265,17 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int8"
+          "deviceResource": "RandomValue_Int8"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int8"
+          "deviceResource": "RandomValue_Int8"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Int8",
+          "deviceResource": "EnableRandomization_Int8",
           "parameter": "false"
         }
       ]
@@ -285,18 +285,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int16"
+          "deviceResource": "RandomValue_Int16"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int16",
+          "deviceResource": "RandomValue_Int16",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Int16",
+          "deviceResource": "EnableRandomization_Int16",
           "parameter": "false"
         }
       ]
@@ -306,17 +306,17 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int32"
+          "deviceResource": "RandomValue_Int32"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int32"
+          "deviceResource": "RandomValue_Int32"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Int32",
+          "deviceResource": "EnableRandomization_Int32",
           "parameter": "false"
         }
       ]
@@ -326,18 +326,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Int64"
+          "deviceResource": "RandomValue_Int64"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Int64",
+          "deviceResource": "RandomValue_Int64",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Int64",
+          "deviceResource": "EnableRandomization_Int64",
           "parameter": "false"
         }
       ]
@@ -347,13 +347,13 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestTransform_Fail"
+          "deviceResource": "ResourceTestTransform_Fail"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "ResourceTestTransform_Fail",
+          "deviceResource": "ResourceTestTransform_Fail",
           "parameter": "0"
         }
       ]
@@ -363,13 +363,13 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestAssertion_Pass"
+          "deviceResource": "ResourceTestAssertion_Pass"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "ResourceTestAssertion_Pass",
+          "deviceResource": "ResourceTestAssertion_Pass",
           "parameter": "0"
         }
       ]
@@ -379,13 +379,13 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestAssertion_Fail"
+          "deviceResource": "ResourceTestAssertion_Fail"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "ResourceTestAssertion_Fail",
+          "deviceResource": "ResourceTestAssertion_Fail",
           "parameter": "0"
         }
       ]
@@ -395,7 +395,7 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestMapping_Pass",
+          "deviceResource": "ResourceTestMapping_Pass",
           "mappings": {
             "123": "Pass"
           }
@@ -404,7 +404,7 @@
       "set": [
         {
           "operation": "set",
-          "object": "ResourceTestMapping_Pass",
+          "deviceResource": "ResourceTestMapping_Pass",
           "parameter": "0",
           "mappings": {
             "Pass": "123"
@@ -417,7 +417,7 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceTestMapping_Fail",
+          "deviceResource": "ResourceTestMapping_Fail",
           "mappings": {
             "12": "Pass"
           }
@@ -426,7 +426,7 @@
       "set": [
         {
           "operation": "set",
-          "object": "ResourceTestMapping_Fail",
+          "deviceResource": "ResourceTestMapping_Fail",
           "parameter": "0",
           "mappings": {
             "Pass": "12"
@@ -439,13 +439,13 @@
       "get": [
         {
           "operation": "get",
-          "object": "ResourceNotFound"
+          "deviceResource": "ResourceNotFound"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "ResourceNotFound"
+          "deviceResource": "ResourceNotFound"
         }
       ]
     },
@@ -454,7 +454,7 @@
       "get": [
         {
           "operation": "get",
-          "object": "NoDeviceResourceForResult"
+          "deviceResource": "NoDeviceResourceForResult"
         }
       ]
     },
@@ -464,25 +464,25 @@
         {
           "index": "1",
           "operation": "get",
-          "object": "Error"
+          "deviceResource": "Error"
         },
         {
           "index": "2",
           "operation": "get",
-          "object": "Error"
+          "deviceResource": "Error"
         }
       ],
       "set": [
         {
           "index": "1",
           "operation": "set",
-          "object": "Error",
+          "deviceResource": "Error",
           "parameter": "Error"
         },
         {
           "index": "2",
           "operation": "set",
-          "object": "Error",
+          "deviceResource": "Error",
           "parameter": "Error"
         }
       ]

--- a/internal/mock/data/deviceprofile/Random-UnsignedInteger-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-UnsignedInteger-Generator.json
@@ -145,18 +145,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint8"
+          "deviceResource": "RandomValue_Uint8"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Uint8",
+          "deviceResource": "RandomValue_Uint8",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Uint8",
+          "deviceResource": "EnableRandomization_Uint8",
           "parameter": "false"
         }
       ]
@@ -166,18 +166,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint16"
+          "deviceResource": "RandomValue_Uint16"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Uint16",
+          "deviceResource": "RandomValue_Uint16",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Uint16",
+          "deviceResource": "EnableRandomization_Uint16",
           "parameter": "false"
         }
       ]
@@ -187,18 +187,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint32"
+          "deviceResource": "RandomValue_Uint32"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Uint32",
+          "deviceResource": "RandomValue_Uint32",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Uint32",
+          "deviceResource": "EnableRandomization_Uint32",
           "parameter": "false"
         }
       ]
@@ -208,18 +208,18 @@
       "get": [
         {
           "operation": "get",
-          "object": "RandomValue_Uint64"
+          "deviceResource": "RandomValue_Uint64"
         }
       ],
       "set": [
         {
           "operation": "set",
-          "object": "RandomValue_Uint64",
+          "deviceResource": "RandomValue_Uint64",
           "parameter": "0"
         },
         {
           "operation": "set",
-          "object": "EnableRandomization_Uint64",
+          "deviceResource": "EnableRandomization_Uint64",
           "parameter": "false"
         }
       ]

--- a/internal/mock/mock_devicevirtualdriver.go
+++ b/internal/mock/mock_devicevirtualdriver.go
@@ -44,8 +44,8 @@ func (DriverMock) HandleReadCommands(deviceName string, protocols map[string]con
 			default:
 				v, _ = dsModels.NewInt8Value(req.DeviceResourceName, now, Int8Value)
 			case "NoDeviceResourceForResult":
-				ro := contract.ResourceOperation{Object: ""}
-				v, _ = dsModels.NewInt8Value(ro.Object, now, Int8Value)
+				ro := contract.ResourceOperation{DeviceResource: ""}
+				v, _ = dsModels.NewInt8Value(ro.DeviceResource, now, Int8Value)
 			case "Error":
 				err = fmt.Errorf("error occurred in HandleReadCommands")
 			}

--- a/internal/mock/mock_valuedescriptorclient.go
+++ b/internal/mock/mock_valuedescriptorclient.go
@@ -159,18 +159,18 @@ func CreateDescriptorsFromProfile(profile contract.DeviceProfile) error {
 }
 
 func createDescriptorFromResourceOperation(profileName string, drs []contract.DeviceResource, op contract.ResourceOperation) error {
-	if _, ok := descMap[op.Object]; ok {
+	if _, ok := descMap[op.DeviceResource]; ok {
 		return nil
 	}
 	drMap := make(map[string]map[string]contract.DeviceResource, 0)
 	drMap[profileName] = deviceResourceSliceToMap(drs)
-	dr := drMap[profileName][op.Object]
+	dr := drMap[profileName][op.DeviceResource]
 
-	desc, err := createDescriptor(op.Object, dr)
+	desc, err := createDescriptor(op.DeviceResource, dr)
 	if err != nil {
 		return err
 	}
-	descMap[op.Object] = desc
+	descMap[op.DeviceResource] = desc
 	return nil
 }
 

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -202,15 +202,15 @@ func isValueDescriptorManagedByMetadata() bool {
 }
 
 func createDescriptorFromResourceOperation(profileName string, op contract.ResourceOperation) {
-	if _, ok := cache.ValueDescriptors().ForName(op.Object); ok {
+	if _, ok := cache.ValueDescriptors().ForName(op.DeviceResource); ok {
 		// Value Descriptor has been created
 		return
 	} else {
-		dr, ok := cache.Profiles().DeviceResource(profileName, op.Object)
+		dr, ok := cache.Profiles().DeviceResource(profileName, op.DeviceResource)
 		if !ok {
-			common.LoggingClient.Error(fmt.Sprintf("can't find Device Resource %s to match Device Command (Resource Operation) %v in Device Profile %s", op.Object, op, profileName))
+			common.LoggingClient.Error(fmt.Sprintf("can't find Device Resource %s to match Device Command (Resource Operation) %v in Device Profile %s", op.DeviceResource, op, profileName))
 		}
-		desc, err := createDescriptor(op.Object, dr)
+		desc, err := createDescriptor(op.DeviceResource, dr)
 		if err != nil {
 			common.LoggingClient.Error(fmt.Sprintf("createing Value Descriptor %v failed: %v", desc, err))
 		} else {

--- a/internal/transformer/transformresult_test.go
+++ b/internal/transformer/transformresult_test.go
@@ -27,8 +27,8 @@ func TestTransformReadResult_base_unt8(t *testing.T) {
 	val := uint8(2)
 	base := "10"
 	expected := uint8(100)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -53,8 +53,8 @@ func TestTransformReadResult_base_unt8(t *testing.T) {
 func TestTransformReadResult_base_unt8_overflow(t *testing.T) {
 	val := uint8(10)
 	base := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -73,8 +73,8 @@ func TestTransformReadResult_scale_unt8(t *testing.T) {
 	val := uint8(math.MaxUint8 / 5)
 	scale := "5"
 	expected := uint8(math.MaxUint8)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -99,8 +99,8 @@ func TestTransformReadResult_scale_unt8(t *testing.T) {
 func TestTransformReadResult_scale_unt8_overflow(t *testing.T) {
 	val := uint8(math.MaxUint8 / 5)
 	scale := "6"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -119,8 +119,8 @@ func TestTransformReadResult_offset_unt8(t *testing.T) {
 	val := uint8(math.MaxUint8 - 1)
 	offset := "1"
 	expected := uint8(math.MaxUint8)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -145,8 +145,8 @@ func TestTransformReadResult_offset_unt8(t *testing.T) {
 func TestTransformReadResult_offset_unt8_overflow(t *testing.T) {
 	val := uint8(math.MaxUint8)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -165,8 +165,8 @@ func TestTransformReadResult_base_unt16(t *testing.T) {
 	val := uint16(2)
 	base := "200"
 	expected := uint16(40000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -191,8 +191,8 @@ func TestTransformReadResult_base_unt16(t *testing.T) {
 func TestTransformReadResult_base_uint16_overflow(t *testing.T) {
 	val := uint16(200)
 	base := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -211,8 +211,8 @@ func TestTransformReadResult_scale_uint16(t *testing.T) {
 	val := uint16(math.MaxUint16 / 5)
 	scale := "5"
 	expected := uint16(math.MaxUint16)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -237,8 +237,8 @@ func TestTransformReadResult_scale_uint16(t *testing.T) {
 func TestTransformReadResult_scale_uint16_overflow(t *testing.T) {
 	val := uint16(math.MaxUint16 / 5)
 	scale := "6"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -257,8 +257,8 @@ func TestTransformReadResult_offset_uint16(t *testing.T) {
 	val := uint16(math.MaxUint16 - 1)
 	offset := "1"
 	expected := uint16(math.MaxUint16)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -283,8 +283,8 @@ func TestTransformReadResult_offset_uint16(t *testing.T) {
 func TestTransformReadResult_offset_uint16_overflow(t *testing.T) {
 	val := uint16(math.MaxUint16)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -303,8 +303,8 @@ func TestTransformReadResult_base_uint32(t *testing.T) {
 	val := uint32(2)
 	base := "20000"
 	expected := uint32(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -329,8 +329,8 @@ func TestTransformReadResult_base_uint32(t *testing.T) {
 func TestTransformReadResult_base_uint32_overflow(t *testing.T) {
 	val := uint32(4000000)
 	base := "1000"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -349,8 +349,8 @@ func TestTransformReadResult_scale_uint32(t *testing.T) {
 	val := uint32(math.MaxUint32 / 5)
 	scale := "5"
 	expected := uint32(math.MaxUint32)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -375,8 +375,8 @@ func TestTransformReadResult_scale_uint32(t *testing.T) {
 func TestTransformReadResult_scale_uint32_overflow(t *testing.T) {
 	val := uint32(math.MaxUint32 / 5)
 	scale := "6"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -395,8 +395,8 @@ func TestTransformReadResult_offset_uint32(t *testing.T) {
 	val := uint32(math.MaxUint32 - 1)
 	offset := "1"
 	expected := uint32(math.MaxUint32)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -421,8 +421,8 @@ func TestTransformReadResult_offset_uint32(t *testing.T) {
 func TestTransformReadResult_offset_uint32_overflow(t *testing.T) {
 	val := uint32(math.MaxUint32)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -441,8 +441,8 @@ func TestTransformReadResult_base_uint64(t *testing.T) {
 	val := uint64(2)
 	base := "20000"
 	expected := uint64(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -468,8 +468,8 @@ func TestTransformReadResult_scale_uint64(t *testing.T) {
 	val := uint64(20000)
 	scale := "20000"
 	expected := uint64(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -495,8 +495,8 @@ func TestTransformReadResult_offset_uint64(t *testing.T) {
 	val := uint64(math.MaxUint64) - uint64(1)
 	offset := "1"
 	expected := uint64(math.MaxUint64)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -522,8 +522,8 @@ func TestTransformReadResult_base_int8(t *testing.T) {
 	val := int8(2)
 	base := "10"
 	expected := int8(100)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -548,8 +548,8 @@ func TestTransformReadResult_base_int8(t *testing.T) {
 func TestTransformReadResult_base_int8_overflow(t *testing.T) {
 	val := int8(10)
 	base := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -568,8 +568,8 @@ func TestTransformReadResult_scale_int8(t *testing.T) {
 	val := int8(10)
 	scale := "10"
 	expected := int8(100)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -594,8 +594,8 @@ func TestTransformReadResult_scale_int8(t *testing.T) {
 func TestTransformReadResult_scale_int8_overflow(t *testing.T) {
 	val := uint8(10)
 	scale := "30"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -614,8 +614,8 @@ func TestTransformReadResult_offset_int8(t *testing.T) {
 	val := int8(math.MaxInt8 - 1)
 	offset := "1"
 	expected := int8(math.MaxInt8)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -640,8 +640,8 @@ func TestTransformReadResult_offset_int8(t *testing.T) {
 func TestTransformReadResult_offset_int8_overflow(t *testing.T) {
 	val := int8(math.MaxInt8)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -660,8 +660,8 @@ func TestTransformReadResult_base_int16(t *testing.T) {
 	val := int16(2)
 	base := "100"
 	expected := int16(10000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -686,8 +686,8 @@ func TestTransformReadResult_base_int16(t *testing.T) {
 func TestTransformReadResult_base_int16_overflow(t *testing.T) {
 	val := int16(100)
 	base := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -706,8 +706,8 @@ func TestTransformReadResult_scale_int16(t *testing.T) {
 	val := int16(10000)
 	scale := "3"
 	expected := int16(30000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -732,8 +732,8 @@ func TestTransformReadResult_scale_int16(t *testing.T) {
 func TestTransformReadResult_scale_int16_overflow(t *testing.T) {
 	val := int16(10000)
 	scale := "4"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -752,8 +752,8 @@ func TestTransformReadResult_offset_int16(t *testing.T) {
 	val := int16(math.MaxInt16 - 1)
 	offset := "1"
 	expected := int16(math.MaxInt16)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -778,8 +778,8 @@ func TestTransformReadResult_offset_int16(t *testing.T) {
 func TestTransformReadResult_offset_int16_overflow(t *testing.T) {
 	val := int16(math.MaxInt16)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -798,8 +798,8 @@ func TestTransformReadResult_base_int32(t *testing.T) {
 	val := int32(2)
 	base := "20000"
 	expected := int32(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -824,8 +824,8 @@ func TestTransformReadResult_base_int32(t *testing.T) {
 func TestTransformReadResult_base_int32_overflow(t *testing.T) {
 	val := int32(20000)
 	base := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -844,8 +844,8 @@ func TestTransformReadResult_scale_int32(t *testing.T) {
 	val := int32(200000000)
 	scale := "10"
 	expected := int32(2000000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -870,8 +870,8 @@ func TestTransformReadResult_scale_int32(t *testing.T) {
 func TestTransformReadResult_scale_int32_overflow(t *testing.T) {
 	val := int32(200000000)
 	scale := "15"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -890,8 +890,8 @@ func TestTransformReadResult_offset_int32(t *testing.T) {
 	val := int32(math.MaxInt32 - 1)
 	offset := "1"
 	expected := int32(math.MaxInt32)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -916,8 +916,8 @@ func TestTransformReadResult_offset_int32(t *testing.T) {
 func TestTransformReadResult_offset_int32_overflow(t *testing.T) {
 	val := int32(math.MaxInt32)
 	offset := "1"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -936,8 +936,8 @@ func TestTransformReadResult_base_int64(t *testing.T) {
 	val := int64(2)
 	base := "20000"
 	expected := int64(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -963,8 +963,8 @@ func TestTransformReadResult_scale_int64(t *testing.T) {
 	val := int64(20000)
 	scale := "20000"
 	expected := int64(400000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -990,8 +990,8 @@ func TestTransformReadResult_offset_int64(t *testing.T) {
 	val := int64(math.MaxInt64) - int64(1)
 	offset := "1"
 	expected := int64(math.MaxInt64)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewInt64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewInt64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -1017,8 +1017,8 @@ func TestTransformReadResult_base_float32(t *testing.T) {
 	val := float32(1.1)
 	base := "2"
 	expected := float32(2.143547)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -1043,8 +1043,8 @@ func TestTransformReadResult_base_float32(t *testing.T) {
 func TestTransformReadResult_base_float32_overflow(t *testing.T) {
 	val := float32(math.MaxFloat32)
 	base := "2"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -1063,8 +1063,8 @@ func TestTransformReadResult_scale_float32(t *testing.T) {
 	val := float32(12.1)
 	scale := "10"
 	expected := float32(121)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -1089,8 +1089,8 @@ func TestTransformReadResult_scale_float32(t *testing.T) {
 func TestTransformReadResult_scale_float32_overflow(t *testing.T) {
 	val := float32(math.MaxFloat32 / 2)
 	scale := "3"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -1109,8 +1109,8 @@ func TestTransformReadResult_offset_float32(t *testing.T) {
 	val := float32(1.1)
 	offset := "1"
 	expected := float32(2.1)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -1135,8 +1135,8 @@ func TestTransformReadResult_offset_float32(t *testing.T) {
 func TestTransformReadResult_offset_float32_overflow(t *testing.T) {
 	val := float32(math.MaxFloat32)
 	offset := fmt.Sprintf("%v", math.MaxFloat32)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -1155,8 +1155,8 @@ func TestTransformReadResult_base_float64(t *testing.T) {
 	val := 1.1
 	base := "2"
 	expected := 2.1435469250725863
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Base: base,
 	}
@@ -1182,8 +1182,8 @@ func TestTransformReadResult_scale_float64(t *testing.T) {
 	val := float32(200000000)
 	scale := "10"
 	expected := float32(2000000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Scale: scale,
 	}
@@ -1209,8 +1209,8 @@ func TestTransformReadResult_offset_float64(t *testing.T) {
 	val := float64(1.1)
 	offset := "1"
 	expected := float64(2.1)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewFloat64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewFloat64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Offset: offset,
 	}
@@ -1236,8 +1236,8 @@ func TestTransformReadResult_mask_uint8(t *testing.T) {
 	val := uint8(math.MaxUint8)
 	mask := "15"
 	expected := uint8(15)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Mask: mask,
 	}
@@ -1263,8 +1263,8 @@ func TestTransformReadResult_mask_uint16(t *testing.T) {
 	val := uint16(math.MaxUint16)
 	mask := "256"
 	expected := uint16(256)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Mask: mask,
 	}
@@ -1290,8 +1290,8 @@ func TestTransformReadResult_mask_uint32(t *testing.T) {
 	val := uint32(math.MaxUint32)
 	mask := "256"
 	expected := uint32(256)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Mask: mask,
 	}
@@ -1317,8 +1317,8 @@ func TestTransformReadResult_mask_uint64(t *testing.T) {
 	val := uint64(math.MaxUint64)
 	mask := "256"
 	expected := uint64(256)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Mask: mask,
 	}
@@ -1343,8 +1343,8 @@ func TestTransformReadResult_mask_uint64(t *testing.T) {
 func TestTransformReadResult_mask_should_be_unsigned(t *testing.T) {
 	val := uint64(math.MaxUint64)
 	mask := "-256"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Mask: mask,
 	}
@@ -1360,8 +1360,8 @@ func TestTransformReadResult_shift_uint8(t *testing.T) {
 	val := uint8(6)
 	shift := "5"
 	expected := uint8(192)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1387,8 +1387,8 @@ func TestTransformReadResult_signedShift_uint8(t *testing.T) {
 	val := uint8(96)
 	shift := "-4"
 	expected := uint8(6)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint8Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint8Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1414,8 +1414,8 @@ func TestTransformReadResult_shift_uint16(t *testing.T) {
 	val := uint16(128)
 	shift := "8"
 	expected := uint16(32768)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1441,8 +1441,8 @@ func TestTransformReadResult_signedShift_uint16(t *testing.T) {
 	val := uint16(32768)
 	shift := "-8"
 	expected := uint16(128)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint16Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint16Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1468,8 +1468,8 @@ func TestTransformReadResult_shift_uint32(t *testing.T) {
 	val := uint32(120000)
 	shift := "3"
 	expected := uint32(960000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1495,8 +1495,8 @@ func TestTransformReadResult_signedShift_uint32(t *testing.T) {
 	val := uint32(120000)
 	shift := "-2"
 	expected := uint32(30000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint32Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint32Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1522,8 +1522,8 @@ func TestTransformReadResult_shift_uint64(t *testing.T) {
 	val := uint64(1000000000)
 	shift := "4"
 	expected := uint64(16000000000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1549,8 +1549,8 @@ func TestTransformReadResult_signedShift_uint64(t *testing.T) {
 	val := uint64(1000000000)
 	shift := "-4"
 	expected := uint64(62500000)
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}
@@ -1575,8 +1575,8 @@ func TestTransformReadResult_signedShift_uint64(t *testing.T) {
 func TestTransformReadResult_shift_should_be_valid(t *testing.T) {
 	val := uint64(1000000000)
 	shift := "-+4"
-	ro := contract.ResourceOperation{Object: "test-object"}
-	cv, err := dsModels.NewUint64Value(ro.Object, 0, val)
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	cv, err := dsModels.NewUint64Value(ro.DeviceResource, 0, val)
 	pv := contract.PropertyValue{
 		Shift: shift,
 	}

--- a/managedprofiles.go
+++ b/managedprofiles.go
@@ -121,14 +121,14 @@ func (*Service) UpdateDeviceProfile(profile contract.DeviceProfile) error {
 }
 
 // ResourceOperation retrieves the first matched ResourceOpereation instance from cache according to
-// the Device name, Device Resource (object) name, and the method (get or set).
-func (*Service) ResourceOperation(deviceName string, object string, method string) (contract.ResourceOperation, bool) {
+// the Device name, Device Resource name, and the method (get or set).
+func (*Service) ResourceOperation(deviceName string, deviceResource string, method string) (contract.ResourceOperation, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		common.LoggingClient.Error(fmt.Sprintf("retrieving ResourceOperation - Device %s not found", deviceName))
 	}
 
-	ro, err := cache.Profiles().ResourceOperation(device.Profile.Name, object, method)
+	ro, err := cache.Profiles().ResourceOperation(device.Profile.Name, deviceResource, method)
 	if err != nil {
 		common.LoggingClient.Error(err.Error())
 		return ro, false
@@ -137,14 +137,14 @@ func (*Service) ResourceOperation(deviceName string, object string, method strin
 }
 
 // DeviceResource retrieves the specific DeviceResource instance from cache according to
-// the Device name and Device Resource (object) name
-func (*Service) DeviceResource(deviceName string, object string, method string) (contract.DeviceResource, bool) {
+// the Device name and Device Resource name
+func (*Service) DeviceResource(deviceName string, deviceResource string, method string) (contract.DeviceResource, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		common.LoggingClient.Error(fmt.Sprintf("retrieving DeviceResource - Device %s not found", deviceName))
 	}
 
-	dr, ok := cache.Profiles().DeviceResource(device.Profile.Name, object)
+	dr, ok := cache.Profiles().DeviceResource(device.Profile.Name, deviceResource)
 	if !ok {
 		return dr, false
 	}

--- a/service.go
+++ b/service.go
@@ -86,7 +86,7 @@ func (s *Service) Start(errChan chan error) (err error) {
 		return fmt.Errorf("Couldn't register to metadata service")
 	}
 
-	// initialize devices, objects & profiles
+	// initialize devices, deviceResources & profiles
 	cache.InitCache()
 	err = provision.LoadProfiles(common.CurrentConfig.Device.ProfilesDir)
 	if err != nil {
@@ -189,7 +189,7 @@ func createNewDeviceService() (contract.DeviceService, error) {
 		return contract.DeviceService{}, err
 	}
 
-	// NOTE - this differs from Addressable and Device objects,
+	// NOTE - this differs from Addressable and Device Resources,
 	// neither of which require the '.Service'prefix
 	ds.Id = id
 	common.LoggingClient.Debug("New deviceservice Id: " + ds.Id)


### PR DESCRIPTION
Rename ResourceOperation.Object -> ResourceOperation.DeviceResource
Rename ResourceOperation.Resource -> ResourceOperation.DeviceCommand
upgrade go-mod-core-contracts from v0.1.30 to v0.1.31

Fix https://github.com/edgexfoundry/device-sdk-go/issues/245