### PR TITLE
Add update-lastConnected logic to PUT command

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -82,14 +82,6 @@ func SendEvent(event *dsModels.Event) {
 	if errPost != nil {
 		LoggingClient.Error("SendEvent Failed to push event", "device", event.Device, "response", responseBody, "error", errPost)
 	} else {
-		if CurrentConfig.Device.UpdateLastConnected {
-			t := time.Now().UnixNano() / int64(time.Millisecond)
-			err = DeviceClient.UpdateLastConnectedByName(event.Device, t, ctx)
-			if err != nil {
-				LoggingClient.Error(fmt.Sprintf("Error updating device's lastConnected attribute: %v", err))
-			}
-		}
-
 		LoggingClient.Info("SendEvent: Pushed event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation)
 		LoggingClient.Trace("SendEvent: Pushed this event to core data", clients.ContentType, clients.FromContext(clients.ContentType, ctx), clients.CorrelationHeader, correlation, "event", event)
 	}
@@ -285,4 +277,17 @@ func FilterQueryParams(queryParams string) url.Values {
 	}
 
 	return m
+}
+
+func UpdateLastConnected(name string) {
+	if !CurrentConfig.Device.UpdateLastConnected {
+		LoggingClient.Debug("Update of last connected times is disabled for: " + name)
+		return
+	}
+
+	t := time.Now().UnixNano() / int64(time.Millisecond)
+	err := DeviceClient.UpdateLastConnectedByName(name, t, context.Background())
+	if err != nil {
+		LoggingClient.Error("Failed to update last connected value for device: " + name)
+	}
 }


### PR DESCRIPTION
Extract the logic to a function for better maintainability also followed the discussion of #371 and #414, move the logic to PUT command as well. In the future if coredata were responsible for the update we can easily make the change.