### PR TITLE
feat(sdk): Implement Device AutoEvents SDK APIs

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -38,7 +38,7 @@ func NewBootstrap(router *mux.Router) *Bootstrap {
 
 func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) (success bool) {
 	ds.UpdateFromContainer(b.router, dic)
-	autoevent.NewManager(ctx, wg, ds.config.Service.AsyncBufferSize)
+	autoevent.NewManager(ctx, wg, ds.config.Service.AsyncBufferSize, dic)
 
 	err := ds.selfRegister()
 	if err != nil {

--- a/pkg/service/managedautoevents.go
+++ b/pkg/service/managedautoevents.go
@@ -1,0 +1,69 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 VMware
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
+	"github.com/edgexfoundry/device-sdk-go/internal/cache"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+)
+
+// AddDeviceAutoEvent adds a new AutoEvent to the Device with given name
+func (s *DeviceService) AddDeviceAutoEvent(deviceName string, event contract.AutoEvent) error {
+	found := false
+	device, ok := cache.Devices().ForName(deviceName)
+	if !ok {
+		msg := fmt.Sprintf("Device %s cannot be found in cache", deviceName)
+		s.LoggingClient.Error(msg)
+		return fmt.Errorf(msg)
+	}
+
+	for _, e := range device.AutoEvents {
+		if e.Resource == event.Resource {
+			s.LoggingClient.Debug(fmt.Sprintf("Updating existing auto event %s for device %s\n", e.Resource, deviceName))
+			e.Frequency = event.Frequency
+			e.OnChange = event.OnChange
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		s.LoggingClient.Debug(fmt.Sprintf("Adding new auto event to device %s: %v\n", deviceName, event))
+		device.AutoEvents = append(device.AutoEvents, event)
+		cache.Devices().Update(device)
+	}
+
+	autoevent.GetManager().RestartForDevice(deviceName, nil)
+
+	return nil
+}
+
+// RemoveDeviceAutoEvent removes an AutoEvent from the Device with given name
+func (s *DeviceService) RemoveDeviceAutoEvent(deviceName string, event contract.AutoEvent) error {
+	device, ok := cache.Devices().ForName(deviceName)
+	if !ok {
+		msg := fmt.Sprintf("Device %s cannot be found in cache", deviceName)
+		s.LoggingClient.Error(msg)
+		return fmt.Errorf(msg)
+	}
+
+	autoevent.GetManager().StopForDevice(deviceName)
+	for i, e := range device.AutoEvents {
+		if e.Resource == event.Resource {
+			s.LoggingClient.Debug(fmt.Sprintf("Removing auto event %s for device %s\n", e.Resource, deviceName))
+			device.AutoEvents = append(device.AutoEvents[:i], device.AutoEvents[i+1:]...)
+			break
+		}
+	}
+	cache.Devices().Update(device)
+	autoevent.GetManager().RestartForDevice(deviceName, nil)
+
+	return nil
+}


### PR DESCRIPTION
When an auto discovery is used to find attached devices, there is no
easy way to attach an auto event to a newly discovered device.
Proposed new SDK APIs solve that problem. They can be used to add or
remove auto events from devices, from the Device Service context.

Resolves: #647
Signed-off-by: Tzvetomir Stoyanov (VMware)  <tz.stoyanov@gmail.com>