### PR TITLE
Add provisionwatcher callback handler

### DIFF
--- a/internal/handler/callback/general.go
+++ b/internal/handler/callback/general.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2019 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -25,6 +25,8 @@ func CallbackHandler(cbAlert contract.CallbackAlert, method string) common.AppEr
 		return handleDevice(method, cbAlert.Id)
 	} else if cbAlert.ActionType == contract.PROFILE {
 		return handleProfile(method, cbAlert.Id)
+	} else if cbAlert.ActionType == contract.PROVISIONWATCHER {
+		return handleProvisionWatcher(method, cbAlert.Id)
 	}
 
 	common.LoggingClient.Error(fmt.Sprintf("Invalid callback action type: %s", cbAlert.ActionType))

--- a/internal/handler/callback/provisionwatcher.go
+++ b/internal/handler/callback/provisionwatcher.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package callback
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/cache"
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/google/uuid"
+)
+
+func handleProvisionWatcher(method string, id string) common.AppError {
+	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
+	switch method {
+	case http.MethodPost:
+		handlePostCallback(ctx, id)
+	case http.MethodPut:
+		handlePutCallback(ctx, id)
+	case http.MethodDelete:
+		handleDeleteCallback(id)
+	default:
+		common.LoggingClient.Error(fmt.Sprintf("Invalid provisionwatcher method type: %s", method))
+		appErr := common.NewBadRequestError("Invalid provisionwatcher method", nil)
+		return appErr
+	}
+
+	return nil
+}
+
+func handlePostCallback(ctx context.Context, id string) common.AppError {
+	pw, err := common.ProvisionWatcherClient.ProvisionWatcher(id, ctx)
+	if err != nil {
+		appErr := common.NewBadRequestError(err.Error(), err)
+		common.LoggingClient.Error(fmt.Sprintf("Cannot find provisionwatcher %s in Core Metadata: %v", id, err))
+		return appErr
+	}
+
+	err = cache.ProvisionWatchers().Add(pw)
+	if err == nil {
+		common.LoggingClient.Info(fmt.Sprintf("Added provisionwatcher %s", id))
+	} else {
+		appErr := common.NewServerError(err.Error(), err)
+		common.LoggingClient.Error(fmt.Sprintf("Cannot add provisionwatcher %s: %v", id, err.Error()))
+		return appErr
+	}
+
+	return nil
+}
+
+func handlePutCallback(ctx context.Context, id string) common.AppError {
+	pw, err := common.ProvisionWatcherClient.ProvisionWatcher(id, ctx)
+	if err != nil {
+		appErr := common.NewBadRequestError(err.Error(), err)
+		common.LoggingClient.Error(fmt.Sprintf("Cannot find provisionwatcher %s in Core Metadata: %v", id, err))
+		return appErr
+	}
+
+	err = cache.ProvisionWatchers().Update(pw)
+	if err == nil {
+		common.LoggingClient.Info(fmt.Sprintf("Updated provisionwatcher %s", id))
+	} else {
+		appErr := common.NewServerError(err.Error(), err)
+		common.LoggingClient.Error(fmt.Sprintf("Cannot update provisionwatcher %s: %v", id, err.Error()))
+		return appErr
+	}
+
+	return nil
+}
+
+func handleDeleteCallback(id string) common.AppError {
+	err := cache.ProvisionWatchers().Remove(id)
+	if err == nil {
+		common.LoggingClient.Info(fmt.Sprintf("Removed provisionwatcher %s", id))
+	} else {
+		appErr := common.NewServerError(err.Error(), err)
+		common.LoggingClient.Error(fmt.Sprintf("Cannot remove provisionwatcher %s: %v", id, err.Error()))
+		return appErr
+	}
+
+	return nil
+}

--- a/manageddevices.go
+++ b/manageddevices.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2019 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +38,6 @@ func (s *Service) AddDevice(device contract.Device) (id string, err error) {
 	device.Origin = millis
 	device.Service = common.CurrentDeviceService
 	device.Profile = prf
-	common.LoggingClient.Debug(fmt.Sprintf("Adding Device: %s", device.Name))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err = common.DeviceClient.Add(&device, ctx)

--- a/managedwatchers.go
+++ b/managedwatchers.go
@@ -37,7 +37,6 @@ func (s *Service) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id str
 	watcher.Origin = millis
 	watcher.Service = common.CurrentDeviceService
 	watcher.Profile = prf
-	common.LoggingClient.Debug(fmt.Sprintf("Adding Watcher: %s", watcher.Name))
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
 	id, err = common.ProvisionWatcherClient.Add(&watcher, ctx)
@@ -49,7 +48,6 @@ func (s *Service) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id str
 		return "", err
 	}
 	watcher.Id = id
-	cache.ProvisionWatchers().Add(watcher)
 
 	return id, nil
 }
@@ -88,8 +86,7 @@ func (s *Service) RemoveProvisionWatcher(id string) error {
 		return err
 	}
 
-	err = cache.ProvisionWatchers().Remove(id)
-	return err
+	return nil
 }
 
 // UpdateProvisionWatcher updates the Watcher in the cache and ensures that the
@@ -110,5 +107,5 @@ func (s *Service) UpdateProvisionWatcher(watcher contract.ProvisionWatcher) erro
 		return err
 	}
 
-	return cache.ProvisionWatchers().Update(watcher)
+	return nil
 }


### PR DESCRIPTION
Add provisionwatcher callback handler, remove cache operation in `managedwatchers.go` to avoid duplicate operation in device service cache.

Fix #449 