### PR TITLE
Revert "Encode the float as base64 string by little-endian binary"

### DIFF
--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2018-2019 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -337,16 +337,7 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
 		} else if floatEncoding == contract.Base64Encoding {
-			val, err := cv.Float32Value()
-			if err != nil {
-				str = err.Error()
-			}
-			buf := new(bytes.Buffer)
-			err = binary.Write(buf, binary.LittleEndian, val)
-			if err != nil {
-				str = err.Error()
-			}
-			str = base64.StdEncoding.EncodeToString(buf.Bytes())
+			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
 		}
 	case Float64:
 		floatEncoding := getFloatEncoding(encoding)
@@ -356,16 +347,7 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
 		} else if floatEncoding == contract.Base64Encoding {
-			val, err := cv.Float64Value()
-			if err != nil {
-				str = err.Error()
-			}
-			buf := new(bytes.Buffer)
-			err = binary.Write(buf, binary.LittleEndian, val)
-			if err != nil {
-				str = err.Error()
-			}
-			str = base64.StdEncoding.EncodeToString(buf.Bytes())
+			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
 		}
 	case Binary:
 		// produce string representation of first 20 bytes of binary value

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2018 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -642,7 +642,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "AQAAAA==" {
+	if cv.ValueToString(contract.Base64Encoding) != "AAAAAQ==" {
 		t.Errorf("NewFloat32Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -664,7 +664,7 @@ func TestNewFloat32Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat32Value: float32 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "//9/fw==" {
+	if cv.ValueToString(contract.Base64Encoding) != "f3///w==" {
 		t.Errorf("NewFloat32Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }
@@ -693,7 +693,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "AQAAAAAAAAA=" {
+	if cv.ValueToString(contract.Base64Encoding) != "AAAAAAAAAAE=" {
 		t.Errorf("NewFloat64Value #1: invalid reading Value: %s", cv.ValueToString())
 	}
 
@@ -715,7 +715,7 @@ func TestNewFloat64Value(t *testing.T) {
 	if v != value {
 		t.Errorf("NewFloat64Value: float64 value is incorrect")
 	}
-	if cv.ValueToString(contract.Base64Encoding) != "////////738=" {
+	if cv.ValueToString(contract.Base64Encoding) != "f+////////8=" {
 		t.Errorf("NewFloat64Value #2: invalid reading Value: %s", cv.ValueToString())
 	}
 }


### PR DESCRIPTION
Reverts edgexfoundry/device-sdk-go#458

This change breaks the backward compatibility, so revert it.