### PR TITLE
Move Metadata GeneralClient to global variable

### DIFF
--- a/internal/clients/init.go
+++ b/internal/clients/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/internal/endpoint"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
@@ -212,6 +213,10 @@ func initializeClients() {
 	params.Path = clients.ApiDeviceProfileRoute
 	params.Url = metaAddr + params.Path
 	common.DeviceProfileClient = metadata.NewDeviceProfileClient(params, endpoint)
+
+	params.Path = clients.ApiConfigRoute
+	params.Url = metaAddr
+	common.MetadataGeneralClient = general.NewGeneralClient(params, endpoint)
 
 	// initialize Core Data clients
 	params.ServiceKey = common.CurrentConfig.Clients[common.ClientData].Name

--- a/internal/common/globalvars.go
+++ b/internal/common/globalvars.go
@@ -9,6 +9,7 @@ package common
 import (
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -29,4 +30,5 @@ var (
 	DeviceProfileClient   metadata.DeviceProfileClient
 	LoggingClient         logger.LoggingClient
 	ValueDescriptorClient coredata.ValueDescriptorClient
+	MetadataGeneralClient general.GeneralClient
 )

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -14,15 +14,9 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
-	"github.com/edgexfoundry/device-sdk-go/internal/config"
-	"github.com/edgexfoundry/device-sdk-go/internal/endpoint"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v2"
@@ -160,21 +154,10 @@ func CreateDescriptorsFromProfile(profile *contract.DeviceProfile) {
 // Value Descriptor management logic to Core Metadata in Geneva
 func isValueDescriptorManagedByMetadata() bool {
 	common.LoggingClient.Debug("Getting EnableValueDescriptorManagement configuration value from Core Metadata")
-	metadataURL := common.CurrentConfig.Clients[common.ClientMetadata].Url()
-	params := types.EndpointParams{
-		ServiceKey:  common.ClientMetadata,
-		Path:        clients.ApiConfigRoute,
-		UseRegistry: common.UseRegistry,
-		Url:         metadataURL,
-		Interval:    clients.ClientMonitorDefault,
-	}
-	var waitGroup sync.WaitGroup
-	waitGroup.Add(1)
-	gc := general.NewGeneralClient(params, endpoint.Endpoint{RegistryClient: config.RegistryClient, WG: &waitGroup})
 	correlation := uuid.New().String()
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, correlation)
 
-	configString, err := gc.FetchConfiguration(ctx)
+	configString, err := common.MetadataGeneralClient.FetchConfiguration(ctx)
 	if err != nil {
 		common.LoggingClient.Error(fmt.Sprintf("Error when getting configuration from Core Metadata: %v ", err))
 		return false


### PR DESCRIPTION
The Core Metadata GeneralClient should be the global variable like
other clients, so it could be reused without creating it each time.
If using Registry, each client creation will cause a new go routine to
run endpoint.Monitor(), so it has to be avoided.

Fix https://github.com/edgexfoundry/device-sdk-go/issues/388

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>