### PR TITLE
Implement dynamic device discovery

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,38 @@
+# device-simple
+
+The included device-simple example device service demonstrates basic usage of device-sdk-go.
+
+## Protocol Driver
+
+To make a functional Device Service, developers must implement the [ProtocolDriver](../pkg/models/protocoldriver.go) interface. 
+`ProtocolDriver` interface provides abstraction logic of how to interact with Device through specific protocol. See [simpledriver.go](driver/simpledriver.go) for example.
+
+## Protocol Discovery
+
+Some device protocols allow for devices to be discovered automatically.
+A Device Service may include a capability for discovering devices and creating the corresponding Device objects within EdgeX.  
+
+To enable device discovery, developers need to implement the [ProtocolDiscovery](../pkg/models/protocoldiscovery.go) interface.
+The `ProtocolDiscovery` interface defines a single `Discover` method which is used to trigger protocol-specific device discovery.
+Any devices found as a result of discovery being triggered are returned to the SDK via a go channel, passed to the implementation as a parameter during Initialization.
+New discovery attempts may be started as soon as a slice of devices is submitted, so in oreder to avoid the service being congested by concurrent discovery.
+  
+The SDK will then filter these devices against pre-defined acceptance criteria (i.e. Provision Watchers), and add any devices which match (excluding existing devices).
+
+A Provision Watcher contains the following fields:
+
+`Identifiers`: A set of name-value pairs against which a new device's ProtocolProperties are matched  
+`BlockingIdentifiers`: An additional set of name-value pairs which if matched, will block the addition of a newly discovered device.  
+`Profile`: The name of a DeviceProfile which should be assigned to new devices which meet the given criteria  
+`AdminState`: The initial Administrative State for new devices which meet the given criteria  
+ 
+A candidate new device passes a ProvisionWatcher if all of the Identifiers match, and none of the BlockingIdentifiers.
+
+Finally, A boolean configuration value `Device/Discovery/Enabled` defaults to false. If it is set true, and the DS implementation supports discovery, discovery is enabled.
+Dynamic Device Discovery is triggered either by internal timer(see `Device/Discovery/Interval` in [configuration.toml](cmd/device-simple/res/configuration.toml)) or by a call to the device service's `/discovery` REST endpoint.
+
+The following steps show how to trigger discovery on device-simple:
+1. Set `Device/Discovery/Enabled` to true in [configuration file](cmd/device-simple/res/configuration.toml)
+2. Post the [provided provisionwatcher](cmd/device-simple/res/provisionwatcher.json) into core-metadata endpoint: http://edgex-core-metadata:48081/api/v1/provisionwatcher
+3. Trigger discovery by sending POST request to DS endpoint: http://edgex-device-simple:49990/api/v1/discovery
+4. `Simple-Device02` will be discovered and added to EdgeX.

--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -46,6 +46,9 @@ Type = 'consul'
   RemoveCmdArgs = ''
   ProfilesDir = './res'
   UpdateLastConnected = false
+  [Device.Discovery]
+    Enabled = false
+    Interval = '30s'
 
 # Remote and file logging disabled so only stdout logging is used
 [Logging]

--- a/example/cmd/device-simple/res/provisionwatcher.json
+++ b/example/cmd/device-simple/res/provisionwatcher.json
@@ -1,0 +1,19 @@
+{
+  "name":"simple-watcher",
+  "identifiers":{
+    "Address":"simple[0-9]+",
+    "Port":"3[0-9]{2}"
+
+  },
+  "blockingidentifiers": {
+    "Port": ["399", "398", "397"]
+  },
+  "profile":{
+    "name":"Simple-Device"
+
+  },
+  "service":{
+    "name":"device-simple"
+  },
+  "adminState": "UNLOCKED"
+}

--- a/internal/autodiscovery/autodiscovery.go
+++ b/internal/autodiscovery/autodiscovery.go
@@ -1,0 +1,38 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package autodiscovery
+
+import (
+	"time"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/handler"
+)
+
+func Run() {
+	enabled := common.CurrentConfig.Device.Discovery.Enabled
+	if !enabled {
+		common.LoggingClient.Info("AutoDiscovery stopped: disabled by configuration")
+		return
+	}
+	duration, err := time.ParseDuration(common.CurrentConfig.Device.Discovery.Interval)
+	if err != nil || duration <= 0 {
+		common.LoggingClient.Info("AutoDiscovery stopped: interval error in configuration")
+		return
+	}
+	if common.Discovery == nil {
+		common.LoggingClient.Info("AutoDiscovery stopped: ProtocolDiscovery not implemented")
+		return
+	}
+
+	for {
+		time.Sleep(duration)
+
+		common.LoggingClient.Debug("Auto-discovery triggered")
+		handler.DiscoveryHandler(nil)
+	}
+}

