### PR TITLE
feat: add v1 deviceService callback handler

### DIFF
--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -46,6 +46,11 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, dic *di.Containe
 			if e.stop {
 				return
 			}
+			ds := container.DeviceServiceFrom(dic.Get)
+			if ds.AdminState == contract.Locked {
+				lc.Info("AutoEvent - stopped for locked device service")
+				return
+			}
 
 			lc.Debug(fmt.Sprintf("AutoEvent - executing %v", e.autoEvent))
 			evt, appErr := readResource(e, dic)

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -93,10 +93,6 @@ func (c *RestController) transformFunc(w http.ResponseWriter, req *http.Request)
 }
 
 func (c *RestController) callbackFunc(w http.ResponseWriter, req *http.Request) {
-	if c.checkServiceLocked(w, req, container.DeviceServiceFrom(c.dic.Get).AdminState) {
-		return
-	}
-
 	defer req.Body.Close()
 	dec := json.NewDecoder(req.Body)
 	cbAlert := contract.CallbackAlert{}

--- a/internal/handler/callback/general.go
+++ b/internal/handler/callback/general.go
@@ -27,6 +27,8 @@ func CallbackHandler(cbAlert contract.CallbackAlert, method string, dic *di.Cont
 
 	if cbAlert.ActionType == contract.DEVICE {
 		return handleDevice(method, cbAlert.Id, dic)
+	} else if cbAlert.ActionType == contract.SERVICE {
+		return handleService(method, cbAlert.Id, dic)
 	} else if cbAlert.ActionType == contract.PROFILE {
 		return handleProfile(method, cbAlert.Id, dic)
 	} else if cbAlert.ActionType == contract.PROVISIONWATCHER {

--- a/internal/handler/callback/service.go
+++ b/internal/handler/callback/service.go
@@ -1,0 +1,58 @@
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package callback
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+	"github.com/google/uuid"
+)
+
+func handleService(method string, id string, dic *di.Container) common.AppError {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.New().String())
+	switch method {
+	case http.MethodPut:
+		handleUpdateService(ctx, id, dic)
+	default:
+		lc.Error(fmt.Sprintf("Invalid service method type: %s", method))
+		appErr := common.NewBadRequestError("Invalid service method", nil)
+		return appErr
+	}
+
+	return nil
+}
+
+func handleUpdateService(ctx context.Context, _ string, dic *di.Container) common.AppError {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	dsc := container.MetadataDeviceServiceClientFrom(dic.Get)
+	ds := container.DeviceServiceFrom(dic.Get)
+
+	// v1 DeviceServiceClient doesn't support DeviceServiceForId. Use name instead
+	// for the minimum development effort purpose. (assuming device service name won't
+	// be updated)
+	service, err := dsc.DeviceServiceForName(ctx, ds.Name)
+	if err != nil {
+		appErr := common.NewBadRequestError(err.Error(), err)
+		lc.Error(fmt.Sprintf("Cannot find DeviceService %s from Core Metadata: %v", ds.Name, err))
+		return appErr
+	}
+
+	ds.AdminState = service.AdminState
+	dic.Update(di.ServiceConstructorMap{
+		container.DeviceServiceName: func(get di.Get) interface{} {
+			return ds
+		},
+	})
+
+	return nil
+}


### PR DESCRIPTION
fix #651 

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Committing+Code+Guidelines#CommittingCodeGuidelines-CommitMessages
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

DeviceService AdminState would be successfully updated by callback handler and autoevents would stop executing on Locked AdminState.

Also remove the AdminState check for callback api route so that DeviceService will keep syncing with metadata even if it's in Locked state. (otherwise DeviceService will not be able to unlock once it's locked)

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
