### PR TITLE
feat(sdk): start auto-discovery upon service startup

### DIFF
--- a/internal/autodiscovery/autodiscovery.go
+++ b/internal/autodiscovery/autodiscovery.go
@@ -8,6 +8,7 @@ package autodiscovery
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -46,12 +47,13 @@ func BootstrapHandler(
 			wg.Add(1)
 			defer wg.Done()
 
+			lc.Info(fmt.Sprintf("Starting auto-discovery with duration %v", duration))
+			DiscoveryWrapper(discovery, lc)
 			for {
 				select {
 				case <-ctx.Done():
 					return
 				case <-time.After(duration):
-					lc.Debug("Auto-discovery triggered")
 					DiscoveryWrapper(discovery, lc)
 				}
 			}

--- a/internal/autodiscovery/discovery.go
+++ b/internal/autodiscovery/discovery.go
@@ -31,7 +31,7 @@ func DiscoveryWrapper(discovery dsModels.ProtocolDiscovery, lc logger.LoggingCli
 	locker.busy = true
 	locker.mux.Unlock()
 
-	lc.Info(fmt.Sprintf("device discovery triggered"))
+	lc.Debug(fmt.Sprintf("protocol discovery triggered"))
 	discovery.Discover()
 
 	// ReleaseLock

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -34,7 +34,6 @@ import (
 func (s *DeviceService) processAsyncResults(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer func() {
-		close(s.asyncCh)
 		wg.Done()
 	}()
 
@@ -113,7 +112,6 @@ func (s *DeviceService) sendAsyncValues(acv *dsModels.AsyncValues, working chan 
 func (s *DeviceService) processAsyncFilterAndAdd(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	defer func() {
-		close(s.deviceCh)
 		wg.Done()
 	}()
 	for {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -60,7 +60,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 		go ds.processAsyncResults(ctx, wg)
 	}
 	if ds.DeviceDiscovery() {
-		ds.deviceCh = make(chan []dsModels.DiscoveredDevice)
+		ds.deviceCh = make(chan []dsModels.DiscoveredDevice, 1)
 		go ds.processAsyncFilterAndAdd(ctx, wg)
 	}
 


### PR DESCRIPTION
trigger auto-discovery on service startup, make the following changes
to avoid potential panic:
- remove closing channel call in receiver to avoid panic caused by driver
sending discovered device to closed channel.
- update deviceCh to be unbuffered so that the auto-discovery goroutine
won't be blocked

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: fix #547 
