### PR TITLE
Add Binary Support for OnChange Autoevents

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -53,3 +53,6 @@ https://github.com/pkg/errors/blob/master/LICENSE
 
 jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
 https://github.com/jessevdk/go-flags/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go
 
 require (
+	github.com/OneOfOne/xxhash v1.2.6
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -104,6 +104,9 @@ func compareReadings(e *executor, readings []contract.Reading, hasBinary bool) b
 				e.lastReadings[r.Name] = r.Value
 			}
 			identical = false
+		default:
+			common.LoggingClient.Error("Error: unsupported reading type (%T) in autoevent - %v\n", e.lastReadings[r.Name], e.autoEvent)
+			identical = false
 		}
 	}
 	return identical

--- a/internal/autoevent/executor_test.go
+++ b/internal/autoevent/executor_test.go
@@ -20,21 +20,57 @@ func TestCompareReadings(t *testing.T) {
 	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is a image")}
 
 	autoEvent := contract.AutoEvent{Frequency: "500ms"}
-	e, _ := NewExecutor("meter", autoEvent)
+	e, err := NewExecutor("hasBinaryTrue", autoEvent)
+	if err != nil {
+		t.Errorf("Autoevent executor creation failed: %v", err)
+	}
 	resultFalse := compareReadings(e.(*executor), readings, true)
 	if resultFalse {
-		t.Error("compare reading with cache failed, the result should be false in the first place")
+		t.Error("compare readings with cache failed, the result should be false in the first place")
 	}
 
 	readings[1] = contract.Reading{Name: "Humidity", Value: "51"}
 	resultFalse = compareReadings(e.(*executor), readings, true)
 	if resultFalse {
-		t.Error("compare reading with cache failed, the result should be false")
+		t.Error("compare readings with cache failed, the result should be false")
 	}
 
 	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is not a image")}
 	resultFalse = compareReadings(e.(*executor), readings, true)
 	if resultFalse {
-		t.Error("compare reading with cache failed, the result should be false")
+		t.Error("compare readings with cache failed, the result should be false")
+	}
+
+	resultTrue := compareReadings(e.(*executor), readings, true)
+	if !resultTrue {
+		t.Error("compare readings with cache failed, the result should be true with unchanged readings")
+	}
+
+	e, err = NewExecutor("hasBinaryFalse", autoEvent)
+	if err != nil {
+		t.Errorf("Autoevent executor creation failed: %v", err)
+	}
+	// This scenario should not happen in real case
+	resultFalse = compareReadings(e.(*executor), readings, false)
+	if resultFalse {
+		t.Error("compare readings with cache failed, the result should be false in the first place")
+	}
+
+	readings[0] = contract.Reading{Name: "Temperature", Value: "20"}
+	resultFalse = compareReadings(e.(*executor), readings, false)
+	if resultFalse {
+		t.Error("compare readings with cache failed, the result should be false")
+	}
+
+	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is a image")}
+	resultTrue = compareReadings(e.(*executor), readings, false)
+	if !resultTrue {
+		t.Error("compare readings with cache failed, the result should always be true in such scenario")
+	}
+
+	resultTrue = compareReadings(e.(*executor), readings, false)
+	if !resultTrue {
+		t.Error("compare readings with cache failed, the result should be true with unchanged readings")
 	}
 }
+

--- a/internal/autoevent/executor_test.go
+++ b/internal/autoevent/executor_test.go
@@ -13,21 +13,27 @@ import (
 )
 
 func TestCompareReadings(t *testing.T) {
-	readings := make([]contract.Reading, 3)
+	readings := make([]contract.Reading, 4)
 	readings[0] = contract.Reading{Name: "Temperature", Value: "10"}
 	readings[1] = contract.Reading{Name: "Humidity", Value: "50"}
 	readings[2] = contract.Reading{Name: "Pressure", Value: "3"}
+	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is a image")}
 
 	autoEvent := contract.AutoEvent{Frequency: "500ms"}
 	e, _ := NewExecutor("meter", autoEvent)
-	cacheReadings(e.(*executor), readings)
-	resultTrue := compareReadings(e.(*executor), readings)
-	if !resultTrue {
-		t.Error("compare reading with cache failed, the result should be true")
+	resultFalse := compareReadings(e.(*executor), readings, true)
+	if resultFalse {
+		t.Error("compare reading with cache failed, the result should be false in the first place")
 	}
 
 	readings[1] = contract.Reading{Name: "Humidity", Value: "51"}
-	resultFalse := compareReadings(e.(*executor), readings)
+	resultFalse = compareReadings(e.(*executor), readings, true)
+	if resultFalse {
+		t.Error("compare reading with cache failed, the result should be false")
+	}
+
+	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is not a image")}
+	resultFalse = compareReadings(e.(*executor), readings, true)
 	if resultFalse {
 		t.Error("compare reading with cache failed, the result should be false")
 	}


### PR DESCRIPTION
Calculate and cache checksum using [xxHash](http://cyan4973.github.io/xxHash/) on binary readings to determine whether it changed since last autoevents.

Fix #261 