### PR TITLE
fix: improve device discovery flow and whitelist logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.90
 	github.com/edgexfoundry/go-mod-registry v0.1.23
 	github.com/fxamacker/cbor/v2 v2.2.0
-	github.com/google/uuid v1.1.0
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.7.1
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.5.1


### PR DESCRIPTION
Update whitelist logic to make the new device be accepted if any of its
protocol match one of provisionwatcher's identifier.

Improve the adding discovered device logic to loop through all the PWs and
correctly break out if the device is successfully added.

fix #598
fix #606

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
