### PR TITLE
Add option to overwrite registry with local config

### DIFF
--- a/internal/common/globalvars.go
+++ b/internal/common/globalvars.go
@@ -21,6 +21,7 @@ var (
 	CurrentConfig         *Config
 	CurrentDeviceService  contract.DeviceService
 	UseRegistry           bool
+	OverwriteConfig       bool
 	ServiceLocked         bool
 	Driver                dsModels.ProtocolDriver
 	EventClient           coredata.EventClient

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -144,7 +144,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 		}
 	}
 
-	fmt.Println(registryMsg)
+	fmt.Fprintln(os.Stdout, registryMsg)
 	return configuration, nil
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -86,7 +86,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 			return nil, fmt.Errorf("could not verify that Registry already has configuration: %v", err.Error())
 		}
 
-		if hasConfiguration {
+		if hasConfiguration && !common.OverwriteConfig {
 			// Get the configuration values from the Registry
 			rawConfig, err := RegistryClient.GetConfiguration(configuration)
 			if err != nil {
@@ -107,7 +107,7 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 				return nil, err
 			}
 
-			err = RegistryClient.PutConfigurationToml(e.OverrideFromEnvironment(configTree), true)
+			err = RegistryClient.PutConfigurationToml(e.OverrideFromEnvironment(configTree), common.OverwriteConfig)
 			if err != nil {
 				return nil, fmt.Errorf("could not push configuration to Registry: %v", err.Error())
 			}

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -19,9 +19,10 @@ import (
 )
 
 type Options struct {
-	UseRegistry string `short:"r" long:"registry" description:"Indicates the service should use the registry and provide the registry url." optional:"true" optional-value:"LOAD_FROM_FILE"`
-	ConfProfile string `short:"p" long:"profile" description:"Specify a profile other than default."`
-	ConfDir string `short:"c" long:"confdir" description:"Specify an alternate configuration directory."`
+	UseRegistry   string `short:"r" long:"registry" description:"Indicates the service should use the registry and provide the registry url." optional:"true" optional-value:"LOAD_FROM_FILE"`
+	ConfProfile   string `short:"p" long:"profile" description:"Specify a profile other than default."`
+	ConfDir       string `short:"c" long:"confdir" description:"Specify an alternate configuration directory."`
+	OverwriteConf bool   `short:"o" long:"overwrite" description:"Overwrite configuration in the registry."`
 }
 
 var opts Options
@@ -34,6 +35,7 @@ func Bootstrap(serviceName string, serviceVersion string, driver dsModels.Protoc
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 	}
 
+	device.SetOverwriteConfig(opts.OverwriteConf)
 	if err := startService(serviceName, serviceVersion, driver); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/service.go
+++ b/service.go
@@ -240,6 +240,13 @@ func (s *Service) Stop(force bool) error {
 	return nil
 }
 
+// SetOverwriteConfig sets whether or not configuration will be unconditionally loaded
+// from file to the registry.
+// NOTE this will be removed in the next release and made a parameter to NewService
+func SetOverwriteConfig(oc bool) {
+	common.OverwriteConfig = oc
+}
+
 // NewService creates a new Device Service instance with the given
 // version number, config profile, config directory, whether to use registry, and Driver, which cannot be nil.
 // Note - this function is a singleton, if called more than once,


### PR DESCRIPTION
Add -o and --overwrite flag to indicate whether the service should reload the configuration from local file to override the one on registry
Fix #342 
Alternative implementation of PR #348 