### PR TITLE
Add ServerBindAddr setting in configuration

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -5,6 +5,7 @@ LogLevel = 'INFO'
 BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
+ServerBindAddr = ''  # blank value defaults to Service.Host value
 Port = 49990
 Protocol = 'http'
 StartupMsg = 'device simple started'

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-sdk-go
 
 require (
 	github.com/OneOfOne/xxhash v1.2.6
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.33
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.36
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
 	github.com/edgexfoundry/go-mod-registry v0.1.20
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -27,12 +27,13 @@ type ServiceInfo struct {
 	BootTimeout int
 	// Health check interval
 	CheckInterval string
-	// Indicates the interval in milliseconds at which service clients should check for any configuration updates
-	ClientMonitor int
 	// Host is the hostname or IP address of the service.
 	Host string
 	// Port is the HTTP port of the service.
 	Port int
+	// ServerBindAddr specifies an IP address or hostname
+	// for ListenAndServe to bind to, such as 0.0.0.0
+	ServerBindAddr string
 	// The protocol that should be used to call this service
 	Protocol string
 	// StartupMsg specifies a string to log once service
@@ -117,9 +118,9 @@ func (s ServiceInfo) GetBootstrapServiceInfo() bootstrapConfig.ServiceInfo {
 	return bootstrapConfig.ServiceInfo{
 		BootTimeout:    s.BootTimeout,
 		CheckInterval:  s.CheckInterval,
-		ClientMonitor:  s.ClientMonitor,
 		Host:           s.Host,
 		Port:           s.Port,
+		ServerBindAddr: s.ServerBindAddr,
 		Protocol:       s.Protocol,
 		StartupMsg:     s.StartupMsg,
 		MaxResultCount: s.MaxResultCount,


### PR DESCRIPTION
Add the ServerBindAddr setting used for ListenAndServe in
go-mod-bootstrap, also update the ServiceInfo struct to include
this new field and remove the unused ClientMonitor to be consistent
with the ServiceInfo struct defined in go-mod-bootstrap

Fix #548 

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
