### PR TITLE
Add gofmt test in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,10 @@ docker:
 		.
 
 test:
+	$(GO) test -coverprofile=coverage.out ./...
 	$(GO) vet ./...
 	gofmt -l .
-	$(GO) test -coverprofile=coverage.out ./...
+	[ "`gofmt -l .`" = "" ]
 	./bin/test-attribution-txt.sh
 	./bin/test-go-mod-tidy.sh
 

--- a/internal/autoevent/executor_test.go
+++ b/internal/autoevent/executor_test.go
@@ -73,4 +73,3 @@ func TestCompareReadings(t *testing.T) {
 		t.Error("compare readings with cache failed, the result should be true with unchanged readings")
 	}
 }
-


### PR DESCRIPTION
Add another test in `make test` to make sure every file are formatted correctly.  (right now `make test` only list them so they're ignored very often. )

Fix #250 

Signed-off-by: Chris Hung <chris@iotechsys.com>