### PR TITLE
refactor service and clients package

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -12,7 +12,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 )
 
-type EdgeXClient struct {
+type EdgeXClients struct {
 	GeneralClient          general.GeneralClient
 	DeviceClient           metadata.DeviceClient
 	DeviceServiceClient    metadata.DeviceServiceClient

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -1,0 +1,24 @@
+// -*- mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+)
+
+type EdgeXClient struct {
+	GeneralClient          general.GeneralClient
+	DeviceClient           metadata.DeviceClient
+	DeviceServiceClient    metadata.DeviceServiceClient
+	DeviceProfileClient    metadata.DeviceProfileClient
+	AddressableClient      metadata.AddressableClient
+	ProvisionWatcherClient metadata.ProvisionWatcherClient
+	EventClient            coredata.EventClient
+	ValueDescriptorClient  coredata.ValueDescriptorClient
+}

--- a/internal/clients/init.go
+++ b/internal/clients/init.go
@@ -14,52 +14,76 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexfoundry/device-sdk-go/internal/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+	"github.com/edgexfoundry/go-mod-registry/registry"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 )
+
+// Clients contains references to dependencies required by the Clients bootstrap implementation.
+type Clients struct {
+}
+
+// NewClients create a new instance of Clients
+func NewClients() *Clients {
+	return &Clients{}
+}
+
+func (_ *Clients) BootstrapHandler(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+	return InitDependencyClients(ctx, startupTimer, dic)
+}
 
 // InitDependencyClients triggers Service Client Initializer to establish connection to Metadata and Core Data Services
 // through Metadata Client and Core Data Client.
 // Service Client Initializer also needs to check the service status of Metadata and Core Data Services,
 // because they are important dependencies of Device Service.
 // The initialization process should be pending until Metadata Service and Core Data Service are both available.
-func InitDependencyClients(ctx context.Context, waitGroup *sync.WaitGroup, startupTimer startup.Timer) bool {
-	if err := validateClientConfig(); err != nil {
-		common.LoggingClient.Error(err.Error())
+func InitDependencyClients(ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
+	if err := validateClientConfig(container.ConfigurationFrom(dic.Get)); err != nil {
+		lc.Error(err.Error())
 		return false
 	}
 
-	if checkDependencyServices(ctx, startupTimer) == false {
+	if checkDependencyServices(ctx, startupTimer, dic) == false {
 		return false
 	}
 
-	initializeClients(ctx, waitGroup)
+	initializeClients(dic)
 
-	common.LoggingClient.Info("Service clients initialize successful.")
+	lc.Info("Service clients initialize successful.")
 	return true
 }
 
-func validateClientConfig() error {
+func validateClientConfig(configuration *common.ConfigurationStruct) error {
 
-	if len(common.CurrentConfig.Clients[common.ClientMetadata].Host) == 0 {
+	if len(configuration.Clients[common.ClientMetadata].Host) == 0 {
 		return fmt.Errorf("fatal error; Host setting for Core Metadata client not configured")
 	}
 
-	if common.CurrentConfig.Clients[common.ClientMetadata].Port == 0 {
+	if configuration.Clients[common.ClientMetadata].Port == 0 {
 		return fmt.Errorf("fatal error; Port setting for Core Metadata client not configured")
 	}
 
-	if len(common.CurrentConfig.Clients[common.ClientData].Host) == 0 {
+	if len(configuration.Clients[common.ClientData].Host) == 0 {
 		return fmt.Errorf("fatal error; Host setting for Core Data client not configured")
 	}
 
-	if common.CurrentConfig.Clients[common.ClientData].Port == 0 {
+	if configuration.Clients[common.ClientData].Port == 0 {
 		return fmt.Errorf("fatal error; Port setting for Core Ddata client not configured")
 	}
 
@@ -68,7 +92,7 @@ func validateClientConfig() error {
 	return nil
 }
 
-func checkDependencyServices(ctx context.Context, startupTimer startup.Timer) bool {
+func checkDependencyServices(ctx context.Context, startupTimer startup.Timer, dic *di.Container) bool {
 	var dependencyList = []string{common.ClientData, common.ClientMetadata}
 	var waitGroup sync.WaitGroup
 	checkingErr := true
@@ -79,7 +103,7 @@ func checkDependencyServices(ctx context.Context, startupTimer startup.Timer) bo
 	for i := 0; i < dependencyCount; i++ {
 		go func(wg *sync.WaitGroup, serviceName string) {
 			defer wg.Done()
-			if checkServiceAvailable(ctx, serviceName, startupTimer) == false {
+			if checkServiceAvailable(ctx, serviceName, startupTimer, dic) == false {
 				checkingErr = false
 			}
 		}(&waitGroup, dependencyList[i])
@@ -89,18 +113,22 @@ func checkDependencyServices(ctx context.Context, startupTimer startup.Timer) bo
 	return checkingErr
 }
 
-func checkServiceAvailable(ctx context.Context, serviceId string, startupTimer startup.Timer) bool {
+func checkServiceAvailable(ctx context.Context, serviceId string, startupTimer startup.Timer, dic *di.Container) bool {
+	rc := bootstrapContainer.RegistryFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+
 	for startupTimer.HasNotElapsed() {
 		select {
 		case <-ctx.Done():
 			return false
 		default:
-			if common.RegistryClient != nil {
-				if checkServiceAvailableViaRegistry(serviceId) == nil {
+			if rc != nil {
+				if checkServiceAvailableViaRegistry(serviceId, rc, lc) == nil {
 					return true
 				}
 			} else {
-				if checkServiceAvailableByPing(serviceId) == nil {
+				configuration := container.ConfigurationFrom(dic.Get)
+				if checkServiceAvailableByPing(serviceId, configuration, lc) == nil {
 					return true
 				}
 			}
@@ -108,14 +136,14 @@ func checkServiceAvailable(ctx context.Context, serviceId string, startupTimer s
 		}
 	}
 
-	common.LoggingClient.Error(fmt.Sprintf("dependency %s service checking time out", serviceId))
+	lc.Error(fmt.Sprintf("dependency %s service checking time out", serviceId))
 	return false
 }
 
-func checkServiceAvailableByPing(serviceId string) error {
-	common.LoggingClient.Info(fmt.Sprintf("Check %v service's status by ping...", serviceId))
-	addr := common.CurrentConfig.Clients[serviceId].Url()
-	timeout := int64(common.CurrentConfig.Service.BootTimeout) * int64(time.Millisecond)
+func checkServiceAvailableByPing(serviceId string, configuration *common.ConfigurationStruct, lc logger.LoggingClient) error {
+	lc.Info(fmt.Sprintf("Check %v service's status by ping...", serviceId))
+	addr := configuration.Clients[serviceId].Url()
+	timeout := int64(configuration.Service.Timeout) * int64(time.Millisecond)
 
 	client := http.Client{
 		Timeout: time.Duration(timeout),
@@ -123,18 +151,18 @@ func checkServiceAvailableByPing(serviceId string) error {
 
 	_, err := client.Get(addr + clients.ApiPingRoute)
 	if err != nil {
-		common.LoggingClient.Error(err.Error())
+		lc.Error(err.Error())
 	}
 
 	return err
 }
 
-func checkServiceAvailableViaRegistry(serviceId string) error {
-	common.LoggingClient.Info(fmt.Sprintf("Check %s service's status via Registry...", serviceId))
+func checkServiceAvailableViaRegistry(serviceId string, rc registry.Client, lc logger.LoggingClient) error {
+	lc.Info(fmt.Sprintf("Check %s service's status via Registry...", serviceId))
 
-	if !common.RegistryClient.IsAlive() {
+	if !rc.IsAlive() {
 		errMsg := fmt.Sprintf("unable to check status of %s service: Registry not running", serviceId)
-		common.LoggingClient.Error(errMsg)
+		lc.Error(errMsg)
 		return fmt.Errorf(errMsg)
 	}
 
@@ -143,25 +171,62 @@ func checkServiceAvailableViaRegistry(serviceId string) error {
 	} else {
 		serviceId = clients.CoreMetaDataServiceKey
 	}
-	_, err := common.RegistryClient.IsServiceAvailable(serviceId)
+	_, err := rc.IsServiceAvailable(serviceId)
 	if err != nil {
-		common.LoggingClient.Error(err.Error())
+		lc.Error(err.Error())
 		return err
 	}
 
 	return nil
 }
 
-func initializeClients(ctx context.Context, waitGroup *sync.WaitGroup) {
+func initializeClients(dic *di.Container) {
+	configuration := container.ConfigurationFrom(dic.Get)
 	// initialize Core Metadata clients
-	common.AddressableClient = metadata.NewAddressableClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url() + clients.ApiAddressableRoute))
-	common.DeviceClient = metadata.NewDeviceClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url() + clients.ApiDeviceRoute))
-	common.DeviceServiceClient = metadata.NewDeviceServiceClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url() + clients.ApiDeviceServiceRoute))
-	common.DeviceProfileClient = metadata.NewDeviceProfileClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url() + clients.ApiDeviceProfileRoute))
-	common.MetadataGeneralClient = general.NewGeneralClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url()))
-	common.ProvisionWatcherClient = metadata.NewProvisionWatcherClient(local.New(common.CurrentConfig.Clients[common.ClientMetadata].Url() + clients.ApiProvisionWatcherRoute))
-
+	ac := metadata.NewAddressableClient(local.New(configuration.Clients[common.ClientMetadata].Url() + clients.ApiAddressableRoute))
+	dc := metadata.NewDeviceClient(local.New(configuration.Clients[common.ClientMetadata].Url() + clients.ApiDeviceRoute))
+	dsc := metadata.NewDeviceServiceClient(local.New(configuration.Clients[common.ClientMetadata].Url() + clients.ApiDeviceServiceRoute))
+	dpc := metadata.NewDeviceProfileClient(local.New(configuration.Clients[common.ClientMetadata].Url() + clients.ApiDeviceProfileRoute))
+	gc := general.NewGeneralClient(local.New(configuration.Clients[common.ClientMetadata].Url()))
+	pwc := metadata.NewProvisionWatcherClient(local.New(configuration.Clients[common.ClientMetadata].Url() + clients.ApiProvisionWatcherRoute))
 	// initialize Core Data clients
-	common.EventClient = coredata.NewEventClient(local.New(common.CurrentConfig.Clients[common.ClientData].Url() + clients.ApiEventRoute))
-	common.ValueDescriptorClient = coredata.NewValueDescriptorClient(local.New(common.CurrentConfig.Clients[common.ClientData].Url() + common.APIValueDescriptorRoute))
+	ec := coredata.NewEventClient(local.New(configuration.Clients[common.ClientData].Url() + clients.ApiEventRoute))
+	vdc := coredata.NewValueDescriptorClient(local.New(configuration.Clients[common.ClientData].Url() + common.APIValueDescriptorRoute))
+
+	dic.Update(di.ServiceConstructorMap{
+		container.MetadataAddressableClientName: func(get di.Get) interface{} {
+			return ac
+		},
+		container.MetadataDeviceClientName: func(get di.Get) interface{} {
+			return dc
+		},
+		container.MetadataDeviceServiceClientName: func(get di.Get) interface{} {
+			return dsc
+		},
+		container.MetadataDeviceProfileClientName: func(get di.Get) interface{} {
+			return dpc
+		},
+		container.MetadataGeneralClientName: func(get di.Get) interface{} {
+			return gc
+		},
+		container.MetadataProvisionWatcherClientName: func(get di.Get) interface{} {
+			return pwc
+		},
+		container.CoredataEventClientName: func(get di.Get) interface{} {
+			return ec
+		},
+		container.CoredataValueDescriptorClientName: func(get di.Get) interface{} {
+			return vdc
+		},
+	})
+
+	// TODO: remove these after refactor are done.
+	common.AddressableClient = ac
+	common.DeviceClient = dc
+	common.DeviceServiceClient = dsc
+	common.DeviceProfileClient = dpc
+	common.MetadataGeneralClient = gc
+	common.ProvisionWatcherClient = pwc
+	common.EventClient = ec
+	common.ValueDescriptorClient = vdc
 }

--- a/internal/clients/init.go
+++ b/internal/clients/init.go
@@ -206,7 +206,7 @@ func initializeClients(dic *di.Container) {
 		container.MetadataDeviceProfileClientName: func(get di.Get) interface{} {
 			return dpc
 		},
-		container.MetadataGeneralClientName: func(get di.Get) interface{} {
+		container.GeneralClientName: func(get di.Get) interface{} {
 			return gc
 		},
 		container.MetadataProvisionWatcherClientName: func(get di.Get) interface{} {

--- a/internal/clients/init_test.go
+++ b/internal/clients/init_test.go
@@ -17,18 +17,16 @@ import (
 
 func TestCheckServiceAvailableByPingWithTimeoutError(test *testing.T) {
 	var clientConfig = map[string]bootstrapConfig.ClientInfo{
-		common.ClientData: bootstrapConfig.ClientInfo{
+		common.ClientData: {
 			Host:     "www.google.com",
 			Port:     81,
 			Protocol: "http",
 		},
 	}
-	var config = &common.ConfigurationStruct{Clients: clientConfig}
-	common.CurrentConfig = config
-	common.LoggingClient = logger.NewClient("test_service", false, "./device-simple.log", "DEBUG")
+	config := &common.ConfigurationStruct{Clients: clientConfig}
+	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
 
-	err := checkServiceAvailableByPing(common.ClientData)
-
+	err := checkServiceAvailableByPing(common.ClientData, config, lc)
 	if err, ok := err.(net.Error); ok && !err.Timeout() {
 		test.Fatal("Should be timeout error")
 	}

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -1,0 +1,55 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/general"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+)
+
+var MetadataDeviceClientName = "MetadataDeviceClient"
+var MetadataDeviceServiceClientName = "MetadataDeviceServiceClient"
+var MetadataDeviceProfileClientName = "MetadataDeviceProfileClient"
+var MetadataAddressableClientName = "MetadataAddressableClient"
+var MetadataProvisionWatcherClientName = "MetadataProvisionWatcherClient"
+var MetadataGeneralClientName = "MetadataGeneralClient"
+var CoredataEventClientName = "CoredataEventClient"
+var CoredataValueDescriptorClientName = "CoredataValueDescriptorClient"
+
+func MetadataDeviceClientFrom(get di.Get) metadata.DeviceClient {
+	return get(MetadataDeviceClientName).(metadata.DeviceClient)
+}
+
+func MetadataDeviceServiceClientFrom(get di.Get) metadata.DeviceServiceClient {
+	return get(MetadataDeviceServiceClientName).(metadata.DeviceServiceClient)
+}
+
+func MetadataDeviceProfileClientFrom(get di.Get) metadata.DeviceProfileClient {
+	return get(MetadataDeviceProfileClientName).(metadata.DeviceProfileClient)
+}
+
+func MetadataAddressableClientFrom(get di.Get) metadata.AddressableClient {
+	return get(MetadataAddressableClientName).(metadata.AddressableClient)
+}
+
+func MetadataProvisionWatcherClientFrom(get di.Get) metadata.ProvisionWatcherClient {
+	return get(MetadataProvisionWatcherClientName).(metadata.ProvisionWatcherClient)
+}
+
+func MetadataGeneralClientFrom(get di.Get) general.GeneralClient {
+	return get(MetadataGeneralClientName).(general.GeneralClient)
+}
+
+func CoredataEventClientFrom(get di.Get) coredata.EventClient {
+	return get(CoredataEventClientName).(coredata.EventClient)
+}
+
+func CoredataValueDescriptorClientFrom(get di.Get) coredata.ValueDescriptorClient {
+	return get(CoredataValueDescriptorClientName).(coredata.ValueDescriptorClient)
+}

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -13,14 +13,18 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 )
 
-var MetadataDeviceClientName = "MetadataDeviceClient"
-var MetadataDeviceServiceClientName = "MetadataDeviceServiceClient"
-var MetadataDeviceProfileClientName = "MetadataDeviceProfileClient"
-var MetadataAddressableClientName = "MetadataAddressableClient"
-var MetadataProvisionWatcherClientName = "MetadataProvisionWatcherClient"
-var MetadataGeneralClientName = "MetadataGeneralClient"
-var CoredataEventClientName = "CoredataEventClient"
-var CoredataValueDescriptorClientName = "CoredataValueDescriptorClient"
+var GeneralClientName = di.TypeInstanceToName((*general.GeneralClient)(nil))
+var MetadataDeviceClientName = di.TypeInstanceToName((*metadata.DeviceClient)(nil))
+var MetadataDeviceServiceClientName = di.TypeInstanceToName((*metadata.DeviceServiceClient)(nil))
+var MetadataDeviceProfileClientName = di.TypeInstanceToName((*metadata.DeviceProfileClient)(nil))
+var MetadataAddressableClientName = di.TypeInstanceToName((*metadata.AddressableClient)(nil))
+var MetadataProvisionWatcherClientName = di.TypeInstanceToName((*metadata.ProvisionWatcherClient)(nil))
+var CoredataEventClientName = di.TypeInstanceToName((*coredata.EventClient)(nil))
+var CoredataValueDescriptorClientName = di.TypeInstanceToName((*coredata.ValueDescriptorClient)(nil))
+
+func GeneralClientFrom(get di.Get) general.GeneralClient {
+	return get(GeneralClientName).(general.GeneralClient)
+}
 
 func MetadataDeviceClientFrom(get di.Get) metadata.DeviceClient {
 	return get(MetadataDeviceClientName).(metadata.DeviceClient)
@@ -40,10 +44,6 @@ func MetadataAddressableClientFrom(get di.Get) metadata.AddressableClient {
 
 func MetadataProvisionWatcherClientFrom(get di.Get) metadata.ProvisionWatcherClient {
 	return get(MetadataProvisionWatcherClientName).(metadata.ProvisionWatcherClient)
-}
-
-func MetadataGeneralClientFrom(get di.Get) general.GeneralClient {
-	return get(MetadataGeneralClientName).(general.GeneralClient)
 }
 
 func CoredataEventClientFrom(get di.Get) coredata.EventClient {

--- a/internal/container/deviceservice.go
+++ b/internal/container/deviceservice.go
@@ -14,8 +14,8 @@ import (
 
 // DeviceServiceName contains the name of device service implementation in the DIC.
 var DeviceServiceName = di.TypeInstanceToName(contract.DeviceService{})
-var ProtocolDiscoveryName = "ProtocolDiscovery"
-var ProtocolDriverName = "ProtocolDriver"
+var ProtocolDiscoveryName = di.TypeInstanceToName((*models.ProtocolDiscovery)(nil))
+var ProtocolDriverName = di.TypeInstanceToName((*models.ProtocolDriver)(nil))
 
 // DeviceServiceFrom helper function queries the DIC and returns device service implementation.
 func DeviceServiceFrom(get di.Get) contract.DeviceService {

--- a/internal/container/deviceservice.go
+++ b/internal/container/deviceservice.go
@@ -7,14 +7,25 @@
 package container
 
 import (
+	"github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
 // DeviceServiceName contains the name of device service implementation in the DIC.
 var DeviceServiceName = di.TypeInstanceToName(contract.DeviceService{})
+var ProtocolDiscoveryName = "ProtocolDiscovery"
+var ProtocolDriverName = "ProtocolDriver"
 
 // DeviceServiceFrom helper function queries the DIC and returns device service implementation.
-func DeviceServiceFrom(get di.Get) *contract.DeviceService {
-	return get(DeviceServiceName).(*contract.DeviceService)
+func DeviceServiceFrom(get di.Get) contract.DeviceService {
+	return get(DeviceServiceName).(contract.DeviceService)
+}
+
+func ProtocolDiscoveryFrom(get di.Get) models.ProtocolDiscovery {
+	return get(ProtocolDiscoveryName).(models.ProtocolDiscovery)
+}
+
+func ProtocolDriverFrom(get di.Get) models.ProtocolDriver {
+	return get(ProtocolDriverName).(models.ProtocolDriver)
 }

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -139,8 +139,7 @@ func (s *DeviceServiceSDK) processAsyncFilterAndAdd(ctx context.Context, wg *syn
 					device.Origin = millis
 					device.Description = d.Description
 
-					dc := s.edgexClients.DeviceClient
-					_, err := dc.Add(ctx, device)
+					_, err := s.edgexClients.DeviceClient.Add(ctx, device)
 					if err != nil {
 						s.LoggingClient.Error(fmt.Sprintf("Created discovered device %s failed: %v", device.Name, err))
 					}

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -26,7 +26,7 @@ import (
 // processAsyncResults processes readings that are pushed from
 // a DS implementation. Each is reading is optionally transformed
 // before being pushed to Core Data.
-func (s *DeviceServiceSDK) processAsyncResults(ctx context.Context, wg *sync.WaitGroup) {
+func (s *DeviceService) processAsyncResults(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer func() {
 		close(s.asyncCh)
@@ -96,7 +96,7 @@ func (s *DeviceServiceSDK) processAsyncResults(ctx context.Context, wg *sync.Wai
 
 // processAsyncFilterAndAdd filter and add devices discovered by
 // device service protocol discovery.
-func (s *DeviceServiceSDK) processAsyncFilterAndAdd(ctx context.Context, wg *sync.WaitGroup) {
+func (s *DeviceService) processAsyncFilterAndAdd(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer func() {
 		close(s.deviceCh)

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -10,14 +10,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/autodiscovery"
 	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
-	"github.com/edgexfoundry/device-sdk-go/internal/clients"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/internal/provision"
@@ -41,59 +39,70 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 }
 
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) (success bool) {
+	// TODO: remove these after refactor are done.
 	common.CurrentConfig = container.ConfigurationFrom(dic.Get)
 	common.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
 	common.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
 
-	// init svc and autoevent manager in the beginning so that if there's
-	// error in following bootstrap process the device service can correctly
-	// call svc.Stop and gracefully shut down.
-	svc = newService(dic)
+	sdk.UpdateFromContainer(b.router, dic)
+	lc := sdk.LoggingClient
+	configuration := sdk.config
+
+	// init autoevent manager in the beginning so that if there's error
+	// in following bootstrap process the device service can correctly
 	autoevent.NewManager(ctx, wg)
 
-	if svc.svcInfo.EnableAsyncReadings {
-		svc.asyncCh = make(chan *dsModels.AsyncValues, svc.svcInfo.AsyncBufferSize)
-		go processAsyncResults(ctx, wg)
+	if sdk.AsyncReadings() {
+		sdk.asyncCh = make(chan *dsModels.AsyncValues, sdk.svcInfo.AsyncBufferSize)
+		go sdk.processAsyncResults(ctx, wg)
 	}
 
-	svc.deviceCh = make(chan []dsModels.DiscoveredDevice)
-	go processAsyncFilterAndAdd(ctx, wg)
+	sdk.deviceCh = make(chan []dsModels.DiscoveredDevice)
+	go sdk.processAsyncFilterAndAdd(ctx, wg)
 
-	if clients.InitDependencyClients(ctx, wg, startupTimer) == false {
-		return false
-	}
-
-	err := selfRegister()
+	err := sdk.selfRegister()
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Couldn't register to metadata service: %v\n", err)
+		lc.Error(fmt.Sprintf("Couldn't register to metadata service: %v\n", err))
 		return false
 	}
 
-	// initialize devices, deviceResources, provisionwatcheres & profiles
+	// initialize devices, deviceResources, provisionwatcheres & profiles cache
 	cache.InitCache()
 
-	err = common.Driver.Initialize(common.LoggingClient, svc.asyncCh, svc.deviceCh)
+	err = sdk.driver.Initialize(sdk.LoggingClient, sdk.asyncCh, sdk.deviceCh)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Driver.Initialize failed: %v\n", err)
+		lc.Error(fmt.Sprintf("Driver.Initialize failed: %v\n", err))
 		return false
 	}
-	svc.initiazlied = true
+	sdk.initialized = true
 
-	err = provision.LoadProfiles(common.CurrentConfig.Device.ProfilesDir)
+	dic.Update(di.ServiceConstructorMap{
+		container.DeviceServiceName: func(get di.Get) interface{} {
+			return sdk.deviceService
+		},
+		container.ProtocolDiscoveryName: func(get di.Get) interface{} {
+			return sdk.discovery
+		},
+		container.ProtocolDriverName: func(get di.Get) interface{} {
+			return sdk.driver
+		},
+	})
+
+	err = provision.LoadProfiles(configuration.Device.ProfilesDir)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to create the pre-defined Device Profiles: %v\n", err)
+		lc.Error(fmt.Sprintf("Failed to create the pre-defined device profiles: %v\n", err))
 		return false
 	}
 
-	err = provision.LoadDevices(common.CurrentConfig.DeviceList)
+	err = provision.LoadDevices(configuration.DeviceList)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to create the pre-defined Devices: %v\n", err)
+		lc.Error(fmt.Sprintf("Failed to create the pre-defined devices: %v\n", err))
 		return false
 	}
 
 	go autodiscovery.Run()
 	autoevent.GetManager().StartAutoEvents()
-	http.TimeoutHandler(nil, time.Millisecond*time.Duration(common.CurrentConfig.Service.Timeout), "Request timed out")
+	http.TimeoutHandler(nil, time.Millisecond*time.Duration(configuration.Service.Timeout), "Request timed out")
 
 	return true
 }

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -44,7 +44,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	common.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
 	common.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
 
-	sdk.UpdateFromContainer(b.router, dic)
+	sdk.UpdateFromContainer(dic)
 	lc := sdk.LoggingClient
 	configuration := sdk.config
 
@@ -53,7 +53,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	autoevent.NewManager(ctx, wg)
 
 	if sdk.AsyncReadings() {
-		sdk.asyncCh = make(chan *dsModels.AsyncValues, sdk.svcInfo.AsyncBufferSize)
+		sdk.asyncCh = make(chan *dsModels.AsyncValues, sdk.config.Service.AsyncBufferSize)
 		go sdk.processAsyncResults(ctx, wg)
 	}
 

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -38,12 +38,12 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 	sdkFlags.Parse(os.Args[1:])
 
 	serviceName = setServiceName(serviceName, sdkFlags.Profile())
-	sdk = &DeviceServiceSDK{}
-	sdk.Initialize(serviceName, serviceVersion, proto)
+	ds = &DeviceService{}
+	ds.Initialize(serviceName, serviceVersion, proto)
 
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
-			return sdk.config
+			return ds.config
 		},
 	})
 
@@ -54,9 +54,9 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 		ctx,
 		cancel,
 		sdkFlags,
-		sdk.ServiceName,
+		ds.ServiceName,
 		common.ConfigStemDevice+common.ConfigMajorVersion,
-		sdk.config,
+		ds.config,
 		startupTimer,
 		dic,
 		[]interfaces.BootstrapHandler{
@@ -66,7 +66,7 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 			message.NewBootstrap(serviceName, serviceVersion).BootstrapHandler,
 		})
 
-	sdk.Stop(false)
+	ds.Stop(false)
 }
 
 func setServiceName(name string, profile string) string {

--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -20,7 +20,7 @@ import (
 
 // AddDevice adds a new Device to the Device Service and Core Metadata
 // Returns new Device id or non-nil error.
-func (s *DeviceServiceSDK) AddDevice(device contract.Device) (id string, err error) {
+func (s *DeviceService) AddDevice(device contract.Device) (id string, err error) {
 	if d, ok := cache.Devices().ForName(device.Name); ok {
 		return d.Id, fmt.Errorf("name conflicted, Device %s exists", device.Name)
 	}
@@ -58,12 +58,12 @@ func (s *DeviceServiceSDK) AddDevice(device contract.Device) (id string, err err
 }
 
 // Devices return all managed Devices from cache
-func (s *DeviceServiceSDK) Devices() []contract.Device {
+func (s *DeviceService) Devices() []contract.Device {
 	return cache.Devices().All()
 }
 
 // GetDeviceByName returns the Device by its name if it exists in the cache, or returns an error.
-func (s *DeviceServiceSDK) GetDeviceByName(name string) (contract.Device, error) {
+func (s *DeviceService) GetDeviceByName(name string) (contract.Device, error) {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", name)
@@ -75,7 +75,7 @@ func (s *DeviceServiceSDK) GetDeviceByName(name string) (contract.Device, error)
 
 // RemoveDevice removes the specified Device by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceServiceSDK) RemoveDevice(id string) error {
+func (s *DeviceService) RemoveDevice(id string) error {
 	device, ok := cache.Devices().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", id)
@@ -95,7 +95,7 @@ func (s *DeviceServiceSDK) RemoveDevice(id string) error {
 
 // RemoveDevice removes the specified Device by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceServiceSDK) RemoveDeviceByName(name string) error {
+func (s *DeviceService) RemoveDeviceByName(name string) error {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", name)
@@ -115,7 +115,7 @@ func (s *DeviceServiceSDK) RemoveDeviceByName(name string) error {
 
 // UpdateDevice updates the Device in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceServiceSDK) UpdateDevice(device contract.Device) error {
+func (s *DeviceService) UpdateDevice(device contract.Device) error {
 	_, ok := cache.Devices().ForId(device.Id)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", device.Id)
@@ -135,7 +135,7 @@ func (s *DeviceServiceSDK) UpdateDevice(device contract.Device) error {
 
 // UpdateDeviceOperatingState updates the Device's OperatingState with given name
 // in Core Metadata and device service cache.
-func (s *DeviceServiceSDK) UpdateDeviceOperatingState(deviceName string, state string) error {
+func (s *DeviceService) UpdateDeviceOperatingState(deviceName string, state string) error {
 	d, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", deviceName)

--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -20,33 +20,33 @@ import (
 
 // AddDevice adds a new Device to the Device Service and Core Metadata
 // Returns new Device id or non-nil error.
-func (s *Service) AddDevice(device contract.Device) (id string, err error) {
+func (s *DeviceServiceSDK) AddDevice(device contract.Device) (id string, err error) {
 	if d, ok := cache.Devices().ForName(device.Name); ok {
 		return d.Id, fmt.Errorf("name conflicted, Device %s exists", device.Name)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Adding managed device: : %s\n", device.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Adding managed device: : %s\n", device.Name))
 
 	var prf contract.DeviceProfile
 	prf, cacheExist := cache.Profiles().ForName(device.Profile.Name)
 	if !cacheExist {
-		prf, err = common.DeviceProfileClient.DeviceProfileForName(context.Background(), device.Profile.Name)
+		prf, err = s.edgexClients.DeviceProfileClient.DeviceProfileForName(context.Background(), device.Profile.Name)
 		if err != nil {
 			errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Device %s", device.Profile.Name, device.Name)
-			common.LoggingClient.Error(errMsg)
+			s.LoggingClient.Error(errMsg)
 			return "", fmt.Errorf(errMsg)
 		}
 	}
 
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	device.Origin = millis
-	device.Service = common.CurrentDeviceService
+	device.Service = s.deviceService
 	device.Profile = prf
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	id, err = common.DeviceClient.Add(ctx, &device)
+	id, err = s.edgexClients.DeviceClient.Add(ctx, &device)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Device failed %s, error: %v", device.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Add Device failed %s, error: %v", device.Name, err))
 		return "", err
 	}
 	if err = common.VerifyIdFormat(id, "Device"); err != nil {
@@ -58,16 +58,16 @@ func (s *Service) AddDevice(device contract.Device) (id string, err error) {
 }
 
 // Devices return all managed Devices from cache
-func (s *Service) Devices() []contract.Device {
+func (s *DeviceServiceSDK) Devices() []contract.Device {
 	return cache.Devices().All()
 }
 
 // GetDeviceByName returns the Device by its name if it exists in the cache, or returns an error.
-func (s *Service) GetDeviceByName(name string) (contract.Device, error) {
+func (s *DeviceServiceSDK) GetDeviceByName(name string) (contract.Device, error) {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", name)
-		common.LoggingClient.Info(msg)
+		s.LoggingClient.Info(msg)
 		return contract.Device{}, fmt.Errorf(msg)
 	}
 	return device, nil
@@ -75,19 +75,19 @@ func (s *Service) GetDeviceByName(name string) (contract.Device, error) {
 
 // RemoveDevice removes the specified Device by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *Service) RemoveDevice(id string) error {
+func (s *DeviceServiceSDK) RemoveDevice(id string) error {
 	device, ok := cache.Devices().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceClient.Delete(ctx, id)
+	err := s.edgexClients.DeviceClient.Delete(ctx, id)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Delete Device %s from Core Metadata failed", id))
+		s.LoggingClient.Error(fmt.Sprintf("Delete Device %s from Core Metadata failed", id))
 	}
 
 	return err
@@ -95,19 +95,19 @@ func (s *Service) RemoveDevice(id string) error {
 
 // RemoveDevice removes the specified Device by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *Service) RemoveDeviceByName(name string) error {
+func (s *DeviceServiceSDK) RemoveDeviceByName(name string) error {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", name)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Removing managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceClient.DeleteByName(ctx, name)
+	err := s.edgexClients.DeviceClient.DeleteByName(ctx, name)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Delete Device %s from Core Metadata failed", name))
+		s.LoggingClient.Error(fmt.Sprintf("Delete Device %s from Core Metadata failed", name))
 	}
 
 	return err
@@ -115,19 +115,19 @@ func (s *Service) RemoveDeviceByName(name string) error {
 
 // UpdateDevice updates the Device in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *Service) UpdateDevice(device contract.Device) error {
+func (s *DeviceServiceSDK) UpdateDevice(device contract.Device) error {
 	_, ok := cache.Devices().ForId(device.Id)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", device.Id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed Device: : %s\n", device.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Updating managed Device: : %s\n", device.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceClient.Update(ctx, device)
+	err := s.edgexClients.DeviceClient.Update(ctx, device)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Update Device %s from Core Metadata failed: %v", device.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Update Device %s from Core Metadata failed: %v", device.Name, err))
 	}
 
 	return err
@@ -135,17 +135,17 @@ func (s *Service) UpdateDevice(device contract.Device) error {
 
 // UpdateDeviceOperatingState updates the Device's OperatingState with given name
 // in Core Metadata and device service cache.
-func (s *Service) UpdateDeviceOperatingState(deviceName string, state string) error {
+func (s *DeviceServiceSDK) UpdateDeviceOperatingState(deviceName string, state string) error {
 	d, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		msg := fmt.Sprintf("Device %s cannot be found in cache", deviceName)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed Device OperatingState: : %s\n", d.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Updating managed Device OperatingState: : %s\n", d.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceClient.UpdateOpState(ctx, d.Id, state)
+	err := s.edgexClients.DeviceClient.UpdateOpState(ctx, d.Id, state)
 	if err != nil {
 		common.LoggingClient.Error(fmt.Sprintf("Update Device %s OperatingState from Core Metadata failed: %v", d.Name, err))
 	}

--- a/pkg/service/managedprofiles.go
+++ b/pkg/service/managedprofiles.go
@@ -21,7 +21,7 @@ import (
 
 // AddDeviceProfile adds a new DeviceProfile to the Device Service and Core Metadata
 // Returns new DeviceProfile id or non-nil error.
-func (s *DeviceServiceSDK) AddDeviceProfile(profile contract.DeviceProfile) (id string, err error) {
+func (s *DeviceService) AddDeviceProfile(profile contract.DeviceProfile) (id string, err error) {
 	if p, ok := cache.Profiles().ForName(profile.Name); ok {
 		return p.Id, fmt.Errorf("name conflicted, Profile %s exists", profile.Name)
 	}
@@ -48,13 +48,13 @@ func (s *DeviceServiceSDK) AddDeviceProfile(profile contract.DeviceProfile) (id 
 }
 
 // DeviceProfiles return all managed DeviceProfiles from cache
-func (s *DeviceServiceSDK) DeviceProfiles() []contract.DeviceProfile {
+func (s *DeviceService) DeviceProfiles() []contract.DeviceProfile {
 	return cache.Profiles().All()
 }
 
 // RemoveDeviceProfile removes the specified DeviceProfile by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceServiceSDK) RemoveDeviceProfile(id string) error {
+func (s *DeviceService) RemoveDeviceProfile(id string) error {
 	profile, ok := cache.Profiles().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", id)
@@ -76,7 +76,7 @@ func (s *DeviceServiceSDK) RemoveDeviceProfile(id string) error {
 
 // RemoveDeviceProfileByName removes the specified DeviceProfile by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceServiceSDK) RemoveDeviceProfileByName(name string) error {
+func (s *DeviceService) RemoveDeviceProfileByName(name string) error {
 	profile, ok := cache.Profiles().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", name)
@@ -98,7 +98,7 @@ func (s *DeviceServiceSDK) RemoveDeviceProfileByName(name string) error {
 
 // UpdateDeviceProfile updates the DeviceProfile in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceServiceSDK) UpdateDeviceProfile(profile contract.DeviceProfile) error {
+func (s *DeviceService) UpdateDeviceProfile(profile contract.DeviceProfile) error {
 	_, ok := cache.Profiles().ForId(profile.Id)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", profile.Id)
@@ -122,7 +122,7 @@ func (s *DeviceServiceSDK) UpdateDeviceProfile(profile contract.DeviceProfile) e
 
 // ResourceOperation retrieves the first matched ResourceOpereation instance from cache according to
 // the Device name, Device Resource name, and the method (get or set).
-func (s *DeviceServiceSDK) ResourceOperation(deviceName string, deviceResource string, method string) (contract.ResourceOperation, bool) {
+func (s *DeviceService) ResourceOperation(deviceName string, deviceResource string, method string) (contract.ResourceOperation, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		s.LoggingClient.Error(fmt.Sprintf("retrieving ResourceOperation - Device %s not found", deviceName))
@@ -138,7 +138,7 @@ func (s *DeviceServiceSDK) ResourceOperation(deviceName string, deviceResource s
 
 // DeviceResource retrieves the specific DeviceResource instance from cache according to
 // the Device name and Device Resource name
-func (s *DeviceServiceSDK) DeviceResource(deviceName string, deviceResource string, _ string) (contract.DeviceResource, bool) {
+func (s *DeviceService) DeviceResource(deviceName string, deviceResource string, _ string) (contract.DeviceResource, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		s.LoggingClient.Error(fmt.Sprintf("retrieving DeviceResource - Device %s not found", deviceName))

--- a/pkg/service/managedprofiles.go
+++ b/pkg/service/managedprofiles.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2019 IOTech Ltd
+// Copyright (C) 2018-2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,19 +21,19 @@ import (
 
 // AddDeviceProfile adds a new DeviceProfile to the Device Service and Core Metadata
 // Returns new DeviceProfile id or non-nil error.
-func (s *Service) AddDeviceProfile(profile contract.DeviceProfile) (id string, err error) {
+func (s *DeviceServiceSDK) AddDeviceProfile(profile contract.DeviceProfile) (id string, err error) {
 	if p, ok := cache.Profiles().ForName(profile.Name); ok {
 		return p.Id, fmt.Errorf("name conflicted, Profile %s exists", profile.Name)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Adding managed Profile: : %s", profile.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Adding managed Profile: : %s", profile.Name))
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	profile.Origin = millis
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	id, err = common.DeviceProfileClient.Add(ctx, &profile)
+	id, err = s.edgexClients.DeviceProfileClient.Add(ctx, &profile)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Profile failed %s, error: %v", profile.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Add Profile failed %s, error: %v", profile.Name, err))
 		return "", err
 	}
 	if err = common.VerifyIdFormat(id, "Device Profile"); err != nil {
@@ -48,25 +48,25 @@ func (s *Service) AddDeviceProfile(profile contract.DeviceProfile) (id string, e
 }
 
 // DeviceProfiles return all managed DeviceProfiles from cache
-func (s *Service) DeviceProfiles() []contract.DeviceProfile {
+func (s *DeviceServiceSDK) DeviceProfiles() []contract.DeviceProfile {
 	return cache.Profiles().All()
 }
 
 // RemoveDeviceProfile removes the specified DeviceProfile by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *Service) RemoveDeviceProfile(id string) error {
+func (s *DeviceServiceSDK) RemoveDeviceProfile(id string) error {
 	profile, ok := cache.Profiles().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceProfileClient.Delete(ctx, id)
+	err := s.edgexClients.DeviceProfileClient.Delete(ctx, id)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Delete DeviceProfile %s from Core Metadata failed", id))
+		s.LoggingClient.Error(fmt.Sprintf("Delete DeviceProfile %s from Core Metadata failed", id))
 		return err
 	}
 
@@ -76,19 +76,19 @@ func (s *Service) RemoveDeviceProfile(id string) error {
 
 // RemoveDeviceProfileByName removes the specified DeviceProfile by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (*Service) RemoveDeviceProfileByName(name string) error {
+func (s *DeviceServiceSDK) RemoveDeviceProfileByName(name string) error {
 	profile, ok := cache.Profiles().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", name)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Removing managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceProfileClient.DeleteByName(ctx, name)
+	err := s.edgexClients.DeviceProfileClient.DeleteByName(ctx, name)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Delete DeviceProfile %s from Core Metadata failed", name))
+		s.LoggingClient.Error(fmt.Sprintf("Delete DeviceProfile %s from Core Metadata failed", name))
 		return err
 	}
 
@@ -98,19 +98,19 @@ func (*Service) RemoveDeviceProfileByName(name string) error {
 
 // UpdateDeviceProfile updates the DeviceProfile in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (*Service) UpdateDeviceProfile(profile contract.DeviceProfile) error {
+func (s *DeviceServiceSDK) UpdateDeviceProfile(profile contract.DeviceProfile) error {
 	_, ok := cache.Profiles().ForId(profile.Id)
 	if !ok {
 		msg := fmt.Sprintf("DeviceProfile %s cannot be found in cache", profile.Id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed DeviceProfile: : %s", profile.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Updating managed DeviceProfile: : %s", profile.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.DeviceProfileClient.Update(ctx, profile)
+	err := s.edgexClients.DeviceProfileClient.Update(ctx, profile)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Update DeviceProfile %s from Core Metadata failed: %v", profile.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Update DeviceProfile %s from Core Metadata failed: %v", profile.Name, err))
 		return err
 	}
 
@@ -122,15 +122,15 @@ func (*Service) UpdateDeviceProfile(profile contract.DeviceProfile) error {
 
 // ResourceOperation retrieves the first matched ResourceOpereation instance from cache according to
 // the Device name, Device Resource name, and the method (get or set).
-func (*Service) ResourceOperation(deviceName string, deviceResource string, method string) (contract.ResourceOperation, bool) {
+func (s *DeviceServiceSDK) ResourceOperation(deviceName string, deviceResource string, method string) (contract.ResourceOperation, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
-		common.LoggingClient.Error(fmt.Sprintf("retrieving ResourceOperation - Device %s not found", deviceName))
+		s.LoggingClient.Error(fmt.Sprintf("retrieving ResourceOperation - Device %s not found", deviceName))
 	}
 
 	ro, err := cache.Profiles().ResourceOperation(device.Profile.Name, deviceResource, method)
 	if err != nil {
-		common.LoggingClient.Error(err.Error())
+		s.LoggingClient.Error(err.Error())
 		return ro, false
 	}
 	return ro, true
@@ -138,10 +138,10 @@ func (*Service) ResourceOperation(deviceName string, deviceResource string, meth
 
 // DeviceResource retrieves the specific DeviceResource instance from cache according to
 // the Device name and Device Resource name
-func (*Service) DeviceResource(deviceName string, deviceResource string, _ string) (contract.DeviceResource, bool) {
+func (s *DeviceServiceSDK) DeviceResource(deviceName string, deviceResource string, _ string) (contract.DeviceResource, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
-		common.LoggingClient.Error(fmt.Sprintf("retrieving DeviceResource - Device %s not found", deviceName))
+		s.LoggingClient.Error(fmt.Sprintf("retrieving DeviceResource - Device %s not found", deviceName))
 	}
 
 	dr, ok := cache.Profiles().DeviceResource(device.Profile.Name, deviceResource)

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -19,7 +19,7 @@ import (
 
 // AddProvisionWatcher adds a new Watcher to the cache and Core Metadata
 // Returns new Watcher id or non-nil error.
-func (s *DeviceServiceSDK) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id string, err error) {
+func (s *DeviceService) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id string, err error) {
 	if pw, ok := cache.ProvisionWatchers().ForName(watcher.Name); ok {
 		return pw.Id, fmt.Errorf("name conflicted, watcher %s exists", watcher.Name)
 	}
@@ -54,12 +54,12 @@ func (s *DeviceServiceSDK) AddProvisionWatcher(watcher contract.ProvisionWatcher
 }
 
 // ProvisionWatchers return all managed Watchers from cache
-func (s *DeviceServiceSDK) ProvisionWatchers() []contract.ProvisionWatcher {
+func (s *DeviceService) ProvisionWatchers() []contract.ProvisionWatcher {
 	return cache.ProvisionWatchers().All()
 }
 
 // GetProvisionWatcherByName returns the Watcher by its name if it exists in the cache, or returns an error.
-func (s *DeviceServiceSDK) GetProvisionWatcherByName(name string) (contract.ProvisionWatcher, error) {
+func (s *DeviceService) GetProvisionWatcherByName(name string) (contract.ProvisionWatcher, error) {
 	pw, ok := cache.ProvisionWatchers().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Watcher %s cannot be found in cache", name)
@@ -71,7 +71,7 @@ func (s *DeviceServiceSDK) GetProvisionWatcherByName(name string) (contract.Prov
 
 // RemoveProvisionWatcher removes the specified Watcher by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceServiceSDK) RemoveProvisionWatcher(id string) error {
+func (s *DeviceService) RemoveProvisionWatcher(id string) error {
 	pw, ok := cache.ProvisionWatchers().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("ProvisionWatcher %s cannot be found in cache", id)
@@ -92,7 +92,7 @@ func (s *DeviceServiceSDK) RemoveProvisionWatcher(id string) error {
 
 // UpdateProvisionWatcher updates the Watcher in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceServiceSDK) UpdateProvisionWatcher(watcher contract.ProvisionWatcher) error {
+func (s *DeviceService) UpdateProvisionWatcher(watcher contract.ProvisionWatcher) error {
 	_, ok := cache.ProvisionWatchers().ForId(watcher.Id)
 	if !ok {
 		msg := fmt.Sprintf("provisionwatcher %s cannot be found in cache", watcher.Id)

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -19,17 +19,17 @@ import (
 
 // AddProvisionWatcher adds a new Watcher to the cache and Core Metadata
 // Returns new Watcher id or non-nil error.
-func (s *Service) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id string, err error) {
+func (s *DeviceServiceSDK) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id string, err error) {
 	if pw, ok := cache.ProvisionWatchers().ForName(watcher.Name); ok {
 		return pw.Id, fmt.Errorf("name conflicted, watcher %s exists", watcher.Name)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Adding managed watcher: %s\n", watcher.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Adding managed watcher: %s\n", watcher.Name))
 
 	prf, ok := cache.Profiles().ForName(watcher.Profile.Name)
 	if !ok {
 		errMsg := fmt.Sprintf("Device Profile %s doesn't exist for Watcher %s", watcher.Profile.Name, watcher.Name)
-		common.LoggingClient.Error(errMsg)
+		s.LoggingClient.Error(errMsg)
 		return "", fmt.Errorf(errMsg)
 	}
 
@@ -39,9 +39,9 @@ func (s *Service) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id str
 	watcher.Profile = prf
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	id, err = common.ProvisionWatcherClient.Add(ctx, &watcher)
+	id, err = s.edgexClients.ProvisionWatcherClient.Add(ctx, &watcher)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Watcher failed %s, error: %v", watcher.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Add Watcher failed %s, error: %v", watcher.Name, err))
 		return "", err
 	}
 	if err = common.VerifyIdFormat(id, "Watcher"); err != nil {
@@ -54,16 +54,16 @@ func (s *Service) AddProvisionWatcher(watcher contract.ProvisionWatcher) (id str
 }
 
 // ProvisionWatchers return all managed Watchers from cache
-func (s *Service) ProvisionWatchers() []contract.ProvisionWatcher {
+func (s *DeviceServiceSDK) ProvisionWatchers() []contract.ProvisionWatcher {
 	return cache.ProvisionWatchers().All()
 }
 
 // GetProvisionWatcherByName returns the Watcher by its name if it exists in the cache, or returns an error.
-func (s *Service) GetProvisionWatcherByName(name string) (contract.ProvisionWatcher, error) {
+func (s *DeviceServiceSDK) GetProvisionWatcherByName(name string) (contract.ProvisionWatcher, error) {
 	pw, ok := cache.ProvisionWatchers().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("Watcher %s cannot be found in cache", name)
-		common.LoggingClient.Info(msg)
+		s.LoggingClient.Info(msg)
 		return contract.ProvisionWatcher{}, fmt.Errorf(msg)
 	}
 	return pw, nil
@@ -71,19 +71,19 @@ func (s *Service) GetProvisionWatcherByName(name string) (contract.ProvisionWatc
 
 // RemoveProvisionWatcher removes the specified Watcher by id from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *Service) RemoveProvisionWatcher(id string) error {
+func (s *DeviceServiceSDK) RemoveProvisionWatcher(id string) error {
 	pw, ok := cache.ProvisionWatchers().ForId(id)
 	if !ok {
 		msg := fmt.Sprintf("ProvisionWatcher %s cannot be found in cache", id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Removing managed ProvisionWatcher: %s", pw.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Removing managed ProvisionWatcher: %s", pw.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.ProvisionWatcherClient.Delete(ctx, id)
+	err := s.edgexClients.ProvisionWatcherClient.Delete(ctx, id)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Delete ProvisionWatcher %s from Core Metadata failed", id))
+		s.LoggingClient.Error(fmt.Sprintf("Delete ProvisionWatcher %s from Core Metadata failed", id))
 		return err
 	}
 
@@ -92,19 +92,19 @@ func (s *Service) RemoveProvisionWatcher(id string) error {
 
 // UpdateProvisionWatcher updates the Watcher in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *Service) UpdateProvisionWatcher(watcher contract.ProvisionWatcher) error {
+func (s *DeviceServiceSDK) UpdateProvisionWatcher(watcher contract.ProvisionWatcher) error {
 	_, ok := cache.ProvisionWatchers().ForId(watcher.Id)
 	if !ok {
 		msg := fmt.Sprintf("provisionwatcher %s cannot be found in cache", watcher.Id)
-		common.LoggingClient.Error(msg)
+		s.LoggingClient.Error(msg)
 		return fmt.Errorf(msg)
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Updating managed ProvisionWatcher: %s", watcher.Name))
+	s.LoggingClient.Debug(fmt.Sprintf("Updating managed ProvisionWatcher: %s", watcher.Name))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	err := common.ProvisionWatcherClient.Update(ctx, watcher)
+	err := s.edgexClients.ProvisionWatcherClient.Update(ctx, watcher)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Update ProvisionWatcher %s from Core Metadata failed: %v", watcher.Name, err))
+		s.LoggingClient.Error(fmt.Sprintf("Update ProvisionWatcher %s from Core Metadata failed: %v", watcher.Name, err))
 		return err
 	}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -15,14 +15,20 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
+	"github.com/edgexfoundry/device-sdk-go/internal/clients"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/internal/controller"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/types"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
@@ -30,93 +36,151 @@ import (
 )
 
 var (
-	svc *Service
+	sdk *DeviceServiceSDK
 )
 
-// A Service listens for requests and routes them to the right command
-type Service struct {
-	svcInfo     *common.ServiceInfo
-	asyncCh     chan *dsModels.AsyncValues
-	deviceCh    chan []dsModels.DiscoveredDevice
-	startTime   time.Time
-	controller  controller.RestController
-	initiazlied bool
+type DeviceServiceSDK struct {
+	ServiceName    string
+	LoggingClient  logger.LoggingClient
+	registryClient registry.Client
+	edgexClients   clients.EdgeXClient
+	controller     controller.RestController
+	config         *common.ConfigurationStruct
+	svcInfo        *common.ServiceInfo
+	deviceService  contract.DeviceService
+	driver         dsModels.ProtocolDriver
+	discovery      dsModels.ProtocolDiscovery
+	asyncCh        chan *dsModels.AsyncValues
+	deviceCh       chan []dsModels.DiscoveredDevice
+	initialized    bool
+}
+
+// TODO: remove common.xxx = xxx assignment after refactor are done.
+func (s *DeviceServiceSDK) Initialize(serviceName, serviceVersion string, proto interface{}) {
+	if serviceName == "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Please specify device service name")
+		os.Exit(1)
+	}
+	common.ServiceName = serviceName
+	s.ServiceName = serviceName
+
+	if serviceVersion == "" {
+		_, _ = fmt.Fprintf(os.Stderr, "Please specify device service version")
+		os.Exit(1)
+	}
+	common.ServiceVersion = serviceVersion
+
+	if driver, ok := proto.(dsModels.ProtocolDriver); ok {
+		common.Driver = driver
+		s.driver = driver
+	} else {
+		_, _ = fmt.Fprintf(os.Stderr, "Please implement and specify the protocoldriver")
+		os.Exit(1)
+	}
+
+	if discovery, ok := proto.(dsModels.ProtocolDiscovery); ok {
+		common.Discovery = discovery
+		s.discovery = discovery
+	} else {
+		s.discovery = nil
+	}
+
+	s.config = &common.ConfigurationStruct{}
+}
+
+func (s *DeviceServiceSDK) UpdateFromContainer(r *mux.Router, dic *di.Container) {
+	s.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
+	s.registryClient = bootstrapContainer.RegistryFrom(dic.Get)
+	s.edgexClients.GeneralClient = container.MetadataGeneralClientFrom(dic.Get)
+	s.edgexClients.DeviceClient = container.MetadataDeviceClientFrom(dic.Get)
+	s.edgexClients.DeviceServiceClient = container.MetadataDeviceServiceClientFrom(dic.Get)
+	s.edgexClients.DeviceProfileClient = container.MetadataDeviceProfileClientFrom(dic.Get)
+	s.edgexClients.AddressableClient = container.MetadataAddressableClientFrom(dic.Get)
+	s.edgexClients.ProvisionWatcherClient = container.MetadataProvisionWatcherClientFrom(dic.Get)
+	s.edgexClients.EventClient = container.CoredataEventClientFrom(dic.Get)
+	s.edgexClients.ValueDescriptorClient = container.CoredataValueDescriptorClientFrom(dic.Get)
+
+	s.svcInfo = &container.ConfigurationFrom(dic.Get).Service
+	s.controller = container.RestControllerFrom(dic.Get)
 }
 
 // Name returns the name of this Device Service
-func (s *Service) Name() string {
-	return common.ServiceName
+func (s *DeviceServiceSDK) Name() string {
+	return s.ServiceName
 }
 
 // Version returns the version number of this Device Service
-func (s *Service) Version() string {
+func (s *DeviceServiceSDK) Version() string {
 	return common.ServiceVersion
 }
 
 // AsyncReadings returns a bool value to indicate whether the asynchronous reading is enabled.
-func (s *Service) AsyncReadings() bool {
-	return common.CurrentConfig.Service.EnableAsyncReadings
+func (s *DeviceServiceSDK) AsyncReadings() bool {
+	return s.config.Service.EnableAsyncReadings
 }
 
 // AddRoute allows leveraging the existing internal web server to add routes specific to Device Service.
-func (s *Service) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) error {
+func (s *DeviceServiceSDK) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) error {
 	return s.controller.AddRoute(route, handler, methods...)
 }
 
 // Stop shuts down the Service
-func (s *Service) Stop(force bool) {
-	if s.initiazlied {
+func (s *DeviceServiceSDK) Stop(force bool) {
+	if s.initialized {
+		//_ = s.driver.Stop(false)
 		_ = common.Driver.Stop(force)
 	}
 	autoevent.GetManager().StopAutoEvents()
 }
 
 // selfRegister register device service itself onto metadata.
-func selfRegister() error {
-	common.LoggingClient.Debug("Trying to find Device Service: " + common.ServiceName)
+func (s *DeviceServiceSDK) selfRegister() error {
+	s.LoggingClient.Debug("Trying to find Device Service: " + common.ServiceName)
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	ds, err := common.DeviceServiceClient.DeviceServiceForName(ctx, common.ServiceName)
+	ds, err := s.edgexClients.DeviceServiceClient.DeviceServiceForName(ctx, common.ServiceName)
 
 	if err != nil {
 		if errsc, ok := err.(types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
-			common.LoggingClient.Info(fmt.Sprintf("Device Service %s doesn't exist, creating a new one", common.ServiceName))
-			ds, err = createNewDeviceService()
+			s.LoggingClient.Info(fmt.Sprintf("Device Service %s doesn't exist, creating a new one", s.ServiceName))
+			ds, err = s.createNewDeviceService()
 		} else {
-			common.LoggingClient.Error(fmt.Sprintf("DeviceServicForName failed: %v", err))
+			s.LoggingClient.Error(fmt.Sprintf("DeviceServicForName failed: %v", err))
 			return err
 		}
 	} else {
-		common.LoggingClient.Info(fmt.Sprintf("Device Service %s exists", ds.Name))
+		s.LoggingClient.Info(fmt.Sprintf("Device Service %s exists", ds.Name))
 	}
 
-	common.LoggingClient.Debug(fmt.Sprintf("Device Service in Core MetaData: %s", common.ServiceName))
+	s.LoggingClient.Debug(fmt.Sprintf("Device Service in Core MetaData: %s", common.ServiceName))
+	s.deviceService = ds
+	// TODO: remove this after refactor are done.
 	common.CurrentDeviceService = ds
 
 	return nil
 }
 
-func createNewDeviceService() (contract.DeviceService, error) {
-	addr, err := makeNewAddressable()
+func (s *DeviceServiceSDK) createNewDeviceService() (contract.DeviceService, error) {
+	addr, err := s.makeNewAddressable()
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("makeNewAddressable failed: %v", err))
+		s.LoggingClient.Error(fmt.Sprintf("makeNewAddressable failed: %v", err))
 		return contract.DeviceService{}, err
 	}
 
 	millis := time.Now().UnixNano() / int64(time.Millisecond)
 	ds := contract.DeviceService{
-		Name:           common.ServiceName,
-		Labels:         svc.svcInfo.Labels,
-		OperatingState: "ENABLED",
+		Name:           s.ServiceName,
+		Labels:         s.svcInfo.Labels,
+		OperatingState: contract.Enabled,
 		Addressable:    *addr,
-		AdminState:     "UNLOCKED",
+		AdminState:     contract.Unlocked,
 	}
 	ds.Origin = millis
 
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	id, err := common.DeviceServiceClient.Add(ctx, &ds)
+	id, err := s.edgexClients.DeviceServiceClient.Add(ctx, &ds)
 	if err != nil {
-		common.LoggingClient.Error(fmt.Sprintf("Add Deviceservice: %s; failed: %v", common.ServiceName, err))
+		s.LoggingClient.Error(fmt.Sprintf("Add Deviceservice: %s; failed: %v", s.ServiceName, err))
 		return contract.DeviceService{}, err
 	}
 	if err = common.VerifyIdFormat(id, "Device Service"); err != nil {
@@ -131,28 +195,28 @@ func createNewDeviceService() (contract.DeviceService, error) {
 	return ds, nil
 }
 
-func makeNewAddressable() (*contract.Addressable, error) {
+func (s *DeviceServiceSDK) makeNewAddressable() (*contract.Addressable, error) {
 	// check whether there has been an existing addressable
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-	addr, err := common.AddressableClient.AddressableForName(ctx, common.ServiceName)
+	addr, err := s.edgexClients.AddressableClient.AddressableForName(ctx, s.ServiceName)
 	if err != nil {
 		if errsc, ok := err.(types.ErrServiceClient); ok && (errsc.StatusCode == http.StatusNotFound) {
-			common.LoggingClient.Info(fmt.Sprintf("Addressable %s doesn't exist, creating a new one", common.ServiceName))
+			s.LoggingClient.Info(fmt.Sprintf("Addressable %s doesn't exist, creating a new one", s.ServiceName))
 			millis := time.Now().UnixNano() / int64(time.Millisecond)
 			addr = contract.Addressable{
 				Timestamps: contract.Timestamps{
 					Origin: millis,
 				},
-				Name:       common.ServiceName,
+				Name:       s.ServiceName,
 				HTTPMethod: http.MethodPost,
 				Protocol:   common.HttpProto,
-				Address:    svc.svcInfo.Host,
-				Port:       svc.svcInfo.Port,
+				Address:    s.svcInfo.Host,
+				Port:       s.svcInfo.Port,
 				Path:       common.APICallbackRoute,
 			}
-			id, err := common.AddressableClient.Add(ctx, &addr)
+			id, err := s.edgexClients.AddressableClient.Add(ctx, &addr)
 			if err != nil {
-				common.LoggingClient.Error(fmt.Sprintf("Add addressable failed %s, error: %v", addr.Name, err))
+				s.LoggingClient.Error(fmt.Sprintf("Add addressable failed %s, error: %v", addr.Name, err))
 				return nil, err
 			}
 			if err = common.VerifyIdFormat(id, "Addressable"); err != nil {
@@ -160,32 +224,22 @@ func makeNewAddressable() (*contract.Addressable, error) {
 			}
 			addr.Id = id
 		} else {
-			common.LoggingClient.Error(fmt.Sprintf("AddressableForName failed: %v", err))
+			s.LoggingClient.Error(fmt.Sprintf("AddressableForName failed: %v", err))
 			return nil, err
 		}
 	} else {
-		common.LoggingClient.Info(fmt.Sprintf("Addressable %s exists", common.ServiceName))
+		s.LoggingClient.Info(fmt.Sprintf("Addressable %s exists", common.ServiceName))
 	}
 
 	return &addr, nil
 }
 
-func newService(dic *di.Container) *Service {
-	svc = &Service{}
-	svc.startTime = time.Now()
-	svc.svcInfo = &container.ConfigurationFrom(dic.Get).Service
-	svc.controller = container.RestControllerFrom(dic.Get)
-	svc.initiazlied = false
-
-	return svc
-}
-
 // RunningService returns the Service instance which is running
-func RunningService() *Service {
-	return svc
+func RunningService() *DeviceServiceSDK {
+	return sdk
 }
 
 // DriverConfigs retrieves the driver specific configuration
 func DriverConfigs() map[string]string {
-	return common.CurrentConfig.Driver
+	return sdk.config.Driver
 }


### PR DESCRIPTION
The first part of removing global vars refactor.

Refactor the clients package to a BootstrapHandler to inject various
clients into dic, which will be pass all over SDK in the future refactor.

Expand and rename the Service struct to DeviceServiceSDK(refer to
app-function-sdk) to avoid using global vars in service package.

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
