### PR TITLE
bug(DeviceCache): Devices not added to the device cache on first clean run

### DIFF
--- a/internal/provision/devices.go
+++ b/internal/provision/devices.go
@@ -69,5 +69,6 @@ func createDevice(dc common.DeviceConfig) error {
 	}
 	device.Id = id
 
+	cache.Devices().Add(*device)
 	return nil
 }


### PR DESCRIPTION
Added back call to cache.Devices().Add() in createDevice()

closes #376