### PR TITLE
Update relevant files in device-sdk-go for Go 1.13. Closes #440.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -15,7 +15,7 @@
 #
 
 # This is the base build image for 
-ARG BASE=golang:1.12-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE}
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 edgeXBuildGoApp (
     project: 'device-sdk-go',
-    goVersion: '1.12',
+    goVersion: '1.13',
     dockerImageName: 'docker-device-sdk-simple',
     dockerFilePath: 'example/cmd/device-simple/Dockerfile',
     pushImage: false

--- a/example/cmd/device-simple/Dockerfile
+++ b/example/cmd/device-simple/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.12-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE} AS builder
 
 ARG MAKE='make build'

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-go 1.12
+go 1.13

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,7 @@ parts:
   # This go part is necessary because it's expected that this snapcraft.yaml
   # will be build on Linux Foundation infrastructure and as such runs in a 
   # docker container. Since this may be run in a docker container, we can't 
-  # use the default (and convenient) `build-snaps: [go/1.12]` inside the 
+  # use the default (and convenient) `build-snaps: [go/1.13]` inside the
   # device-simple part which requires a working snapd which isn't available
   # inside a docker container
   go:


### PR DESCRIPTION
Fix #440 
- As with other similar `PR`s addressing the upgrade to `Go 1.13`, after making the updates to the relevant files, I ensured that the Docker image got built and tagged.