### PR TITLE
feat(sdk): expose RegistryClient

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -46,7 +46,7 @@ var (
 type DeviceService struct {
 	ServiceName    string
 	LoggingClient  logger.LoggingClient
-	registryClient registry.Client
+	RegistryClient registry.Client
 	edgexClients   clients.EdgeXClients
 	controller     *controller.RestController
 	config         *common.ConfigurationStruct
@@ -89,7 +89,7 @@ func (s *DeviceService) Initialize(serviceName, serviceVersion string, proto int
 
 func (s *DeviceService) UpdateFromContainer(r *mux.Router, dic *di.Container) {
 	s.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
-	s.registryClient = bootstrapContainer.RegistryFrom(dic.Get)
+	s.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
 	s.edgexClients.GeneralClient = container.GeneralClientFrom(dic.Get)
 	s.edgexClients.DeviceClient = container.MetadataDeviceClientFrom(dic.Get)
 	s.edgexClients.DeviceServiceClient = container.MetadataDeviceServiceClientFrom(dic.Get)


### PR DESCRIPTION
registryClient was already available on DeviceService, just made it public

Signed-off-by: Alex Ullrich <alexullrich@technotects.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
registryClient is available but not exported

Issue Number:
#621 

## What is the new behavior?
RegistryClient is available and exported

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information