### PR TITLE
bug(MediaType): Fuji - Update to latest go-mod-contracts for PropertyValue.MediaType fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-sdk-go
 
 require (
 	github.com/OneOfOne/xxhash v1.2.6
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.36
 	github.com/edgexfoundry/go-mod-registry v0.1.0
 	github.com/google/uuid v1.1.0
 	github.com/gorilla/context v0.0.0-20181012153548-51ce91d2eadd // indirect


### PR DESCRIPTION
Fix on Fuji branch

go-mod-contracts has fix for YAML marshaling of PropertyValue.MediaType needed for using MediaType in YAML device profiles.

Latest go-mod-contracts requires update to endpoint.go
closes #427 