### PR TITLE
Encode the float as base64 string by little-endian binary

### DIFF
--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2019 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -337,7 +337,16 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
 		} else if floatEncoding == contract.Base64Encoding {
-			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
+			val, err := cv.Float32Value()
+			if err != nil {
+				str = err.Error()
+			}
+			buf := new(bytes.Buffer)
+			err = binary.Write(buf, binary.LittleEndian, val)
+			if err != nil {
+				str = err.Error()
+			}
+			str = base64.StdEncoding.EncodeToString(buf.Bytes())
 		}
 	case Float64:
 		floatEncoding := getFloatEncoding(encoding)
@@ -347,7 +356,16 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
 		} else if floatEncoding == contract.Base64Encoding {
-			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
+			val, err := cv.Float64Value()
+			if err != nil {
+				str = err.Error()
+			}
+			buf := new(bytes.Buffer)
+			err = binary.Write(buf, binary.LittleEndian, val)
+			if err != nil {
+				str = err.Error()
+			}
+			str = base64.StdEncoding.EncodeToString(buf.Bytes())
 		}
 	case Binary:
 		// produce string representation of first 20 bytes of binary value

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -642,7 +642,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "AAAAAQ==" {
+	if cv.ValueToString(contract.Base64Encoding) != "AQAAAA==" {
 		t.Errorf("NewFloat32Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -664,7 +664,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "f3///w==" {
+	if cv.ValueToString(contract.Base64Encoding) != "//9/fw==" {
 		t.Errorf("NewFloat32Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }
@@ -693,7 +693,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "AAAAAAAAAAE=" {
+	if cv.ValueToString(contract.Base64Encoding) != "AQAAAAAAAAA=" {
 		t.Errorf("NewFloat64Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -715,7 +715,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "f+////////8=" {
+	if cv.ValueToString(contract.Base64Encoding) != "////////738=" {
 		t.Errorf("NewFloat64Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }


### PR DESCRIPTION
Fix #457 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
SDK encodes the float as base64 string by **big-endian** binary.

## What is the new behavior?
SDK encodes the float as base64 string by **little-endian** binary.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

DS SDK spec:

> When EdgeX is given (or returns) a float32 or float64 value as a string, the format of the string is by default a base64 encoded little-endian of the float32 or float64 value

https://docs.google.com/document/d/1aMIQ0kb46VE5eeCpDlaTg8PP29-DBSBTlgeWrv6LuYk/edit
