### PR TITLE
bug(MediaType): Update to latest go-mod-core-contracts for PropertyValue.MediaType fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-sdk-go
 
 require (
 	github.com/OneOfOne/xxhash v1.2.6
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.36
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect


### PR DESCRIPTION
go-mod-core-contracts has fix for YAML marshaling of PropertyValue.MediaType needed for using MediaType in YAML device profiles.

Latest go-mod-core-contracts also has change to Endpointer interface requiring changes to endpoint.go

Closes #424 