### PR TITLE
fix: pass ctx into client initialization function

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -59,13 +59,11 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	svc.deviceCh = make(chan []dsModels.DiscoveredDevice)
 	go processAsyncFilterAndAdd(ctx, wg)
 
-	err := clients.InitDependencyClients(ctx, wg, startupTimer)
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	if clients.InitDependencyClients(ctx, wg, startupTimer) == false {
 		return false
 	}
 
-	err = selfRegister()
+	err := selfRegister()
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Couldn't register to metadata service: %v\n", err)
 		return false


### PR DESCRIPTION
go-mod-bootstrap translate SIGTERM to call cancel function to gracefully
stop long-running goroutine in SDK.
Add the exact behavior on goroutines that check dependency servicess and
refactor the package to be prepare for future removing global vars refactor.

Signed-off-by: Chris Hung <chris@iotechsys.com>

fix #495

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
