### PR TITLE
Update the --registry command line options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect
 	github.com/gorilla/mux v1.6.2
+	github.com/jessevdk/go-flags v1.4.0
 	github.com/pelletier/go-toml v1.2.0
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -21,6 +21,7 @@ const (
 	HttpScheme = "http://"
 	HttpProto  = "HTTP"
 
+	RegistryDefault    = "LOAD_FROM_FILE"
 	ConfigDirectory    = "./res"
 	ConfigFileName     = "configuration.toml"
 	ConfigRegistryStem = "edgex/devices/1.0/"

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -8,7 +8,6 @@
 package startup
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -16,24 +15,24 @@ import (
 
 	"github.com/edgexfoundry/device-sdk-go"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	flags "github.com/jessevdk/go-flags"
 )
 
-var (
-	confProfile string
-	confDir     string
-	useRegistry string
-)
+type Options struct {
+	UseRegistry string `short:"r" long:"registry" description:"Indicates the service should use the registry and provide the registry url." optional:"true" optional-value:"LOAD_FROM_FILE"`
+	ConfProfile string `short:"p" long:"profile" description:"Specify a profile other than default."`
+	ConfDir string `short:"c" long:"confdir" description:"Specify an alternate configuration directory."`
+}
+
+var opts Options
 
 // Bootstrap starts the Device Service in a default way
 func Bootstrap(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) {
 	//flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError) // clean up existing flag defined by other code
-	flag.StringVar(&useRegistry, "registry", "", "Indicates the service should use the registry and provide the registry url.")
-	flag.StringVar(&useRegistry, "r", "", "Indicates the service should use registry and provide the registry path.")
-	flag.StringVar(&confProfile, "profile", "", "Specify a profile other than default.")
-	flag.StringVar(&confProfile, "p", "", "Specify a profile other than default.")
-	flag.StringVar(&confDir, "confdir", "", "Specify an alternate configuration directory.")
-	flag.StringVar(&confDir, "c", "", "Specify an alternate configuration directory.")
-	flag.Parse()
+	_, err := flags.Parse(&opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
 
 	if err := startService(serviceName, serviceVersion, driver); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -42,7 +41,7 @@ func Bootstrap(serviceName string, serviceVersion string, driver dsModels.Protoc
 }
 
 func startService(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) error {
-	s, err := device.NewService(serviceName, serviceVersion, confProfile, confDir, useRegistry, driver)
+	s, err := device.NewService(serviceName, serviceVersion, opts.ConfProfile, opts.ConfDir, opts.UseRegistry, driver)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use [go-flags](https://github.com/jessevdk/go-flags) package to parse command line argument and implement following behaviors:
--registry=\<url\> - Use the registry at that url
--registry - Load the url from configuration.toml
\<no flag\> - Don't use the registry

`go-flags` allow us to set an `optional-value` when the option occurs without an argument. Currently the value is hard-coded as `LOAD_FROM_FILE` for readability.

Fix #253 