### PR TITLE
Filter out query parameters with prefix "ds-" to ProtocolDriver

### DIFF
--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -48,4 +48,5 @@ const (
 
 	CorrelationHeader = clients.CorrelationHeader
 	URLRawQuery       = "urlRawQuery"
+	SDKReservedPrefix = "ds-"
 )

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -11,7 +11,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -260,4 +262,19 @@ func GetUniqueOrigin() int64 {
 	}
 	previousOrigin = now
 	return now
+}
+
+func FilterQueryParams(queryParams string) url.Values {
+	m, err := url.ParseQuery(queryParams)
+	if err != nil {
+		LoggingClient.Error("Error parsing query parameters: %s\n", err)
+	}
+	// Filter out parameters with ds- prefix
+	for k, _ := range m {
+		if strings.HasPrefix(k, SDKReservedPrefix) {
+			delete(m, k)
+		}
+	}
+
+	return m
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -269,7 +269,7 @@ func FilterQueryParams(queryParams string) url.Values {
 	if err != nil {
 		LoggingClient.Error("Error parsing query parameters: %s\n", err)
 	}
-	// Filter out parameters with ds- prefix
+	// Filter out parameters with predefined prefix
 	for k, _ := range m {
 		if strings.HasPrefix(k, SDKReservedPrefix) {
 			delete(m, k)

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -85,3 +85,20 @@ func TestGetUniqueOrigin(t *testing.T) {
 		t.Errorf("origin1: %d should <= origin2: %d", origin1, origin2)
 	}
 }
+
+func TestFilterQueryParams(t *testing.T) {
+	query := "test1=test1&ds-name=name&test2=tset2&ds-id=id"
+	m := FilterQueryParams(query)
+
+	if _, ok := m["ds-name"]; ok {
+		t.Errorf("Parameters with -ds prefix should be filtered out.")
+	}
+
+	if _, ok := m["ds-id"]; ok {
+		t.Errorf("Parameters with -ds prefix should be filtered out.")
+	}
+
+	if _, ok := m["test1"]; !ok {
+		t.Errorf("Error while parsing parameters.")
+	}
+}

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -94,7 +94,8 @@ func execReadDeviceResource(device *contract.Device, dr *contract.DeviceResource
 		if len(req.Attributes) <= 0 {
 			req.Attributes = make(map[string]string)
 		}
-		req.Attributes[common.URLRawQuery] = queryParams
+		m := common.FilterQueryParams(queryParams)
+		req.Attributes[common.URLRawQuery] = m.Encode()
 	}
 	req.Type = dsModels.ParseValueType(dr.Properties.Value.Type)
 	reqs = append(reqs, req)
@@ -223,7 +224,8 @@ func execReadCmd(device *contract.Device, cmd string, queryParams string) (*dsMo
 			if len(reqs[i].Attributes) <= 0 {
 				reqs[i].Attributes = make(map[string]string)
 			}
-			reqs[i].Attributes[common.URLRawQuery] = queryParams
+			m := common.FilterQueryParams(queryParams)
+			reqs[i].Attributes[common.URLRawQuery] = m.Encode()
 		}
 		reqs[i].Type = dsModels.ParseValueType(dr.Properties.Value.Type)
 	}


### PR DESCRIPTION
Use `regexp` package to filter out parameters with `ds-` prefix
We could use `Regexp.FindAllString` to handle those parameters in the future .

Fix #354 