### PR TITLE
fix: allow startup duration/interval to be overridden via env vars

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -10,7 +10,6 @@ Port = 49990
 Protocol = 'http'
 StartupMsg = 'device simple started'
 Timeout = 20000
-ConnectRetries = 20
 Labels = []
 EnableAsyncReadings = true
 AsyncBufferSize = 16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-sdk-go
 
 require (
 	github.com/OneOfOne/xxhash v1.2.6
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.36
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.37
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.58
 	github.com/edgexfoundry/go-mod-registry v0.1.20
 	github.com/fxamacker/cbor/v2 v2.2.0

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -7,7 +7,6 @@
 package common
 
 import (
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
 )
 
@@ -21,7 +20,7 @@ type ConfigurationStruct struct {
 	Logging bootstrapConfig.LoggingInfo
 	// Registry contains registry-specific settings.
 	Registry bootstrapConfig.RegistryInfo
-	// Service contains RegistryService-specific settings.
+	// Service contains DeviceService-specific settings.
 	Service ServiceInfo
 	// Device contains device-specific configuration settings.
 	Device DeviceInfo
@@ -64,9 +63,9 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // GetBootstrap returns the configuration elements required by the bootstrap.  Currently, a copy of the configuration
 // data is returned.  This is intended to be temporary -- since ConfigurationStruct drives the configuration.toml's
 // structure -- until we can make backwards-breaking configuration.toml changes (which would consolidate these fields
-// into an interfaces.BootstrapConfiguration struct contained within ConfigurationStruct).
-func (c *ConfigurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
-	return interfaces.BootstrapConfiguration{
+// into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
+func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
+	return bootstrapConfig.BootstrapConfiguration{
 		Clients:  c.Clients,
 		Service:  c.Service.GetBootstrapServiceInfo(),
 		Registry: c.Registry,

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -46,10 +46,7 @@ type ServiceInfo struct {
 	// - timeout for processing REST calls and
 	// - interval time the DS will wait between each retry call.
 	Timeout int
-	// ConnectRetries is the number of times the DS will try to connect to all dependent services.
-	// If exceeded for even one dependent service, the DS will exit.
-	ConnectRetries int
-	// Labels are...
+	// Labels are properties applied to the device service to help with searching
 	Labels []string
 	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
 	EnableAsyncReadings bool

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -40,7 +40,7 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 	}
 }
 
-func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ startup.Timer, dic *di.Container) (success bool) {
+func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) (success bool) {
 	common.CurrentConfig = container.ConfigurationFrom(dic.Get)
 	common.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
 	common.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
@@ -59,7 +59,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	svc.deviceCh = make(chan []dsModels.DiscoveredDevice)
 	go processAsyncFilterAndAdd(ctx, wg)
 
-	err := clients.InitDependencyClients(ctx, wg)
+	err := clients.InitDependencyClients(ctx, wg, startupTimer)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return false

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -28,7 +28,7 @@ import (
 var instanceName string
 
 func Main(serviceName string, serviceVersion string, proto interface{}, ctx context.Context, cancel context.CancelFunc, router *mux.Router, readyStream chan<- bool) {
-	startupTimer := startup.NewStartUpTimer(common.BootRetrySecondsDefault, common.BootTimeoutSecondsDefault)
+	startupTimer := startup.NewStartUpTimer(serviceName)
 
 	additionalUsage :=
 		"    -i, --instance                  Provides a service name suffix which allows unique instance to be created\n" +


### PR DESCRIPTION
remove the ConnectRetries configuration and use the startup
duration/interval instead and update the associated retry loops
during bootstrap process.

fix #561 

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
