### PR TITLE
Update the --registry command line options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
 	github.com/gorilla/mux v1.6.2
+	github.com/jessevdk/go-flags v1.4.0
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -21,6 +21,7 @@ const (
 	HttpScheme = "http://"
 	HttpProto  = "HTTP"
 
+	RegistryDefault    = "LOAD_FROM_FILE"
 	ConfigDirectory    = "./res"
 	ConfigFileName     = "configuration.toml"
 	ConfigRegistryStem = "edgex/devices/1.0/"

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -34,7 +34,7 @@ var (
 // LoadConfig loads the local configuration file based upon the
 // specified parameters and returns a pointer to the global Config
 // struct which holds all of the local configuration settings for
-// the DS. The string useRegisty indicates whether the registry
+// the DS. The string useRegistry indicates whether the registry
 // should be used to read config settings, and it might contain the registry path.
 // This also controls whether the service registers itself the registry.
 // The profile and confDir are used to locate the local TOML config file.
@@ -45,12 +45,20 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 	var registryMsg string
 
 	e := NewEnvironment()
-	if useRegistry != "" {
+	if useRegistry == "" {
+		registryMsg = "Load configuration from local file and bypassing registration in Registry..."
+		configuration, _, err = loadConfigFromFile(profile, confDir)
+	} else {
+		fmt.Fprintf(os.Stdout, "Source of registry url: %s\n", useRegistry)
 		configuration = &common.Config{}
-		useRegistry = e.OverrideUseRegistryFromEnvironment(useRegistry)
-		err = parseRegistryPath(useRegistry, configuration)
-		if err != nil {
-			return
+		if useRegistry == common.RegistryDefault {
+			configuration, _, err = loadConfigFromFile(profile, confDir)
+		} else {
+			useRegistry = e.OverrideUseRegistryFromEnvironment(useRegistry)
+			err = parseRegistryPath(useRegistry, configuration)
+			if err != nil {
+				return
+			}
 		}
 
 		registryMsg = "Register in registry..."
@@ -94,7 +102,6 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 		} else {
 			// Self bootstrap the Registry with the device service's configuration
 			fmt.Fprintln(os.Stdout, "Pushing configuration into Registry...")
-
 			_, configTree, err := loadConfigFromFile(profile, confDir)
 			if err != nil {
 				return nil, err
@@ -134,12 +141,6 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 		err = RegistryClient.Register()
 		if err != nil {
 			return nil, fmt.Errorf("could not register service with Registry: %v", err.Error())
-		}
-	} else {
-		registryMsg = "Bypassing registration in registry..."
-		configuration, _, err = loadConfigFromFile(profile, confDir)
-		if err != nil {
-			return nil, err
 		}
 	}
 
@@ -187,7 +188,7 @@ func loadConfigFromFile(profile string, confDir string) (config *common.Config, 
 
 	// As the toml package can panic if TOML is invalid,
 	// or elements are found that don't match members of
-	// the given struct, use a defered func to recover
+	// the given struct, use a deferred func to recover
 	// from the panic and output a useful error.
 	defer func() {
 		if r := recover(); r != nil {

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -8,7 +8,6 @@
 package startup
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -16,24 +15,24 @@ import (
 
 	"github.com/edgexfoundry/device-sdk-go"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	flags "github.com/jessevdk/go-flags"
 )
 
-var (
-	confProfile string
-	confDir     string
-	useRegistry string
-)
+type Options struct {
+	UseRegistry string `short:"r" long:"registry" description:"Indicates the service should use the registry and provide the registry url." optional:"true" optional-value:"LOAD_FROM_FILE"`
+	ConfProfile string `short:"p" long:"profile" description:"Specify a profile other than default."`
+	ConfDir string `short:"c" long:"confdir" description:"Specify an alternate configuration directory."`
+}
+
+var opts Options
 
 // Bootstrap starts the Device Service in a default way
 func Bootstrap(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) {
 	//flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError) // clean up existing flag defined by other code
-	flag.StringVar(&useRegistry, "registry", "", "Indicates the service should use the registry and provide the registry url.")
-	flag.StringVar(&useRegistry, "r", "", "Indicates the service should use registry and provide the registry path.")
-	flag.StringVar(&confProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&confProfile, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&confDir, "confdir", "", "Specify an alternate configuration directory.")
-	flag.StringVar(&confDir, "c", "", "Specify an alternate configuration directory.")
-	flag.Parse()
+	_, err := flags.Parse(&opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
 
 	if err := startService(serviceName, serviceVersion, driver); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -42,7 +41,7 @@ func Bootstrap(serviceName string, serviceVersion string, driver dsModels.Protoc
 }
 
 func startService(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) error {
-	s, err := device.NewService(serviceName, serviceVersion, confProfile, confDir, useRegistry, driver)
+	s, err := device.NewService(serviceName, serviceVersion, opts.ConfProfile, opts.ConfDir, opts.UseRegistry, driver)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use [go-flags](https://github.com/jessevdk/go-flags) package to parse command line argument and implement following behaviors:
--registry=\<url\> - Use the registry at that url
--registry -  Load the url from configuration.toml
\<no flag\> -  Don't use the registry

`go-flags` allow us to set an `optional-value` when the option occurs without an argument. Currently the value is hard-coded as `LOAD_FROM_FILE` for readability.

Fix #253 

