### PR TITLE
Override useRegistry from environment before related comparison

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -50,3 +50,6 @@ https://github.com/edgexfoundry/edgex-go/blob/master/LICENSE
 
 pkg/errors (BSD-2) https://github.com/pkg/errors
 https://github.com/pkg/errors/blob/master/LICENSE
+
+jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
+https://github.com/jessevdk/go-flags/blob/master/LICENSE

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -45,12 +45,12 @@ func LoadConfig(useRegistry string, profile string, confDir string) (configurati
 	var registryMsg string
 
 	e := NewEnvironment()
+	useRegistry = e.OverrideUseRegistryFromEnvironment(useRegistry)
 	if useRegistry == "" {
 		registryMsg = "Load configuration from local file and bypassing registration in Registry..."
 		configuration, _, err = loadConfigFromFile(profile, confDir)
 	} else {
 		configuration = &common.Config{}
-		useRegistry = e.OverrideUseRegistryFromEnvironment(useRegistry)
 		fmt.Fprintf(os.Stdout, "Source of registry url: %s\n", useRegistry)
 		if useRegistry == common.RegistryDefault {
 			configuration, _, err = loadConfigFromFile(profile, confDir)


### PR DESCRIPTION
move call to `OverrideUseRegistryFromEnvironment` before all the comparisons of `useRegistry`  ,
also add `go-flags` package into `Attribution.txt`

Fix #401 