### PR TITLE
Move protocol driver init before provision

### DIFF
--- a/service.go
+++ b/service.go
@@ -99,6 +99,16 @@ func (s *Service) Start(errChan chan error) (err error) {
 	}()
 	common.LoggingClient.Info("Listening on port: " + strconv.Itoa(common.CurrentConfig.Service.Port))
 
+	// initialize driver
+	err = common.Driver.Initialize(common.LoggingClient, s.asyncCh)
+	if err != nil {
+		return fmt.Errorf("Driver.Initialize failure: %v", err)
+	}
+	if common.CurrentConfig.Service.EnableAsyncReadings {
+		s.asyncCh = make(chan *dsModels.AsyncValues, common.CurrentConfig.Service.AsyncBufferSize)
+		go processAsyncResults()
+	}
+
 	err = provision.LoadProfiles(common.CurrentConfig.Device.ProfilesDir)
 	if err != nil {
 		return fmt.Errorf("Failed to create the pre-defined Device Profiles")
@@ -111,21 +121,10 @@ func (s *Service) Start(errChan chan error) (err error) {
 
 	s.cw = newWatchers()
 
-	// initialize driver
-	if common.CurrentConfig.Service.EnableAsyncReadings {
-		s.asyncCh = make(chan *dsModels.AsyncValues, common.CurrentConfig.Service.AsyncBufferSize)
-		go processAsyncResults()
-	}
-	err = common.Driver.Initialize(common.LoggingClient, s.asyncCh)
-	if err != nil {
-		return fmt.Errorf("Driver.Initialize failure: %v", err)
-	}
-
 	autoevent.GetManager().StartAutoEvents()
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(s.svcInfo.Timeout), "Request timed out")
 
 	common.LoggingClient.Info("Service started in: " + time.Since(s.startTime).String())
-
 	common.LoggingClient.Debug("*Service Start() exit")
 
 	return err


### PR DESCRIPTION
Provision will cause the callback sent by Core Metadata, and sometimes
the protocol driver hasn't been ready.  Thus, the protocol driver
initialization should be run before Provision.

Fix https://github.com/edgexfoundry/device-sdk-go/issues/376

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>