### PR TITLE
fix(sdk): prevent creating duplicate autoevent executor

### DIFF
--- a/internal/autoevent/executor_test.go
+++ b/internal/autoevent/executor_test.go
@@ -26,24 +26,24 @@ func TestCompareReadings(t *testing.T) {
 	if err != nil {
 		t.Errorf("Autoevent executor creation failed: %v", err)
 	}
-	resultFalse := compareReadings(e.(*executor), readings, true, lc)
+	resultFalse := compareReadings(&e, readings, true, lc)
 	if resultFalse {
 		t.Error("compare readings with cache failed, the result should be false in the first place")
 	}
 
 	readings[1] = contract.Reading{Name: "Humidity", Value: "51"}
-	resultFalse = compareReadings(e.(*executor), readings, true, lc)
+	resultFalse = compareReadings(&e, readings, true, lc)
 	if resultFalse {
 		t.Error("compare readings with cache failed, the result should be false")
 	}
 
 	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is not a image")}
-	resultFalse = compareReadings(e.(*executor), readings, true, lc)
+	resultFalse = compareReadings(&e, readings, true, lc)
 	if resultFalse {
 		t.Error("compare readings with cache failed, the result should be false")
 	}
 
-	resultTrue := compareReadings(e.(*executor), readings, true, lc)
+	resultTrue := compareReadings(&e, readings, true, lc)
 	if !resultTrue {
 		t.Error("compare readings with cache failed, the result should be true with unchanged readings")
 	}
@@ -53,24 +53,24 @@ func TestCompareReadings(t *testing.T) {
 		t.Errorf("Autoevent executor creation failed: %v", err)
 	}
 	// This scenario should not happen in real case
-	resultFalse = compareReadings(e.(*executor), readings, false, lc)
+	resultFalse = compareReadings(&e, readings, false, lc)
 	if resultFalse {
 		t.Error("compare readings with cache failed, the result should be false in the first place")
 	}
 
 	readings[0] = contract.Reading{Name: "Temperature", Value: "20"}
-	resultFalse = compareReadings(e.(*executor), readings, false, lc)
+	resultFalse = compareReadings(&e, readings, false, lc)
 	if resultFalse {
 		t.Error("compare readings with cache failed, the result should be false")
 	}
 
 	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is a image")}
-	resultTrue = compareReadings(e.(*executor), readings, false, lc)
+	resultTrue = compareReadings(&e, readings, false, lc)
 	if !resultTrue {
 		t.Error("compare readings with cache failed, the result should always be true in such scenario")
 	}
 
-	resultTrue = compareReadings(e.(*executor), readings, false, lc)
+	resultTrue = compareReadings(&e, readings, false, lc)
 	if !resultTrue {
 		t.Error("compare readings with cache failed, the result should be true with unchanged readings")
 	}


### PR DESCRIPTION
add check in StartAutoEvents function to avoid creating duplicate
autoevent executor and do some refactoring on autoevent package to
make it more readable

Signed-off-by: Chris Hung <chris@iotechsys.com>

fix #596 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:
