### PR TITLE
Make deviceResource can be accessed directly

### DIFF
--- a/async.go
+++ b/async.go
@@ -55,11 +55,8 @@ func processAsyncResults() {
 
 			ro, err := cache.Profiles().ResourceOperation(device.Profile.Name, cv.DeviceResourceName, common.GetCmdMethod)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("processAsyncResults - getting resource operation failed: %s", err.Error()))
-				continue
-			}
-
-			if len(ro.Mappings) > 0 {
+				common.LoggingClient.Debug(fmt.Sprintf("processAsyncResults - getting resource operation failed: %s", err.Error()))
+			} else if len(ro.Mappings) > 0 {
 				newCV, ok := transformer.MapCommandValue(cv, ro.Mappings)
 				if ok {
 					cv = newCV

--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -83,6 +83,15 @@ func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[strin
 		if reqs[0].DeviceResourceName == "SwitchButton" {
 			cv, _ := dsModels.NewBoolValue(reqs[0].DeviceResourceName, now, s.switchButton)
 			res[0] = cv
+		} else if reqs[0].DeviceResourceName == "Xrotation" {
+			cv, _ := dsModels.NewInt32Value(reqs[0].DeviceResourceName, now, s.xRotation)
+			res[0] = cv
+		} else if reqs[0].DeviceResourceName == "Yrotation" {
+			cv, _ := dsModels.NewInt32Value(reqs[0].DeviceResourceName, now, s.yRotation)
+			res[0] = cv
+		} else if reqs[0].DeviceResourceName == "Zrotation" {
+			cv, _ := dsModels.NewInt32Value(reqs[0].DeviceResourceName, now, s.zRotation)
+			res[0] = cv
 		} else if reqs[0].DeviceResourceName == "Image" {
 			// Show a binary/image representation of the switch's on/off value
 			buf := new(bytes.Buffer)
@@ -120,31 +129,30 @@ func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[strin
 // command.
 func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[string]contract.ProtocolProperties, reqs []dsModels.CommandRequest,
 	params []*dsModels.CommandValue) error {
-	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleWriteCommands: protocols: %v, resource: %v, parameters: %v", protocols, reqs[0].DeviceResourceName, params))
 	var err error
-	if len(reqs) == 1 {
-		if s.switchButton, err = params[0].BoolValue(); err != nil {
-			err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Boolean, parameter: %s", params[0].String())
-			return err
-		}
-	} else if len(reqs) == 3 {
-		for i, r := range reqs {
-			switch r.DeviceResourceName {
-			case "Xrotation":
-				if s.xRotation, err = params[i].Int32Value(); err != nil {
-					err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
-					return err
-				}
-			case "Yrotation":
-				if s.yRotation, err = params[i].Int32Value(); err != nil {
-					err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
-					return err
-				}
-			case "Zrotation":
-				if s.zRotation, err = params[i].Int32Value(); err != nil {
-					err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
-					return err
-				}
+
+	for i, r := range reqs {
+		s.lc.Info(fmt.Sprintf("SimpleDriver.HandleWriteCommands: protocols: %v, resource: %v, parameters: %v", protocols, reqs[i].DeviceResourceName, params[i]))
+		switch r.DeviceResourceName {
+		case "SwitchButton":
+			if s.switchButton, err = params[i].BoolValue(); err != nil {
+				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Boolean, parameter: %s", params[0].String())
+				return err
+			}
+		case "Xrotation":
+			if s.xRotation, err = params[i].Int32Value(); err != nil {
+				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
+				return err
+			}
+		case "Yrotation":
+			if s.yRotation, err = params[i].Int32Value(); err != nil {
+				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
+				return err
+			}
+		case "Zrotation":
+			if s.zRotation, err = params[i].Int32Value(); err != nil {
+				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
+				return err
 			}
 		}
 	}

--- a/internal/cache/profiles_test.go
+++ b/internal/cache/profiles_test.go
@@ -147,16 +147,16 @@ func TestProfileCache_DeviceResource(t *testing.T) {
 func TestProfileCache_CommandExists(t *testing.T) {
 	dpc := newProfileCache(dps)
 
-	if _, err := dpc.CommandExists(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.CoreCommands[0].Name); err == nil {
+	if _, err := dpc.CommandExists(mock.NewDeviceProfile.Name, mock.NewDeviceProfile.CoreCommands[0].Name, common.GetCmdMethod); err == nil {
 		t.Error("DeviceProfileRandomFloatGenerator is not in cache, supposed to get an error")
 	}
-	if exists, err := dpc.CommandExists(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.CoreCommands[0].Name); err != nil {
+	if exists, err := dpc.CommandExists(mock.DeviceProfileRandomBoolGenerator.Name, mock.DeviceProfileRandomBoolGenerator.CoreCommands[0].Name, common.GetCmdMethod); err != nil {
 		t.Error("DeviceProfileRandomBoolGenerator exists in cache, not supposed to get an error")
 	} else if !exists {
 		t.Error("DeviceProfileRandomBoolGenerator.Commands[0] exists in cache, the returned value should be true")
 	}
 
-	if exists, _ := dpc.CommandExists(mock.DeviceProfileRandomBoolGenerator.Name, "arbitaryNameXXX"); exists {
+	if exists, _ := dpc.CommandExists(mock.DeviceProfileRandomBoolGenerator.Name, "arbitaryNameXXX", common.GetCmdMethod); exists {
 		t.Error("arbitaryNameXXX doesn't belong to any command in DeviceProfileRandomBoolGenerator.Commands, the returned value should be false")
 	}
 }

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -56,7 +56,7 @@ func CommandHandler(vars map[string]string, body string, method string, queryPar
 
 	// TODO: need to mark device when operation in progress, so it can't be removed till completed
 
-	cmdExists, err := cache.Profiles().CommandExists(d.Profile.Name, cmd)
+	cmdExists, err := cache.Profiles().CommandExists(d.Profile.Name, cmd, method)
 
 	// TODO: once cache locking has been implemented, this should never happen
 	if err != nil {
@@ -145,11 +145,8 @@ func cvsToEvent(device *contract.Device, cvs []*dsModels.CommandValue, cmd strin
 
 		ro, err := cache.Profiles().ResourceOperation(device.Profile.Name, cv.DeviceResourceName, common.GetCmdMethod)
 		if err != nil {
-			common.LoggingClient.Error(fmt.Sprintf("Handler - execReadCmd: getting resource operation failed: %s", err.Error()))
-			transformsOK = false
-		}
-
-		if len(ro.Mappings) > 0 {
+			common.LoggingClient.Debug(fmt.Sprintf("getting resource operation failed: %s", err.Error()))
+		} else if len(ro.Mappings) > 0 {
 			newCV, ok := transformer.MapCommandValue(cv, ro.Mappings)
 			if ok {
 				cv = newCV


### PR DESCRIPTION
Improve `CommandExists` logic to check the cmd exists in either deviceCommands or coreCommands, also remove resourceOperation requirement while transforming `CommandValue` to `Event` so that deviceResource can be accessed directly without definition of deviceCommands in device profile.

Fix #419,  #426 