### PR TITLE
feat: Make the numeric value type allows overflow and NaN

### DIFF
--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -48,9 +48,6 @@ https://github.com/google/uuid/blob/master/LICENSE
 edgexfoundry/edgex-go (Apache 2.0) https://github.com/edgexfoundry/edgex-go
 https://github.com/edgexfoundry/edgex-go/blob/master/LICENSE
 
-pkg/errors (BSD-2) https://github.com/pkg/errors
-https://github.com/pkg/errors/blob/master/LICENSE
-
 jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
 https://github.com/jessevdk/go-flags/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/internal/mock/consts.go
+++ b/internal/mock/consts.go
@@ -38,4 +38,6 @@ const (
 	ResourceObjectFloat32     = "RandomValue_Float32"
 	ResourceObjectFloat64     = "RandomValue_Float64"
 	ResourceObjectRandFloat32 = "randfloat32"
+	ResourceObjectNaNFloat32  = "NaN_Float32"
+	ResourceObjectNaNFloat64  = "NaN_Float64"
 )

--- a/internal/mock/data/deviceprofile/Random-Float-Generator.json
+++ b/internal/mock/data/deviceprofile/Random-Float-Generator.json
@@ -75,6 +75,40 @@
           "defaultValue": "random float64 value"
         }
       }
+    },
+    {
+      "description": "Generate NaN float32 value",
+      "name": "NaN_Float32",
+      "properties": {
+        "value": {
+          "type": "Float32",
+          "readWrite": "R",
+          "defaultValue": "0",
+          "floatEncoding": "eNotation"
+        },
+        "units": {
+          "type": "String",
+          "readWrite": "R",
+          "defaultValue": "NaN float32 value"
+        }
+      }
+    },
+    {
+      "description": "Generate NaN float64 value",
+      "name": "NaN_Float64",
+      "properties": {
+        "value": {
+          "type": "Float64",
+          "readWrite": "R",
+          "defaultValue": "0",
+          "floatEncoding": "eNotation"
+        },
+        "units": {
+          "type": "String",
+          "readWrite": "R",
+          "defaultValue": "NaN float64 value"
+        }
+      }
     }
   ],
   "deviceCommands": [
@@ -117,6 +151,24 @@
           "operation": "set",
           "deviceResource": "EnableRandomization_Float64",
           "parameter": "false"
+        }
+      ]
+    },
+    {
+      "name": "NaN_Float32",
+      "get": [
+        {
+          "operation": "get",
+          "deviceResource": "NaN_Float32"
+        }
+      ]
+    },
+    {
+      "name": "NaN_Float64",
+      "get": [
+        {
+          "operation": "get",
+          "deviceResource": "NaN_Float64"
         }
       ]
     }

--- a/internal/mock/mock_devicevirtualdriver.go
+++ b/internal/mock/mock_devicevirtualdriver.go
@@ -8,6 +8,7 @@ package mock
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -56,9 +57,14 @@ func (DriverMock) HandleReadCommands(deviceName string, protocols map[string]con
 				err = fmt.Errorf("error occurred in HandleReadCommands")
 			}
 		case "Random-Float-Generator01":
-			if req.DeviceResourceName == "RandomValue_Float32" {
+			switch req.DeviceResourceName {
+			case ResourceObjectFloat32:
 				v, _ = dsModels.NewFloat32Value(req.DeviceResourceName, now, float32(123))
-			} else {
+			case ResourceObjectNaNFloat32:
+				v, _ = dsModels.NewFloat32Value(req.DeviceResourceName, now, float32(math.NaN()))
+			case ResourceObjectNaNFloat64:
+				v, _ = dsModels.NewFloat64Value(req.DeviceResourceName, now, math.NaN())
+			default:
 				err = fmt.Errorf("error occurred in HandleReadCommands")
 			}
 		}

