### PR TITLE
fix: fix device autodiscovery behavior

### DIFF
--- a/internal/autodiscovery/autodiscovery.go
+++ b/internal/autodiscovery/autodiscovery.go
@@ -28,6 +28,10 @@ func BootstrapHandler(
 	configuration := container.ConfigurationFrom(dic.Get)
 	var runDiscovery bool = true
 
+	if configuration.Device.Discovery.Enabled == false {
+		lc.Info("AutoDiscovery stopped: disabled by configuration")
+		runDiscovery = false
+	}
 	duration, err := time.ParseDuration(configuration.Device.Discovery.Interval)
 	if err != nil || duration <= 0 {
 		lc.Info("AutoDiscovery stopped: interval error in configuration")

--- a/internal/container/deviceservice.go
+++ b/internal/container/deviceservice.go
@@ -12,20 +12,30 @@ import (
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 )
 
-// DeviceServiceName contains the name of device service implementation in the DIC.
+// DeviceServiceName contains the name of device service struct in the DIC.
 var DeviceServiceName = di.TypeInstanceToName(contract.DeviceService{})
+
+// ProtocolDiscoveryName contains the name of protocol discovery implementation in the DIC.
 var ProtocolDiscoveryName = di.TypeInstanceToName((*models.ProtocolDiscovery)(nil))
+
+// ProtocolDriverName contains the name of protocol driver implementation in the DIC.
 var ProtocolDriverName = di.TypeInstanceToName((*models.ProtocolDriver)(nil))
 
-// DeviceServiceFrom helper function queries the DIC and returns device service implementation.
+// DeviceServiceFrom helper function queries the DIC and returns device service struct.
 func DeviceServiceFrom(get di.Get) contract.DeviceService {
 	return get(DeviceServiceName).(contract.DeviceService)
 }
 
+// ProtocolDiscoveryFrom helper function queries the DIC and returns protocol discovery implementation.
 func ProtocolDiscoveryFrom(get di.Get) models.ProtocolDiscovery {
-	return get(ProtocolDiscoveryName).(models.ProtocolDiscovery)
+	casted, ok := get(ProtocolDiscoveryName).(models.ProtocolDiscovery)
+	if ok {
+		return casted
+	}
+	return nil
 }
 
+// ProtocolDriverFrom helper function queries the DIC and returns protocol driver implementation.
 func ProtocolDriverFrom(get di.Get) models.ProtocolDriver {
 	return get(ProtocolDriverName).(models.ProtocolDriver)
 }


### PR DESCRIPTION
fix panic caused by not implementing ProtocolDiscovery and
add missing judgement to not start autodiscovery if disabled
in configuration

Signed-off-by: Chris Hung <chris@iotechsys.com>

this is one of the issue found in https://github.com/edgexfoundry/device-virtual-go/pull/131

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