--- a/internal/common/globalvars.go
+++ b/internal/common/globalvars.go
@@ -24,6 +24,7 @@ var (
 	ServiceLocked          bool
 	Driver                 dsModels.ProtocolDriver
 	RegistryClient         registry.Client
+	Discovery              dsModels.ProtocolDiscovery
 	EventClient            coredata.EventClient
 	AddressableClient      metadata.AddressableClient
 	DeviceClient           metadata.DeviceClient

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -84,6 +84,17 @@ type DeviceInfo struct {
 	// UpdateLastConnected specifies whether to update device's LastConnected
 	// timestamp in metadata.
 	UpdateLastConnected bool
+
+	Discovery DiscoveryInfo
+}
+
+// DiscoveryInfo is a struct which contains configuration of device auto discovery.
+type DiscoveryInfo struct {
+	// Enabled controls whether or not device discovery is enabled.
+	Enabled bool
+	// Interval indicates how often the discovery process will be triggered.
+	// It represents as a duration string.
+	Interval string
 }
 
 // DeviceConfig is the definition of Devices which will be auto created when the Device Service starts up
@@ -92,7 +103,7 @@ type DeviceConfig struct {
 	Name string
 	// Profile is the profile name of the Device
 	Profile string
-
+	// Description describes the device
 	Description string
 	// Other labels applied to the device to help with searching
 	Labels []string

--- a/internal/handler/control.go
+++ b/internal/handler/control.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
+// Copyright (C) 2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,15 +9,59 @@ package handler
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"sync"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/google/uuid"
 )
 
-func DiscoveryHandler(requestMap map[string]string) {
-	common.LoggingClient.Info(fmt.Sprintf("service: discovery request"))
+type discoveryLocker struct {
+	busy bool
+	id   string
+	mux  sync.Mutex
 }
+
+var locker discoveryLocker
 
 func TransformHandler(requestMap map[string]string) (map[string]string, common.AppError) {
 	common.LoggingClient.Info(fmt.Sprintf("service: transform request: transformData: %s", requestMap["transformData"]))
 	return requestMap, nil
+}
+
+func DiscoveryHandler(w http.ResponseWriter) {
+	locker.mux.Lock()
+	if locker.id == "" {
+		locker.id = uuid.New().String()
+	}
+	locker.mux.Unlock()
+
+	if w != nil {
+		msg := fmt.Sprintf("Discovery triggered or already running, id = %s", locker.id)
+		w.WriteHeader(http.StatusAccepted) //status=202
+		_, _ = io.WriteString(w, msg)
+	}
+
+	locker.mux.Lock()
+	defer locker.mux.Unlock()
+	if locker.busy {
+		common.LoggingClient.Info(fmt.Sprintf("Device discovery process is running, id = %s", locker.id))
+		return
+	}
+	locker.busy = true
+	common.LoggingClient.Info(fmt.Sprintf("service %s discovery triggered", common.ServiceName))
+
+	go common.Discovery.Discover()
+}
+
+func ReleaseLock() string {
+	var id string
+	locker.mux.Lock()
+	id = locker.id
+	locker.id = ""
+	locker.busy = false
+	locker.mux.Unlock()
+
+	return id
 }

--- a/internal/mock/mock_devicevirtualdriver.go
+++ b/internal/mock/mock_devicevirtualdriver.go
@@ -23,7 +23,7 @@ func (DriverMock) DisconnectDevice(deviceName string, protocols map[string]contr
 	panic("implement me")
 }
 
-func (DriverMock) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsModels.AsyncValues) error {
+func (DriverMock) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsModels.AsyncValues, deviceCh chan<- []dsModels.DiscoveredDevice) error {
 	panic("implement me")
 }
 

--- a/pkg/models/protocoldiscovery.go
+++ b/pkg/models/protocoldiscovery.go
@@ -1,20 +1,28 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
+// Copyright (C) 2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package models
 
+import contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
 // ProtocolDiscovery is a low-level device-specific interface implemented
 // by device services that support dynamic device discovery.
 type ProtocolDiscovery interface {
-	// Discover triggers protocol specific device discovery, which is
-	// a synchronous operation which returns a list of new devices
-	// which may be added to the device service based on service
-	// config. This function may also optionally trigger sensor
-	// discovery, which could result in dynamic device profile creation.
-	//
-	// TODO: add models.ScanList (or define locally) for devices
-	Discover() (devices *interface{}, err error)
+	// Discover triggers protocol specific device discovery, asynchronously
+	// writes the results to the channel which is passed to the implementation
+	// via ProtocolDriver.Initialize(). The results may be added to the device service
+	// based on a set of acceptance criteria (i.e. Provision Watchers).
+	Discover()
+}
+
+// DiscoveredDevice defines the required information for a found device.
+type DiscoveredDevice struct {
+	Name        string
+	Protocols   map[string]contract.ProtocolProperties
+	Description string
+	Labels      []string
 }

--- a/pkg/models/protocoldriver.go
+++ b/pkg/models/protocoldriver.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2019 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,10 +21,11 @@ import (
 // by other components of an EdgeX Device Service to interact with
 // a specific class of devices.
 type ProtocolDriver interface {
-	// Initialize performs protocol-specific initialization for the device
-	// service. The given *AsyncValues channel can be used to push asynchronous
-	// events and readings to Core Data.
-	Initialize(lc logger.LoggingClient, asyncCh chan<- *AsyncValues) error
+	// Initialize performs protocol-specific initialization for the device service.
+	// The given *AsyncValues channel can be used to push asynchronous events and
+	// readings to Core Data. The given []DiscoveredDevice channel is used to send
+	// discovered devices that will be filtered and added to Core Metadata asynchronously.
+	Initialize(lc logger.LoggingClient, asyncCh chan<- *AsyncValues, deviceCh chan<- []DiscoveredDevice) error
 
 	// HandleReadCommands passes a slice of CommandRequest struct each representing
 	// a ResourceOperation for a specific device resource.

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -10,10 +10,13 @@ package service
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sync"
+	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/handler"
 	"github.com/edgexfoundry/device-sdk-go/internal/transformer"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -88,4 +91,97 @@ func processAsyncResults(ctx context.Context, wg *sync.WaitGroup) {
 
 		}
 	}
+}
+
+// processAsyncFilterAndAdd filter and add devices discovered by
+// device service protocol discovery.
+func processAsyncFilterAndAdd(ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer func() {
+		close(svc.deviceCh)
+		wg.Done()
+	}()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case devices := <-svc.deviceCh:
+			id := handler.ReleaseLock()
+			pws := cache.ProvisionWatchers().All()
+			ctx := context.WithValue(context.Background(), common.CorrelationHeader, id)
+			for _, d := range devices {
+				for _, pw := range pws {
+					if !whitelistPass(d, pw) {
+						break
+					}
+					if !blacklistPass(d, pw) {
+						break
+					}
+
+					if _, ok := cache.Devices().ForName(d.Name); ok {
+						common.LoggingClient.Debug(fmt.Sprintf("Candidate discovered device %s already existed", d.Name))
+						break
+					}
+
+					common.LoggingClient.Info(fmt.Sprintf("Updating discovered device %s to Edgex", d.Name))
+					millis := time.Now().UnixNano() / int64(time.Millisecond)
+					device := &contract.Device{
+						Name:           d.Name,
+						Profile:        pw.Profile,
+						Protocols:      d.Protocols,
+						Labels:         d.Labels,
+						Service:        pw.Service,
+						AdminState:     pw.AdminState,
+						OperatingState: contract.Enabled,
+						AutoEvents:     nil,
+					}
+					device.Origin = millis
+					device.Description = d.Description
+					_, err := common.DeviceClient.Add(ctx, device)
+					if err != nil {
+						common.LoggingClient.Error(fmt.Sprintf("Created discovered device %s failed: %v", device.Name, err))
+					}
+				}
+			}
+			common.LoggingClient.Debug("Filtered device addition finished")
+		}
+	}
+}
+
+func whitelistPass(d dsModels.DiscoveredDevice, pw contract.ProvisionWatcher) bool {
+	// a candidate device should pass all identifiers
+	for name, regex := range pw.Identifiers {
+		// ignore the device protocol properties name
+		for _, protocol := range d.Protocols {
+			if value, ok := protocol[name]; ok {
+				matched, err := regexp.MatchString(regex, value)
+				if !matched || err != nil {
+					common.LoggingClient.Debug(fmt.Sprintf("Device %s's %s value %s did not match PW identifier: %s", d.Name, name, value, regex))
+					return false
+				}
+			} else {
+				common.LoggingClient.Debug(fmt.Sprintf("Identifier field: %s, did not exist in discovered device %s", name, d.Name))
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func blacklistPass(d dsModels.DiscoveredDevice, pw contract.ProvisionWatcher) bool {
+	// a candidate should match none of the blocking identifiers
+	for name, blacklist := range pw.BlockingIdentifiers {
+		// ignore the device protocol properties name
+		for _, protocol := range d.Protocols {
+			if value, ok := protocol[name]; ok {
+				for _, v := range blacklist {
+					if value == v {
+						common.LoggingClient.Debug(fmt.Sprintf("Discovered Device %s's %s should not be %s", d.Name, name, value))
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -37,6 +37,7 @@ var (
 type Service struct {
 	svcInfo    *common.ServiceInfo
 	asyncCh    chan *dsModels.AsyncValues
+	deviceCh   chan []dsModels.DiscoveredDevice
 	startTime  time.Time
 	controller controller.RestController
 }

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -10,12 +10,11 @@ package startup
 import (
 	"context"
 
-	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/device-sdk-go/pkg/service"
 	"github.com/gorilla/mux"
 )
 
-func Bootstrap(serviceName string, serviceVersion string, driver dsModels.ProtocolDriver) {
+func Bootstrap(serviceName string, serviceVersion string, driver interface{}) {
 	ctx, cancel := context.WithCancel(context.Background())
 	service.Main(serviceName, serviceVersion, driver, ctx, cancel, mux.NewRouter(), nil)
 }


### PR DESCRIPTION
Implement discovery via provisionwatcher following the [new design](https://github.com/edgexfoundry/edgex-docs/blob/8d0715376fd4fb63bebf1a891f5c25e4ffff7e06/design/legacy-design/device-service/discovery.md) .
Fix #418 

(PS: the provisionwatcher callback mechanism will be separated to another PR #450  )