### PR TITLE
feat(sdk): prepare v2 cache for v2 callback api

### DIFF
--- a/internal/v2/cache/devices.go
+++ b/internal/v2/cache/devices.go
@@ -1,0 +1,176 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"fmt"
+	"sync"
+
+	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/errors"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+var (
+	dc *deviceCache
+)
+
+type DeviceCache interface {
+	ForName(name string) (contract.Device, bool)
+	ForId(id string) (contract.Device, bool)
+	All() []contract.Device
+	Add(device contract.Device) edgexErr.EdgeX
+	Update(device contract.Device) edgexErr.EdgeX
+	Remove(id string) edgexErr.EdgeX
+	RemoveByName(name string) edgexErr.EdgeX
+	UpdateAdminState(id string, state contract.AdminState) edgexErr.EdgeX
+}
+
+type deviceCache struct {
+	deviceMap map[string]*contract.Device // key is Device name
+	nameMap   map[string]string           // key is id, and value is Device name
+	mutex     sync.Mutex
+}
+
+// ForName returns a Device with the given device name.
+func (d *deviceCache) ForName(name string) (contract.Device, bool) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	device, ok := d.deviceMap[name]
+	return *device, ok
+}
+
+// ForId returns a device with the given device id.
+func (d *deviceCache) ForId(id string) (contract.Device, bool) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	name, ok := d.nameMap[id]
+	if !ok {
+		return contract.Device{}, ok
+	}
+
+	device, ok := d.deviceMap[name]
+	return *device, ok
+}
+
+// All returns the current list of devices in the cache.
+func (d *deviceCache) All() []contract.Device {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	i := 0
+	devices := make([]contract.Device, len(d.deviceMap))
+	for _, device := range d.deviceMap {
+		devices[i] = *device
+		i++
+	}
+	return devices
+}
+
+// Add adds a new device to the cache. This method is used to populate the
+// device cache with pre-existing or recently-added devices from Core Metadata.
+func (d *deviceCache) Add(device contract.Device) edgexErr.EdgeX {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	return d.add(device)
+}
+
+func (d *deviceCache) add(device contract.Device) edgexErr.EdgeX {
+	if _, ok := d.deviceMap[device.Name]; ok {
+		errMsg := fmt.Sprintf("device %s has already existed in cache", device.Name)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindDuplicateName, errMsg, nil)
+	}
+
+	d.deviceMap[device.Name] = &device
+	d.nameMap[device.Id] = device.Name
+	return nil
+}
+
+// Update updates the device in the cache
+func (d *deviceCache) Update(device contract.Device) edgexErr.EdgeX {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if err := d.remove(device.Id); err != nil {
+		return err
+	}
+
+	return d.add(device)
+}
+
+// Remove removes the specified device by id from the cache.
+func (d *deviceCache) Remove(id string) edgexErr.EdgeX {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	return d.remove(id)
+}
+
+func (d *deviceCache) remove(id string) edgexErr.EdgeX {
+	name, ok := d.nameMap[id]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find device with given id %s in cache", id)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	return d.removeByName(name)
+}
+
+// RemoveByName removes the specified device by name from the cache.
+func (d *deviceCache) RemoveByName(name string) edgexErr.EdgeX {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	return d.removeByName(name)
+}
+
+func (d *deviceCache) removeByName(name string) edgexErr.EdgeX {
+	device, ok := d.deviceMap[name]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find device %s in cache", name)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	delete(d.nameMap, device.Id)
+	delete(d.deviceMap, name)
+	return nil
+}
+
+// UpdateAdminState updates the device admin state in cache by id. This method
+// is used by the UpdateHandler to trigger update device admin state that's been
+// updated directly to Core Metadata.
+func (d *deviceCache) UpdateAdminState(id string, state contract.AdminState) edgexErr.EdgeX {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	name, ok := d.nameMap[id]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find device with given id %s in cache", id)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	d.deviceMap[name].AdminState = state
+	return nil
+}
+
+func newDeviceCache(devices []contract.Device) DeviceCache {
+	defaultSize := len(devices) * 2
+	dMap := make(map[string]*contract.Device, defaultSize)
+	nameMap := make(map[string]string, defaultSize)
+	for i, d := range devices {
+		dMap[d.Name] = &devices[i]
+		nameMap[d.Id] = d.Name
+	}
+	dc = &deviceCache{deviceMap: dMap, nameMap: nameMap}
+	return dc
+}
+
+func Devices() DeviceCache {
+	return dc
+}

