### PR TITLE
fix: fix autoevent panic during callback

### DIFF
--- a/internal/autoevent/manager.go
+++ b/internal/autoevent/manager.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
@@ -40,19 +39,8 @@ var (
 )
 
 // NewManager initiates the AutoEvent manager once
-func NewManager() *manager {
-	m = &manager{execsMap: make(map[string][]Executor)}
-	return m
-}
-
-func (m *manager) BootstrapHandler(
-	ctx context.Context,
-	wg *sync.WaitGroup,
-	_ startup.Timer,
-	dic *di.Container) bool {
-	m.ctx = ctx
-	m.wg = wg
-	return m.StartAutoEvents(dic)
+func NewManager(ctx context.Context, wg *sync.WaitGroup) {
+	m = &manager{execsMap: make(map[string][]Executor), ctx: ctx, wg: wg}
 }
 
 func (m *manager) StartAutoEvents(dic *di.Container) bool {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
@@ -47,6 +48,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 
 	lc := ds.LoggingClient
 	configuration := ds.config
+	autoevent.NewManager(ctx, wg)
 
 	if ds.AsyncReadings() {
 		ds.asyncCh = make(chan *dsModels.AsyncValues, configuration.Service.AsyncBufferSize)
@@ -97,6 +99,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 		return false
 	}
 
+	autoevent.GetManager().StartAutoEvents(dic)
 	http.TimeoutHandler(nil, time.Millisecond*time.Duration(configuration.Service.Timeout), "Request timed out")
 
 	return true

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/autodiscovery"
-	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
 	"github.com/edgexfoundry/device-sdk-go/internal/clients"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
@@ -63,7 +62,6 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 			httpServer.BootstrapHandler,
 			clients.NewClients().BootstrapHandler,
 			NewBootstrap(router).BootstrapHandler,
-			autoevent.NewManager().BootstrapHandler,
 			autodiscovery.BootstrapHandler,
 			message.NewBootstrap(serviceName, serviceVersion).BootstrapHandler,
 		})


### PR DESCRIPTION
Device Service callback API relies on autoevent manager to restart
autoevent for specific device, hence the manager need to at least
be initialized before the callback happening.

Revert the changes of making autoevent a BootstrapHandler and put
the logic back into DeviceService BootstrapHandler.

Signed-off-by: Chris Hung <chris@iotechsys.com>

this fix the first issue found in https://github.com/edgexfoundry/device-virtual-go/pull/131#issuecomment-694615752

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
