### PR TITLE
Add configurable option to update lastConnected attribute

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -49,6 +49,7 @@ FailWaitTime = 10
   RemoveCmd = ""
   RemoveCmdArgs = ""
   ProfilesDir = "./res"
+  UpdateLastConnected = false
 
 [Logging]
 EnableRemote = false

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -87,6 +87,9 @@ type DeviceInfo struct {
 	// ProfilesDir specifies a directory which contains deviceprofile
 	// files which should be imported on startup.
 	ProfilesDir string
+	// UpdateLastConnected specifies whether to update device's LastConnected
+	// timestamp in metadata.
+	UpdateLastConnected bool
 }
 
 // LoggingInfo is a struct which contains logging specific configuration settings.

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -82,6 +82,14 @@ func SendEvent(event *dsModels.Event) {
 	if errPost != nil {
 		LoggingClient.Error("SendEvent Failed to push event", "device", event.Device, "response", responseBody, "error", errPost)
 	} else {
+		if CurrentConfig.Device.UpdateLastConnected {
+			t := time.Now().UnixNano() / int64(time.Millisecond)
+			err = DeviceClient.UpdateLastConnectedByName(event.Device, t, ctx)
+			if err != nil {
+				LoggingClient.Error(fmt.Sprintf("Error updating device's lastConnected attribute: %v", err))
+			}
+		}
+
 		LoggingClient.Info("SendEvent: Pushed event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation)
 		LoggingClient.Trace("SendEvent: Pushed this event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation, "event", event)
 	}


### PR DESCRIPTION
Add a new setting `UpdateLastConnected` in device service's configuration, default is `false`.
If enabled, device's `LastConnected` attribute would be updated every time an event being sent to coredata.

Fix #371 