--- a/internal/v2/cache/init.go
+++ b/internal/v2/cache/init.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2020 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,10 +9,7 @@ package cache
 import (
 	"sync"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
 var (
@@ -20,30 +17,13 @@ var (
 )
 
 // Init basic state for cache
-func InitV2Cache(
-	serviceName string,
-	lc logger.LoggingClient,
-	vdc coredata.ValueDescriptorClient,
-	dc metadata.DeviceClient,
-	pwc metadata.ProvisionWatcherClient) {
+func InitV2Cache() {
 	initOnce.Do(func() {
-		// TODO: uncomment when v2 core-contracts is ready.
-		//ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
-		//ds, err := dc.DevicesForServiceByName(ctx, serviceName)
-		//if err != nil {
-		//	lc.Error(fmt.Sprintf("Device cache initialization failed: %v", err))
-		//	ds = make([]contract.Device, 0)
-		//}
-
-		//dps := make([]contract.DeviceProfile, len(ds))
-		//for i, d := range ds {
-		//	dps[i] = d.Profile
-		//}
-
-		var ds []contract.Device
+		// TODO: retrieve data from metadata when v2 core-contracts is ready.
+		var ds []models.Device
 		newDeviceCache(ds)
 
-		var dps []contract.DeviceProfile
+		var dps []models.DeviceProfile
 		newProfileCache(dps)
 	})
 }

--- a/internal/v2/cache/init.go
+++ b/internal/v2/cache/init.go
@@ -1,0 +1,49 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2018-2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+var (
+	initOnce sync.Once
+)
+
+// Init basic state for cache
+func InitV2Cache(
+	serviceName string,
+	lc logger.LoggingClient,
+	vdc coredata.ValueDescriptorClient,
+	dc metadata.DeviceClient,
+	pwc metadata.ProvisionWatcherClient) {
+	initOnce.Do(func() {
+		// TODO: uncomment when v2 core-contracts is ready.
+		//ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
+		//ds, err := dc.DevicesForServiceByName(ctx, serviceName)
+		//if err != nil {
+		//	lc.Error(fmt.Sprintf("Device cache initialization failed: %v", err))
+		//	ds = make([]contract.Device, 0)
+		//}
+
+		//dps := make([]contract.DeviceProfile, len(ds))
+		//for i, d := range ds {
+		//	dps[i] = d.Profile
+		//}
+
+		var ds []contract.Device
+		newDeviceCache(ds)
+
+		var dps []contract.DeviceProfile
+		newProfileCache(dps)
+	})
+}

--- a/internal/v2/cache/profiles.go
+++ b/internal/v2/cache/profiles.go
@@ -1,0 +1,339 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/errors"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+)
+
+var (
+	pc *profileCache
+)
+
+type ProfileCache interface {
+	ForName(name string) (contract.DeviceProfile, bool)
+	ForId(id string) (contract.DeviceProfile, bool)
+	All() []contract.DeviceProfile
+	Add(profile contract.DeviceProfile) edgexErr.EdgeX
+	Update(profile contract.DeviceProfile) edgexErr.EdgeX
+	Remove(id string) edgexErr.EdgeX
+	RemoveByName(name string) edgexErr.EdgeX
+	DeviceResource(profileName string, resourceName string) (contract.DeviceResource, bool)
+	CommandExists(profileName string, cmd string, method string) (bool, edgexErr.EdgeX)
+	ResourceOperations(profileName string, cmd string, method string) ([]contract.ResourceOperation, edgexErr.EdgeX)
+	ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, edgexErr.EdgeX)
+}
+
+type profileCache struct {
+	deviceProfileMap         map[string]*contract.DeviceProfile // key is DeviceProfile name
+	nameMap                  map[string]string                  // key is id, and value is DeviceProfile name
+	deviceResourceMap        map[string]map[string]contract.DeviceResource
+	getResourceOperationsMap map[string]map[string][]contract.ResourceOperation
+	setResourceOperationsMap map[string]map[string][]contract.ResourceOperation
+	commandsMap              map[string]map[string]contract.Command
+	mutex                    sync.Mutex
+}
+
+// ForName returns a profile with the given profile name.
+func (p *profileCache) ForName(name string) (contract.DeviceProfile, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	profile, ok := p.deviceProfileMap[name]
+	return *profile, ok
+}
+
+// ForName returns a profile with the given profile id.
+func (p *profileCache) ForId(id string) (contract.DeviceProfile, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	name, ok := p.nameMap[id]
+	if !ok {
+		return contract.DeviceProfile{}, ok
+	}
+
+	profile, ok := p.deviceProfileMap[name]
+	return *profile, ok
+}
+
+// All returns the current list of profiles in the cache.
+func (p *profileCache) All() []contract.DeviceProfile {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	i := 0
+	ps := make([]contract.DeviceProfile, len(p.deviceProfileMap))
+	for _, profile := range p.deviceProfileMap {
+		ps[i] = *profile
+		i++
+	}
+	return ps
+}
+
+// Add adds a new profile to the cache. This method is used to populate the
+// profile cache with pre-existing or recently-added profiles from Core Metadata.
+func (p *profileCache) Add(profile contract.DeviceProfile) edgexErr.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.add(profile)
+}
+
+func (p *profileCache) add(profile contract.DeviceProfile) edgexErr.EdgeX {
+	if _, ok := p.deviceProfileMap[profile.Name]; ok {
+		errMsg := fmt.Sprintf("device %s has already existed in cache", profile.Name)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindDuplicateName, errMsg, nil)
+	}
+
+	p.deviceProfileMap[profile.Name] = &profile
+	p.nameMap[profile.Id] = profile.Name
+	p.deviceResourceMap[profile.Name] = deviceResourceSliceToMap(profile.DeviceResources)
+	p.getResourceOperationsMap[profile.Name], p.setResourceOperationsMap[profile.Name] = profileResourceSliceToMaps(profile.DeviceCommands)
+	p.commandsMap[profile.Name] = commandSliceToMap(profile.CoreCommands)
+	return nil
+}
+
+func deviceResourceSliceToMap(deviceResources []contract.DeviceResource) map[string]contract.DeviceResource {
+	result := make(map[string]contract.DeviceResource, len(deviceResources))
+	for _, dr := range deviceResources {
+		result[dr.Name] = dr
+	}
+
+	return result
+}
+
+func profileResourceSliceToMaps(profileResources []contract.ProfileResource) (map[string][]contract.ResourceOperation, map[string][]contract.ResourceOperation) {
+	getResult := make(map[string][]contract.ResourceOperation, len(profileResources))
+	setResult := make(map[string][]contract.ResourceOperation, len(profileResources))
+	for _, pr := range profileResources {
+		if len(pr.Get) > 0 {
+			getResult[pr.Name] = pr.Get
+		}
+		if len(pr.Set) > 0 {
+			setResult[pr.Name] = pr.Set
+		}
+	}
+
+	return getResult, setResult
+}
+
+func commandSliceToMap(commands []contract.Command) map[string]contract.Command {
+	result := make(map[string]contract.Command, len(commands))
+	for _, cmd := range commands {
+		result[cmd.Name] = cmd
+	}
+
+	return result
+}
+
+// Update updates the profile in the cache
+func (p *profileCache) Update(profile contract.DeviceProfile) edgexErr.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if err := p.remove(profile.Id); err != nil {
+		return err
+	}
+
+	return p.add(profile)
+}
+
+// Remove removes the specified profile by id from the cache.
+func (p *profileCache) Remove(id string) edgexErr.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.remove(id)
+}
+
+func (p *profileCache) remove(id string) edgexErr.EdgeX {
+	name, ok := p.nameMap[id]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile with given id %s in cache", id)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	return p.removeByName(name)
+}
+
+// RemoveByName removes the specified profile by name from the cache.
+func (p *profileCache) RemoveByName(name string) edgexErr.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.removeByName(name)
+}
+
+func (p *profileCache) removeByName(name string) edgexErr.EdgeX {
+	profile, ok := p.deviceProfileMap[name]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", name)
+		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	delete(p.deviceProfileMap, name)
+	delete(p.nameMap, profile.Id)
+	delete(p.deviceResourceMap, name)
+	delete(p.getResourceOperationsMap, name)
+	delete(p.setResourceOperationsMap, name)
+	delete(p.commandsMap, name)
+	return nil
+}
+
+// DeviceResource returns the DeviceResource with given profileName and resourceName
+func (p *profileCache) DeviceResource(profileName string, resourceName string) (contract.DeviceResource, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	drs, ok := p.deviceResourceMap[profileName]
+	if !ok {
+		return contract.DeviceResource{}, ok
+	}
+
+	dr, ok := drs[resourceName]
+	return dr, ok
+}
+
+// CommandExists returns a bool indicating whether the specified command exists for the
+// specified (by name) device. If the specified device doesn't exist, an error is returned.
+func (p *profileCache) CommandExists(profileName string, cmd string, method string) (bool, edgexErr.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	_, ok := p.deviceProfileMap[profileName]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
+		return false, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+	// Check whether cmd exists in deviceCommands.
+	var deviceCommands map[string][]contract.ResourceOperation
+	if strings.ToLower(method) == common.GetCmdMethod {
+		deviceCommands, _ = p.getResourceOperationsMap[profileName]
+	} else {
+		deviceCommands, _ = p.setResourceOperationsMap[profileName]
+	}
+
+	if _, ok := deviceCommands[cmd]; !ok {
+		errMsg := fmt.Sprintf("failed to find %s command %s in profile %s", method, cmd, profileName)
+		return false, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	return true, nil
+}
+
+// ResourceOperations returns the ResourceOperations with given command and method.
+func (p *profileCache) ResourceOperations(profileName string, cmd string, method string) ([]contract.ResourceOperation, edgexErr.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	var ok bool
+	var ros []contract.ResourceOperation
+	var rosMap map[string][]contract.ResourceOperation
+
+	if _, ok = p.deviceProfileMap[profileName]; !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
+		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	if strings.ToLower(method) == common.GetCmdMethod {
+		rosMap, ok = p.getResourceOperationsMap[profileName]
+	} else if strings.ToLower(method) == common.SetCmdMethod {
+		rosMap, ok = p.setResourceOperationsMap[profileName]
+	}
+
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find %s ResourceOperations in profile %s", method, profileName)
+		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	if ros, ok = rosMap[cmd]; !ok {
+		errMsg := fmt.Sprintf("failed to find %s command in profile %s", cmd, profileName)
+		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	return ros, nil
+}
+
+// ResourceOperation returns the first matched ResourceOperation with given deviceResource and method
+func (p *profileCache) ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, edgexErr.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	var ok bool
+	var ro contract.ResourceOperation
+	var rosMap map[string][]contract.ResourceOperation
+
+	if _, ok = p.deviceProfileMap[profileName]; !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
+		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	if strings.ToLower(method) == common.GetCmdMethod {
+		rosMap, ok = p.getResourceOperationsMap[profileName]
+	} else if strings.ToLower(method) == common.SetCmdMethod {
+		rosMap, ok = p.setResourceOperationsMap[profileName]
+	}
+
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find %s ResourceOperations in profile %s", method, profileName)
+		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+
+	if ro, ok = retrieveFirstRObyDeviceResource(rosMap, deviceResource); !ok {
+		errMsg := fmt.Sprintf("failed to find %s ResourceOpertaion with DeviceResource %s in profile %s", method, deviceResource, profileName)
+		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
+	}
+	return ro, nil
+}
+
+func retrieveFirstRObyDeviceResource(rosMap map[string][]contract.ResourceOperation, deviceResource string) (contract.ResourceOperation, bool) {
+	for _, ros := range rosMap {
+		for _, ro := range ros {
+			if ro.DeviceResource == deviceResource {
+				return ro, true
+			}
+		}
+	}
+
+	return contract.ResourceOperation{}, false
+}
+
+func newProfileCache(profiles []contract.DeviceProfile) ProfileCache {
+	defaultSize := len(profiles) * 2
+	dpMap := make(map[string]*contract.DeviceProfile, defaultSize)
+	nameMap := make(map[string]string, defaultSize)
+	drMap := make(map[string]map[string]contract.DeviceResource, defaultSize)
+	getRoMap := make(map[string]map[string][]contract.ResourceOperation, defaultSize)
+	setRoMap := make(map[string]map[string][]contract.ResourceOperation, defaultSize)
+	cmdMap := make(map[string]map[string]contract.Command, defaultSize)
+	for _, dp := range profiles {
+		dpMap[dp.Name] = &dp
+		nameMap[dp.Id] = dp.Name
+		drMap[dp.Name] = deviceResourceSliceToMap(dp.DeviceResources)
+		getRoMap[dp.Name], setRoMap[dp.Name] = profileResourceSliceToMaps(dp.DeviceCommands)
+		cmdMap[dp.Name] = commandSliceToMap(dp.CoreCommands)
+	}
+	pc = &profileCache{
+		deviceProfileMap:         dpMap,
+		nameMap:                  nameMap,
+		deviceResourceMap:        drMap,
+		getResourceOperationsMap: getRoMap,
+		setResourceOperationsMap: setRoMap,
+		commandsMap:              cmdMap}
+	return pc
+}
+
+func Profiles() ProfileCache {
+	return pc
+}

--- a/internal/v2/cache/profiles.go
+++ b/internal/v2/cache/profiles.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
-	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/errors"
-	contract "github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/errors"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
 var (
@@ -21,302 +21,37 @@ var (
 )
 
 type ProfileCache interface {
-	ForName(name string) (contract.DeviceProfile, bool)
-	ForId(id string) (contract.DeviceProfile, bool)
-	All() []contract.DeviceProfile
-	Add(profile contract.DeviceProfile) edgexErr.EdgeX
-	Update(profile contract.DeviceProfile) edgexErr.EdgeX
-	Remove(id string) edgexErr.EdgeX
-	RemoveByName(name string) edgexErr.EdgeX
-	DeviceResource(profileName string, resourceName string) (contract.DeviceResource, bool)
-	CommandExists(profileName string, cmd string, method string) (bool, edgexErr.EdgeX)
-	ResourceOperations(profileName string, cmd string, method string) ([]contract.ResourceOperation, edgexErr.EdgeX)
-	ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, edgexErr.EdgeX)
+	ForName(name string) (models.DeviceProfile, bool)
+	ForId(id string) (models.DeviceProfile, bool)
+	All() []models.DeviceProfile
+	Add(profile models.DeviceProfile) errors.EdgeX
+	Update(profile models.DeviceProfile) errors.EdgeX
+	RemoveById(id string) errors.EdgeX
+	RemoveByName(name string) errors.EdgeX
+	DeviceResource(profileName string, resourceName string) (models.DeviceResource, bool)
+	CommandExists(profileName string, cmd string, method string) (bool, errors.EdgeX)
+	ResourceOperations(profileName string, cmd string, method string) ([]models.ResourceOperation, errors.EdgeX)
+	ResourceOperation(profileName string, deviceResource string, method string) (models.ResourceOperation, errors.EdgeX)
 }
 
 type profileCache struct {
-	deviceProfileMap         map[string]*contract.DeviceProfile // key is DeviceProfile name
-	nameMap                  map[string]string                  // key is id, and value is DeviceProfile name
-	deviceResourceMap        map[string]map[string]contract.DeviceResource
-	getResourceOperationsMap map[string]map[string][]contract.ResourceOperation
-	setResourceOperationsMap map[string]map[string][]contract.ResourceOperation
-	commandsMap              map[string]map[string]contract.Command
+	deviceProfileMap         map[string]*models.DeviceProfile // key is DeviceProfile name
+	nameMap                  map[string]string                // key is id, and value is DeviceProfile name
+	deviceResourceMap        map[string]map[string]models.DeviceResource
+	getResourceOperationsMap map[string]map[string][]models.ResourceOperation
+	setResourceOperationsMap map[string]map[string][]models.ResourceOperation
+	commandsMap              map[string]map[string]models.Command
 	mutex                    sync.Mutex
 }
 
-// ForName returns a profile with the given profile name.
-func (p *profileCache) ForName(name string) (contract.DeviceProfile, bool) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	profile, ok := p.deviceProfileMap[name]
-	return *profile, ok
-}
-
-// ForName returns a profile with the given profile id.
-func (p *profileCache) ForId(id string) (contract.DeviceProfile, bool) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	name, ok := p.nameMap[id]
-	if !ok {
-		return contract.DeviceProfile{}, ok
-	}
-
-	profile, ok := p.deviceProfileMap[name]
-	return *profile, ok
-}
-
-// All returns the current list of profiles in the cache.
-func (p *profileCache) All() []contract.DeviceProfile {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	i := 0
-	ps := make([]contract.DeviceProfile, len(p.deviceProfileMap))
-	for _, profile := range p.deviceProfileMap {
-		ps[i] = *profile
-		i++
-	}
-	return ps
-}
-
-// Add adds a new profile to the cache. This method is used to populate the
-// profile cache with pre-existing or recently-added profiles from Core Metadata.
-func (p *profileCache) Add(profile contract.DeviceProfile) edgexErr.EdgeX {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	return p.add(profile)
-}
-
-func (p *profileCache) add(profile contract.DeviceProfile) edgexErr.EdgeX {
-	if _, ok := p.deviceProfileMap[profile.Name]; ok {
-		errMsg := fmt.Sprintf("device %s has already existed in cache", profile.Name)
-		return edgexErr.NewCommonEdgeX(edgexErr.KindDuplicateName, errMsg, nil)
-	}
-
-	p.deviceProfileMap[profile.Name] = &profile
-	p.nameMap[profile.Id] = profile.Name
-	p.deviceResourceMap[profile.Name] = deviceResourceSliceToMap(profile.DeviceResources)
-	p.getResourceOperationsMap[profile.Name], p.setResourceOperationsMap[profile.Name] = profileResourceSliceToMaps(profile.DeviceCommands)
-	p.commandsMap[profile.Name] = commandSliceToMap(profile.CoreCommands)
-	return nil
-}
-
-func deviceResourceSliceToMap(deviceResources []contract.DeviceResource) map[string]contract.DeviceResource {
-	result := make(map[string]contract.DeviceResource, len(deviceResources))
-	for _, dr := range deviceResources {
-		result[dr.Name] = dr
-	}
-
-	return result
-}
-
-func profileResourceSliceToMaps(profileResources []contract.ProfileResource) (map[string][]contract.ResourceOperation, map[string][]contract.ResourceOperation) {
-	getResult := make(map[string][]contract.ResourceOperation, len(profileResources))
-	setResult := make(map[string][]contract.ResourceOperation, len(profileResources))
-	for _, pr := range profileResources {
-		if len(pr.Get) > 0 {
-			getResult[pr.Name] = pr.Get
-		}
-		if len(pr.Set) > 0 {
-			setResult[pr.Name] = pr.Set
-		}
-	}
-
-	return getResult, setResult
-}
-
-func commandSliceToMap(commands []contract.Command) map[string]contract.Command {
-	result := make(map[string]contract.Command, len(commands))
-	for _, cmd := range commands {
-		result[cmd.Name] = cmd
-	}
-
-	return result
-}
-
-// Update updates the profile in the cache
-func (p *profileCache) Update(profile contract.DeviceProfile) edgexErr.EdgeX {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	if err := p.remove(profile.Id); err != nil {
-		return err
-	}
-
-	return p.add(profile)
-}
-
-// Remove removes the specified profile by id from the cache.
-func (p *profileCache) Remove(id string) edgexErr.EdgeX {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	return p.remove(id)
-}
-
-func (p *profileCache) remove(id string) edgexErr.EdgeX {
-	name, ok := p.nameMap[id]
-	if !ok {
-		errMsg := fmt.Sprintf("failed to find profile with given id %s in cache", id)
-		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	return p.removeByName(name)
-}
-
-// RemoveByName removes the specified profile by name from the cache.
-func (p *profileCache) RemoveByName(name string) edgexErr.EdgeX {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	return p.removeByName(name)
-}
-
-func (p *profileCache) removeByName(name string) edgexErr.EdgeX {
-	profile, ok := p.deviceProfileMap[name]
-	if !ok {
-		errMsg := fmt.Sprintf("failed to find profile %s in cache", name)
-		return edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	delete(p.deviceProfileMap, name)
-	delete(p.nameMap, profile.Id)
-	delete(p.deviceResourceMap, name)
-	delete(p.getResourceOperationsMap, name)
-	delete(p.setResourceOperationsMap, name)
-	delete(p.commandsMap, name)
-	return nil
-}
-
-// DeviceResource returns the DeviceResource with given profileName and resourceName
-func (p *profileCache) DeviceResource(profileName string, resourceName string) (contract.DeviceResource, bool) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	drs, ok := p.deviceResourceMap[profileName]
-	if !ok {
-		return contract.DeviceResource{}, ok
-	}
-
-	dr, ok := drs[resourceName]
-	return dr, ok
-}
-
-// CommandExists returns a bool indicating whether the specified command exists for the
-// specified (by name) device. If the specified device doesn't exist, an error is returned.
-func (p *profileCache) CommandExists(profileName string, cmd string, method string) (bool, edgexErr.EdgeX) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	_, ok := p.deviceProfileMap[profileName]
-	if !ok {
-		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
-		return false, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-	// Check whether cmd exists in deviceCommands.
-	var deviceCommands map[string][]contract.ResourceOperation
-	if strings.ToLower(method) == common.GetCmdMethod {
-		deviceCommands, _ = p.getResourceOperationsMap[profileName]
-	} else {
-		deviceCommands, _ = p.setResourceOperationsMap[profileName]
-	}
-
-	if _, ok := deviceCommands[cmd]; !ok {
-		errMsg := fmt.Sprintf("failed to find %s command %s in profile %s", method, cmd, profileName)
-		return false, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	return true, nil
-}
-
-// ResourceOperations returns the ResourceOperations with given command and method.
-func (p *profileCache) ResourceOperations(profileName string, cmd string, method string) ([]contract.ResourceOperation, edgexErr.EdgeX) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	var ok bool
-	var ros []contract.ResourceOperation
-	var rosMap map[string][]contract.ResourceOperation
-
-	if _, ok = p.deviceProfileMap[profileName]; !ok {
-		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
-		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	if strings.ToLower(method) == common.GetCmdMethod {
-		rosMap, ok = p.getResourceOperationsMap[profileName]
-	} else if strings.ToLower(method) == common.SetCmdMethod {
-		rosMap, ok = p.setResourceOperationsMap[profileName]
-	}
-
-	if !ok {
-		errMsg := fmt.Sprintf("failed to find %s ResourceOperations in profile %s", method, profileName)
-		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	if ros, ok = rosMap[cmd]; !ok {
-		errMsg := fmt.Sprintf("failed to find %s command in profile %s", cmd, profileName)
-		return nil, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	return ros, nil
-}
-
-// ResourceOperation returns the first matched ResourceOperation with given deviceResource and method
-func (p *profileCache) ResourceOperation(profileName string, deviceResource string, method string) (contract.ResourceOperation, edgexErr.EdgeX) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	var ok bool
-	var ro contract.ResourceOperation
-	var rosMap map[string][]contract.ResourceOperation
-
-	if _, ok = p.deviceProfileMap[profileName]; !ok {
-		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
-		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	if strings.ToLower(method) == common.GetCmdMethod {
-		rosMap, ok = p.getResourceOperationsMap[profileName]
-	} else if strings.ToLower(method) == common.SetCmdMethod {
-		rosMap, ok = p.setResourceOperationsMap[profileName]
-	}
-
-	if !ok {
-		errMsg := fmt.Sprintf("failed to find %s ResourceOperations in profile %s", method, profileName)
-		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-
-	if ro, ok = retrieveFirstRObyDeviceResource(rosMap, deviceResource); !ok {
-		errMsg := fmt.Sprintf("failed to find %s ResourceOpertaion with DeviceResource %s in profile %s", method, deviceResource, profileName)
-		return ro, edgexErr.NewCommonEdgeX(edgexErr.KindInvalidId, errMsg, nil)
-	}
-	return ro, nil
-}
-
-func retrieveFirstRObyDeviceResource(rosMap map[string][]contract.ResourceOperation, deviceResource string) (contract.ResourceOperation, bool) {
-	for _, ros := range rosMap {
-		for _, ro := range ros {
-			if ro.DeviceResource == deviceResource {
-				return ro, true
-			}
-		}
-	}
-
-	return contract.ResourceOperation{}, false
-}
-
-func newProfileCache(profiles []contract.DeviceProfile) ProfileCache {
-	defaultSize := len(profiles) * 2
-	dpMap := make(map[string]*contract.DeviceProfile, defaultSize)
+func newProfileCache(profiles []models.DeviceProfile) ProfileCache {
+	defaultSize := len(profiles)
+	dpMap := make(map[string]*models.DeviceProfile, defaultSize)
 	nameMap := make(map[string]string, defaultSize)
-	drMap := make(map[string]map[string]contract.DeviceResource, defaultSize)
-	getRoMap := make(map[string]map[string][]contract.ResourceOperation, defaultSize)
-	setRoMap := make(map[string]map[string][]contract.ResourceOperation, defaultSize)
-	cmdMap := make(map[string]map[string]contract.Command, defaultSize)
+	drMap := make(map[string]map[string]models.DeviceResource, defaultSize)
+	getRoMap := make(map[string]map[string][]models.ResourceOperation, defaultSize)
+	setRoMap := make(map[string]map[string][]models.ResourceOperation, defaultSize)
+	cmdMap := make(map[string]map[string]models.Command, defaultSize)
 	for _, dp := range profiles {
 		dpMap[dp.Name] = &dp
 		nameMap[dp.Id] = dp.Name
@@ -332,6 +67,270 @@ func newProfileCache(profiles []contract.DeviceProfile) ProfileCache {
 		setResourceOperationsMap: setRoMap,
 		commandsMap:              cmdMap}
 	return pc
+}
+
+// ForName returns a profile with the given profile name.
+func (p *profileCache) ForName(name string) (models.DeviceProfile, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	profile, ok := p.deviceProfileMap[name]
+	return *profile, ok
+}
+
+// ForName returns a profile with the given profile id.
+func (p *profileCache) ForId(id string) (models.DeviceProfile, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	name, ok := p.nameMap[id]
+	if !ok {
+		return models.DeviceProfile{}, ok
+	}
+
+	profile, ok := p.deviceProfileMap[name]
+	return *profile, ok
+}
+
+// All returns the current list of profiles in the cache.
+func (p *profileCache) All() []models.DeviceProfile {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	i := 0
+	ps := make([]models.DeviceProfile, len(p.deviceProfileMap))
+	for _, profile := range p.deviceProfileMap {
+		ps[i] = *profile
+		i++
+	}
+	return ps
+}
+
+// Add adds a new profile to the cache. This method is used to populate the
+// profile cache with pre-existing or recently-added profiles from Core Metadata.
+func (p *profileCache) Add(profile models.DeviceProfile) errors.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.add(profile)
+}
+
+func (p *profileCache) add(profile models.DeviceProfile) errors.EdgeX {
+	if _, ok := p.deviceProfileMap[profile.Name]; ok {
+		errMsg := fmt.Sprintf("device %s has already existed in cache", profile.Name)
+		return errors.NewCommonEdgeX(errors.KindDuplicateName, errMsg, nil)
+	}
+
+	p.deviceProfileMap[profile.Name] = &profile
+	p.nameMap[profile.Id] = profile.Name
+	p.deviceResourceMap[profile.Name] = deviceResourceSliceToMap(profile.DeviceResources)
+	p.getResourceOperationsMap[profile.Name], p.setResourceOperationsMap[profile.Name] = profileResourceSliceToMaps(profile.DeviceCommands)
+	p.commandsMap[profile.Name] = commandSliceToMap(profile.CoreCommands)
+	return nil
+}
+
+func deviceResourceSliceToMap(deviceResources []models.DeviceResource) map[string]models.DeviceResource {
+	result := make(map[string]models.DeviceResource, len(deviceResources))
+	for _, dr := range deviceResources {
+		result[dr.Name] = dr
+	}
+
+	return result
+}
+
+func profileResourceSliceToMaps(profileResources []models.ProfileResource) (map[string][]models.ResourceOperation, map[string][]models.ResourceOperation) {
+	getResult := make(map[string][]models.ResourceOperation, len(profileResources))
+	setResult := make(map[string][]models.ResourceOperation, len(profileResources))
+	for _, pr := range profileResources {
+		if len(pr.Get) > 0 {
+			getResult[pr.Name] = pr.Get
+		}
+		if len(pr.Set) > 0 {
+			setResult[pr.Name] = pr.Set
+		}
+	}
+
+	return getResult, setResult
+}
+
+func commandSliceToMap(commands []models.Command) map[string]models.Command {
+	result := make(map[string]models.Command, len(commands))
+	for _, cmd := range commands {
+		result[cmd.Name] = cmd
+	}
+
+	return result
+}
+
+// Update updates the profile in the cache
+func (p *profileCache) Update(profile models.DeviceProfile) errors.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if err := p.removeById(profile.Id); err != nil {
+		return err
+	}
+
+	return p.add(profile)
+}
+
+// RemoveById removes the specified profile by id from the cache.
+func (p *profileCache) RemoveById(id string) errors.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.removeById(id)
+}
+
+func (p *profileCache) removeById(id string) errors.EdgeX {
+	name, ok := p.nameMap[id]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile with given id %s in cache", id)
+		return errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+
+	return p.removeByName(name)
+}
+
+// RemoveByName removes the specified profile by name from the cache.
+func (p *profileCache) RemoveByName(name string) errors.EdgeX {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return p.removeByName(name)
+}
+
+func (p *profileCache) removeByName(name string) errors.EdgeX {
+	profile, ok := p.deviceProfileMap[name]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", name)
+		return errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+
+	delete(p.deviceProfileMap, name)
+	delete(p.nameMap, profile.Id)
+	delete(p.deviceResourceMap, name)
+	delete(p.getResourceOperationsMap, name)
+	delete(p.setResourceOperationsMap, name)
+	delete(p.commandsMap, name)
+	return nil
+}
+
+// DeviceResource returns the DeviceResource with given profileName and resourceName
+func (p *profileCache) DeviceResource(profileName string, resourceName string) (models.DeviceResource, bool) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	drs, ok := p.deviceResourceMap[profileName]
+	if !ok {
+		return models.DeviceResource{}, ok
+	}
+
+	dr, ok := drs[resourceName]
+	return dr, ok
+}
+
+// CommandExists returns a bool indicating whether the specified command exists for the
+// specified (by name) device. If the specified device doesn't exist, an error is returned.
+func (p *profileCache) CommandExists(profileName string, cmd string, method string) (bool, errors.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	_, ok := p.deviceProfileMap[profileName]
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
+		return false, errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+	// Check whether cmd exists in deviceCommands.
+	var deviceCommands map[string][]models.ResourceOperation
+	if strings.ToLower(method) == common.GetCmdMethod {
+		deviceCommands, _ = p.getResourceOperationsMap[profileName]
+	} else {
+		deviceCommands, _ = p.setResourceOperationsMap[profileName]
+	}
+
+	if _, ok := deviceCommands[cmd]; !ok {
+		errMsg := fmt.Sprintf("failed to find %s command %s in profile %s", method, cmd, profileName)
+		return false, errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+
+	return true, nil
+}
+
+// ResourceOperations returns the ResourceOperations with given command and method.
+func (p *profileCache) ResourceOperations(profileName string, cmd string, method string) ([]models.ResourceOperation, errors.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if err := p.verifyProfileExists(profileName); err != nil {
+		return nil, err
+	}
+
+	rosMap, err := p.verifyResourceOperationsExists(method, profileName)
+	if err != nil {
+		return nil, err
+	}
+
+	var ok bool
+	var ros []models.ResourceOperation
+	if ros, ok = rosMap[cmd]; !ok {
+		errMsg := fmt.Sprintf("failed to find %s command in profile %s", cmd, profileName)
+		return nil, errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+
+	return ros, nil
+}
+
+// ResourceOperation returns the first matched ResourceOperation with given deviceResource and method
+func (p *profileCache) ResourceOperation(profileName string, deviceResource string, method string) (models.ResourceOperation, errors.EdgeX) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if err := p.verifyProfileExists(profileName); err != nil {
+		return models.ResourceOperation{}, err
+	}
+
+	rosMap, err := p.verifyResourceOperationsExists(method, profileName)
+	if err != nil {
+		return models.ResourceOperation{}, err
+	}
+
+	for _, ros := range rosMap {
+		for _, ro := range ros {
+			if ro.DeviceResource == deviceResource {
+				return ro, nil
+			}
+		}
+	}
+
+	errMsg := fmt.Sprintf("failed to find %s ResourceOpertaion with DeviceResource %s in profile %s", method, deviceResource, profileName)
+	return models.ResourceOperation{}, errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+}
+
+func (p *profileCache) verifyProfileExists(profileName string) errors.EdgeX {
+	if _, ok := p.deviceProfileMap[profileName]; !ok {
+		errMsg := fmt.Sprintf("failed to find profile %s in cache", profileName)
+		return errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+	return nil
+}
+
+func (p *profileCache) verifyResourceOperationsExists(method string, profileName string) (map[string][]models.ResourceOperation, errors.EdgeX) {
+	var ok bool
+	var rosMap map[string][]models.ResourceOperation
+
+	if strings.ToLower(method) == common.GetCmdMethod {
+		rosMap, ok = p.getResourceOperationsMap[profileName]
+	} else if strings.ToLower(method) == common.SetCmdMethod {
+		rosMap, ok = p.setResourceOperationsMap[profileName]
+	}
+
+	if !ok {
+		errMsg := fmt.Sprintf("failed to find %s ResourceOperations in profile %s", method, profileName)
+		return rosMap, errors.NewCommonEdgeX(errors.KindInvalidId, errMsg, nil)
+	}
+
+	return rosMap, nil
 }
 
 func Profiles() ProfileCache {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -17,6 +17,7 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/internal/provision"
+	v2cache "github.com/edgexfoundry/device-sdk-go/internal/v2/cache"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
@@ -52,6 +53,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 		container.CoredataValueDescriptorClientFrom(dic.Get),
 		container.MetadataDeviceClientFrom(dic.Get),
 		container.MetadataProvisionWatcherClientFrom(dic.Get))
+	v2cache.InitV2Cache()
 
 	if ds.AsyncReadings() {
 		ds.asyncCh = make(chan *dsModels.AsyncValues, ds.config.Service.AsyncBufferSize)


### PR DESCRIPTION
the implementation is almost identical to v1cache except updating the
models to v2models. Also update the return error to edgexErr.Edgex type
for better trace/debug in the future.

note that the provisionwatcher and valuedscriptor are not yet ready in
core-contracts so we skip their corresponding cache.

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