--- a/internal/transformer/checkNaN.go
+++ b/internal/transformer/checkNaN.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"math"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+)
+
+// NaNError is used to throw the NaN error for the floating-point value
+type NaNError struct{}
+
+func (e NaNError) Error() string {
+	return "not a valid float value NaN"
+}
+
+func isNaN(cv *dsModels.CommandValue) (bool, error) {
+	switch cv.Type {
+	case dsModels.Float32:
+		v, err := cv.Float32Value()
+		if err != nil {
+			return false, err
+		}
+		if math.IsNaN(float64(v)) {
+			return true, nil
+		}
+	case dsModels.Float64:
+		v, err := cv.Float64Value()
+		if err != nil {
+			return false, err
+		}
+		if math.IsNaN(v) {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/transformer/checkNaN_test.go
+++ b/internal/transformer/checkNaN_test.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2020 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformReadResult_NaN(t *testing.T) {
+	ro := contract.ResourceOperation{DeviceResource: "test-object"}
+	float32Val, _ := dsModels.NewFloat32Value(ro.DeviceResource, 0, float32(math.NaN()))
+	float64Val, _ := dsModels.NewFloat64Value(ro.DeviceResource, 0, math.NaN())
+
+	tests := []struct {
+		name string
+		cv   *dsModels.CommandValue
+	}{
+		{"float32 NaN error", float32Val},
+		{"float64 NaN error", float64Val},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pv := contract.PropertyValue{}
+			err := TransformReadResult(tt.cv, pv, lc)
+			assert.True(t, errors.Is(err, NaNError{}), "transform result should be NaNError")
+		})
+	}
+}

--- a/internal/transformer/transformresult_test.go
+++ b/internal/transformer/transformresult_test.go
@@ -7,8 +7,8 @@
 package transformer
 
 import (
+	"errors"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"testing"
 
@@ -64,7 +64,7 @@ func TestTransformReadResult_base_unt8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -110,7 +110,7 @@ func TestTransformReadResult_scale_unt8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -156,7 +156,7 @@ func TestTransformReadResult_offset_unt8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -202,7 +202,7 @@ func TestTransformReadResult_base_uint16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -248,7 +248,7 @@ func TestTransformReadResult_scale_uint16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -294,7 +294,7 @@ func TestTransformReadResult_offset_uint16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -340,7 +340,7 @@ func TestTransformReadResult_base_uint32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -386,7 +386,7 @@ func TestTransformReadResult_scale_uint32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -432,7 +432,7 @@ func TestTransformReadResult_offset_uint32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -559,7 +559,7 @@ func TestTransformReadResult_base_int8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -605,7 +605,7 @@ func TestTransformReadResult_scale_int8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -651,7 +651,7 @@ func TestTransformReadResult_offset_int8_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -697,7 +697,7 @@ func TestTransformReadResult_base_int16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -743,7 +743,7 @@ func TestTransformReadResult_scale_int16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -789,7 +789,7 @@ func TestTransformReadResult_offset_int16_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -835,7 +835,7 @@ func TestTransformReadResult_base_int32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -881,7 +881,7 @@ func TestTransformReadResult_scale_int32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -927,7 +927,7 @@ func TestTransformReadResult_offset_int32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -1054,7 +1054,7 @@ func TestTransformReadResult_base_float32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with base '%v' should be overflow", val, base)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -1100,7 +1100,7 @@ func TestTransformReadResult_scale_float32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with scale '%v' should be overflow", val, scale)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -1146,7 +1146,7 @@ func TestTransformReadResult_offset_float32_overflow(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Unexpect test result, transform reading '%v' with offset '%v' should be overflow", val, offset)
 	}
-	if err, ok := errors.Cause(err).(OverflowError); !ok {
+	if !errors.As(err, &OverflowError{}) {
 		t.Fatalf("Unexpect test result, error should be OverflowError, %v", err)
 	}
 }
@@ -1583,7 +1583,7 @@ func TestTransformReadResult_shift_should_be_valid(t *testing.T) {
 
 	err = TransformReadResult(cv, pv, lc)
 
-	if err == nil || err.Error() != "invalid shift value, the shift -+4 should be parsed to float64 for checking the sign of the number. strconv.ParseFloat: parsing \"-+4\": invalid syntax" {
-		t.Fatalf("Unexpected test result, transform function should throw the correct error. %v", err)
+	if err == nil {
+		t.Fatalf("Unexpected test result, transform function should throw the error.")
 	}
 }


### PR DESCRIPTION
Fix #685 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #685 


## What is the new behavior?
When SDK throws overflow or NaN error, the other correct readings will be dropped. But the user still wants to receive the correct readings, so we need to set the reading value with overflow or NaN constant instead of the real error.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
