### PR TITLE
feat: SecretProvider for storing/retrieving secrets

### DIFF
--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -42,6 +42,9 @@ https://github.com/globalsign/mgo/blob/master/LICENSE
 gopkg.in/yaml v2 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v2
 https://github.com/go-yaml/yaml/blob/v2/LICENSE
 
+gopkg.in/yaml.v3 (MIT) https://github.com/go-yaml/yaml/tree/v3
+https://github.com/go-yaml/yaml/blob/v3/LICENSE
+
 google/uuid (BSD-3) https://github.com/google/uuid
 https://github.com/google/uuid/blob/master/LICENSE
 

--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -1,5 +1,12 @@
 [Writable]
 LogLevel = 'INFO'
+  # Example InsecureSecrets configuration that simulates SecretStore for when EDGEX_SECURITY_SECRET_STORE=false
+  [Writable.InsecureSecrets]
+    [Writable.InsecureSecrets.Sample]
+    path = "sample"
+      [Writable.InsecureSecrets.Sample.Secrets]
+      username = ""
+      password = ""
 
 [Service]
 BootTimeout = 30000
@@ -29,6 +36,23 @@ Type = 'consul'
   Protocol = 'http'
   Host = 'localhost'
   Port = 48081
+
+# Example SecretStore configuration.
+# Only used when EDGEX_SECURITY_SECRET_STORE=true
+# Must also add `ADD_SECRETSTORE_TOKENS: "device-simple"` to vault-worker environment so it generates
+# the token and secret store in vault for 'device-simple'
+[SecretStore]
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secret/edgex/device-simple/'
+Protocol = 'http'
+RootCaCertPath = ''
+ServerName = ''
+TokenFile = '/tmp/edgex/secrets/device-simple/secrets-token.json'
+AdditionalRetryAttempts = 10
+RetryWaitPeriod = "1s"
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
 
 [Device]
   DataTransform = true

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/edgexfoundry/device-sdk-go
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap v0.0.60
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.115
-	github.com/edgexfoundry/go-mod-registry v0.1.26
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.68
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.135
+	github.com/edgexfoundry/go-mod-registry v0.1.27
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/internal/autoevent/executor_test.go
+++ b/internal/autoevent/executor_test.go
@@ -20,7 +20,7 @@ func TestCompareReadings(t *testing.T) {
 	readings[2] = contract.Reading{Name: "Pressure", Value: "3"}
 	readings[3] = contract.Reading{Name: "Image", BinaryValue: []byte("This is a image")}
 
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	autoEvent := contract.AutoEvent{Frequency: "500ms"}
 	e, err := NewExecutor("hasBinaryTrue", autoEvent)
 	if err != nil {

--- a/internal/cache/init_test.go
+++ b/internal/cache/init_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestInitCache(t *testing.T) {
 	serviceName := "init-cache-test"
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	vdc := &mock.ValueDescriptorMock{}
 	dc := &mock.DeviceClientMock{}
 	pwc := &mock.ProvisionWatcherClientMock{}

--- a/internal/clients/init_test.go
+++ b/internal/clients/init_test.go
@@ -24,7 +24,7 @@ func TestCheckServiceAvailableByPingWithTimeoutError(test *testing.T) {
 		},
 	}
 	config := &common.ConfigurationStruct{Clients: clientConfig}
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 
 	err := checkServiceAvailableByPing(common.ClientData, config, lc)
 	if err, ok := err.(net.Error); ok && !err.Timeout() {

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -26,6 +26,8 @@ type ConfigurationStruct struct {
 	DeviceList []DeviceConfig `consul:"-"`
 	// Driver is a string map contains customized configuration for the protocol driver implemented based on Device SDK
 	Driver map[string]string
+	// SecretStore contain information for connecting to the secure SecretStore (Vault) to retrieve or store secrets
+	SecretStore bootstrapConfig.SecretStoreInfo
 }
 
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
@@ -64,9 +66,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:  c.Clients,
-		Service:  c.Service.GetBootstrapServiceInfo(),
-		Registry: c.Registry,
+		Clients:     c.Clients,
+		Service:     c.Service.GetBootstrapServiceInfo(),
+		Registry:    c.Registry,
+		SecretStore: c.SecretStore,
 	}
 }
 
@@ -78,4 +81,9 @@ func (c *ConfigurationStruct) GetLogLevel() string {
 // GetRegistryInfo gets the config.RegistryInfo field from the ConfigurationStruct.
 func (c *ConfigurationStruct) GetRegistryInfo() bootstrapConfig.RegistryInfo {
 	return c.Registry
+}
+
+// GetInsecureSecrets returns the service's InsecureSecrets.
+func (c *ConfigurationStruct) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
+	return c.Writable.InsecureSecrets
 }

--- a/internal/common/config.go
+++ b/internal/common/config.go
@@ -26,7 +26,7 @@ type ConfigurationStruct struct {
 	DeviceList []DeviceConfig `consul:"-"`
 	// Driver is a string map contains customized configuration for the protocol driver implemented based on Device SDK
 	Driver map[string]string
-	// SecretStore contain information for connecting to the secure SecretStore (Vault) to retrieve or store secrets
+	// SecretStore contains information for connecting to the secure SecretStore (Vault) to retrieve or store secrets
 	SecretStore bootstrapConfig.SecretStoreInfo
 }
 

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -16,7 +16,8 @@ import (
 // WritableInfo is a struct which contains configuration settings that can be changed in the Registry .
 type WritableInfo struct {
 	// Level is the logging level of writing log message
-	LogLevel string
+	LogLevel        string
+	InsecureSecrets bootstrapConfig.InsecureSecrets
 }
 
 // ServiceInfo is a struct which contains service related configuration
@@ -57,7 +58,7 @@ type ServiceInfo struct {
 // DeviceInfo is a struct which contains device specific configuration settings.
 type DeviceInfo struct {
 	// DataTransform specifies whether or not the DS perform transformations
-	// specified by valuedescriptor on a actuation or query command.
+	// specified by value descriptor on a actuation or query command.
 	DataTransform bool
 	// InitCmd specifies a device resource command which is automatically
 	// generated whenever a new device is added to the DS.
@@ -68,7 +69,7 @@ type DeviceInfo struct {
 	// can be sent to a Driver in a single command.
 	MaxCmdOps int
 	// MaxCmdValueLen is the maximum string length of a command parameter or
-	// result (including the valuedescriptor name) that can be returned
+	// result (including the value descriptor name) that can be returned
 	// by a Driver.
 	MaxCmdValueLen int
 	// InitCmd specifies a device resource command which is automatically
@@ -76,7 +77,7 @@ type DeviceInfo struct {
 	RemoveCmd string
 	// RemoveCmdArgs specify arguments to be used when building the RemoveCmd.
 	RemoveCmdArgs string
-	// ProfilesDir specifies a directory which contains deviceprofile
+	// ProfilesDir specifies a directory which contains device profile
 	// files which should be imported on startup.
 	ProfilesDir string
 	// UpdateLastConnected specifies whether to update device's LastConnected

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -77,7 +77,7 @@ type DeviceInfo struct {
 	RemoveCmd string
 	// RemoveCmdArgs specify arguments to be used when building the RemoveCmd.
 	RemoveCmdArgs string
-	// ProfilesDir specifies a directory which contains device profile
+	// ProfilesDir specifies a directory which contains device profiles
 	// files which should be imported on startup.
 	ProfilesDir string
 	// UpdateLastConnected specifies whether to update device's LastConnected

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -107,7 +107,7 @@ func TestFilterQueryParams(t *testing.T) {
 			fmt.Sprintf("%sname", SDKReservedPrefix), false},
 	}
 
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	for _, tt := range tests {
 		actual := FilterQueryParams(tt.query, lc)
 		if _, ok := actual[tt.key]; ok != tt.expected {

--- a/internal/controller/restfuncs_test.go
+++ b/internal/controller/restfuncs_test.go
@@ -47,7 +47,7 @@ func TestCallback(t *testing.T) {
 		{"Invalid id", http.MethodPut, `{"id":"","type":"DEVICE"}`, http.StatusBadRequest},
 	}
 
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	deviceClient := &mock.DeviceClientMock{}
 	ds := contract.DeviceService{}
 	dic := di.NewContainer(di.ServiceConstructorMap{
@@ -85,7 +85,7 @@ func TestCallback(t *testing.T) {
 
 // Test Command REST call when service is locked.
 func TestCommandServiceLocked(t *testing.T) {
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	ds := contract.DeviceService{
 		AdminState: contract.Locked,
 	}
@@ -122,7 +122,7 @@ func TestCommandServiceLocked(t *testing.T) {
 // TestCommandNoDevice tests the command REST call when the given deviceId doesn't
 // specify an existing device.
 func TestCommandNoDevice(t *testing.T) {
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	ds := contract.DeviceService{}
 	dc := &mock.DeviceClientMock{}
 	vdc := &mock.ValueDescriptorMock{}

--- a/internal/controller/restrouter_test.go
+++ b/internal/controller/restrouter_test.go
@@ -42,7 +42,7 @@ func TestAddRoute(t *testing.T) {
 		{"Reserved Route", common.APIVersionRoute, true},
 	}
 
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return lc
@@ -89,7 +89,7 @@ func TestAddRoute(t *testing.T) {
 }
 
 func TestInitRestRoutes(t *testing.T) {
-	lc := logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc := logger.NewMockClient()
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return lc

--- a/internal/handler/command_test.go
+++ b/internal/handler/command_test.go
@@ -69,7 +69,7 @@ func init() {
 	pwc = &mock.ProvisionWatcherClientMock{}
 	dc = &mock.DeviceClientMock{}
 	ec = &mock.EventClientMock{}
-	lc = logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc = logger.NewMockClient()
 	driver = &mock.DriverMock{}
 	deviceInfo := common.DeviceInfo{DataTransform: true, MaxCmdOps: 128}
 	configuration = &common.ConfigurationStruct{Device: deviceInfo}

--- a/internal/transformer/transformresult_test.go
+++ b/internal/transformer/transformresult_test.go
@@ -20,7 +20,7 @@ import (
 var lc logger.LoggingClient
 
 func init() {
-	lc = logger.NewClientStdOut("device-sdk-test", false, "DEBUG")
+	lc = logger.NewMockClient()
 }
 
 func TestTransformReadResult_base_unt8(t *testing.T) {

--- a/internal/v2/application/command.go
+++ b/internal/v2/application/command.go
@@ -23,12 +23,14 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/internal/transformer"
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
+
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/errors"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 )
 
@@ -491,28 +493,28 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 
 	origin := time.Now().UnixNano()
 	switch strings.ToLower(dr.Properties.Value.Type) {
-	case strings.ToLower(dtos.ValueTypeString):
+	case strings.ToLower(v2.ValueTypeString):
 		result = dsModels.NewStringValue(dr.Name, origin, v)
-	case strings.ToLower(dtos.ValueTypeBool):
+	case strings.ToLower(v2.ValueTypeBool):
 		value, err := strconv.ParseBool(v)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewBoolValue(dr.Name, origin, value)
-	case strings.ToLower(dtos.ValueTypeBoolArray):
+	case strings.ToLower(v2.ValueTypeBoolArray):
 		var arr []bool
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewBoolArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeUint8):
+	case strings.ToLower(v2.ValueTypeUint8):
 		n, err := strconv.ParseUint(v, 10, 8)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewUint8Value(dr.Name, origin, uint8(n))
-	case strings.ToLower(dtos.ValueTypeUint8Array):
+	case strings.ToLower(v2.ValueTypeUint8Array):
 		var arr []uint8
 		strArr := strings.Split(strings.Trim(v, "[]"), ",")
 		for _, u := range strArr {
@@ -523,13 +525,13 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 			arr = append(arr, uint8(n))
 		}
 		result, err = dsModels.NewUint8ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeUint16):
+	case strings.ToLower(v2.ValueTypeUint16):
 		n, err := strconv.ParseUint(v, 10, 16)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewUint16Value(dr.Name, origin, uint16(n))
-	case strings.ToLower(dtos.ValueTypeUint16Array):
+	case strings.ToLower(v2.ValueTypeUint16Array):
 		var arr []uint16
 		strArr := strings.Split(strings.Trim(v, "[]"), ",")
 		for _, u := range strArr {
@@ -540,13 +542,13 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 			arr = append(arr, uint16(n))
 		}
 		result, err = dsModels.NewUint16ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeUint32):
+	case strings.ToLower(v2.ValueTypeUint32):
 		n, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewUint32Value(dr.Name, origin, uint32(n))
-	case strings.ToLower(dtos.ValueTypeUint32Array):
+	case strings.ToLower(v2.ValueTypeUint32Array):
 		var arr []uint32
 		strArr := strings.Split(strings.Trim(v, "[]"), ",")
 		for _, u := range strArr {
@@ -557,13 +559,13 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 			arr = append(arr, uint32(n))
 		}
 		result, err = dsModels.NewUint32ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeUint64):
+	case strings.ToLower(v2.ValueTypeUint64):
 		n, err := strconv.ParseUint(v, 10, 64)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewUint64Value(dr.Name, origin, n)
-	case strings.ToLower(dtos.ValueTypeUint64Array):
+	case strings.ToLower(v2.ValueTypeUint64Array):
 		var arr []uint64
 		strArr := strings.Split(strings.Trim(v, "[]"), ",")
 		for _, u := range strArr {
@@ -574,59 +576,59 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 			arr = append(arr, n)
 		}
 		result, err = dsModels.NewUint64ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeInt8):
+	case strings.ToLower(v2.ValueTypeInt8):
 		n, err := strconv.ParseInt(v, 10, 8)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt8Value(dr.Name, origin, int8(n))
-	case strings.ToLower(dtos.ValueTypeInt8Array):
+	case strings.ToLower(v2.ValueTypeInt8Array):
 		var arr []int8
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt8ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeInt16):
+	case strings.ToLower(v2.ValueTypeInt16):
 		n, err := strconv.ParseInt(v, 10, 16)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt16Value(dr.Name, origin, int16(n))
-	case strings.ToLower(dtos.ValueTypeInt16Array):
+	case strings.ToLower(v2.ValueTypeInt16Array):
 		var arr []int16
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt16ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeInt32):
+	case strings.ToLower(v2.ValueTypeInt32):
 		n, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt32Value(dr.Name, origin, int32(n))
-	case strings.ToLower(dtos.ValueTypeInt32Array):
+	case strings.ToLower(v2.ValueTypeInt32Array):
 		var arr []int32
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt32ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeInt64):
+	case strings.ToLower(v2.ValueTypeInt64):
 		n, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt64Value(dr.Name, origin, n)
-	case strings.ToLower(dtos.ValueTypeInt64Array):
+	case strings.ToLower(v2.ValueTypeInt64Array):
 		var arr []int64
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewInt64ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeFloat32):
+	case strings.ToLower(v2.ValueTypeFloat32):
 		n, e := strconv.ParseFloat(v, 32)
 		if e == nil {
 			result, err = dsModels.NewFloat32Value(dr.Name, origin, float32(n))
@@ -651,14 +653,14 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 				result, err = dsModels.NewFloat32Value(dr.Name, origin, val)
 			}
 		}
-	case strings.ToLower(dtos.ValueTypeFloat32Array):
+	case strings.ToLower(v2.ValueTypeFloat32Array):
 		var arr []float32
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
 			return result, err
 		}
 		result, err = dsModels.NewFloat32ArrayValue(dr.Name, origin, arr)
-	case strings.ToLower(dtos.ValueTypeFloat64):
+	case strings.ToLower(v2.ValueTypeFloat64):
 		var val float64
 		val, err = strconv.ParseFloat(v, 64)
 		if err == nil {
@@ -682,7 +684,7 @@ func createCommandValueFromDeviceResource(dr *contract.DeviceResource, v string)
 				result, err = dsModels.NewFloat64Value(dr.Name, origin, val)
 			}
 		}
-	case strings.ToLower(dtos.ValueTypeFloat64Array):
+	case strings.ToLower(v2.ValueTypeFloat64Array):
 		var arr []float64
 		err = json.Unmarshal([]byte(v), &arr)
 		if err != nil {
@@ -717,13 +719,10 @@ func commandValueToReading(cv *dsModels.CommandValue, deviceName string, mediaTy
 		encoding = dsModels.DefaultFloatEncoding
 	}
 
-	reading := &dtos.BaseReading{Name: cv.DeviceResourceName, DeviceName: deviceName, ValueType: cv.ValueTypeToString()}
+	reading := &dtos.BaseReading{ResourceName: cv.DeviceResourceName, DeviceName: deviceName, ValueType: cv.ValueTypeToString()}
 	if cv.Type == dsModels.Binary {
 		reading.BinaryValue = cv.BinValue
 		reading.MediaType = mediaType
-	} else if cv.Type == dsModels.Float32 || cv.Type == dsModels.Float64 {
-		reading.Value = cv.ValueToString(encoding)
-		reading.FloatEncoding = encoding
 	} else {
 		reading.Value = cv.ValueToString(encoding)
 	}
@@ -745,7 +744,7 @@ func SendEvent(event *dtos.Event, correlationID string, lc logger.LoggingClient,
 	//ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 	//responseBody, err := ec.Add(ctx, event)
 	//if err != nil {
-	//	lc.Error("SendEvent: failed to push event to coredata", "device", event.DeviceName, "response", responseBody, "error", err)
+	//	lc.Error("SendEvent: failed to push event to core data", "device", event.DeviceName, "response", responseBody, "error", err)
 	//} else {
 	//	lc.Info("SendEvent: pushed event to core data", clients.ContentType, clients.FromContext(ctx, clients.ContentType), clients.CorrelationHeader, id)
 	//}

--- a/internal/v2/application/command.go
+++ b/internal/v2/application/command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/errors"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 )
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+
 	"github.com/edgexfoundry/device-sdk-go/internal/autoevent"
 	"github.com/edgexfoundry/device-sdk-go/internal/clients"
 	"github.com/edgexfoundry/device-sdk-go/internal/common"
@@ -47,6 +49,7 @@ type DeviceService struct {
 	ServiceName    string
 	LoggingClient  logger.LoggingClient
 	RegistryClient registry.Client
+	SecretProvider interfaces.SecretProvider
 	edgexClients   clients.EdgeXClients
 	controller     *controller.RestController
 	config         *common.ConfigurationStruct
@@ -90,6 +93,7 @@ func (s *DeviceService) Initialize(serviceName, serviceVersion string, proto int
 func (s *DeviceService) UpdateFromContainer(r *mux.Router, dic *di.Container) {
 	s.LoggingClient = bootstrapContainer.LoggingClientFrom(dic.Get)
 	s.RegistryClient = bootstrapContainer.RegistryFrom(dic.Get)
+	s.SecretProvider = bootstrapContainer.SecretProviderFrom(dic.Get)
 	s.edgexClients.GeneralClient = container.GeneralClientFrom(dic.Get)
 	s.edgexClients.DeviceClient = container.MetadataDeviceClientFrom(dic.Get)
 	s.edgexClients.DeviceServiceClient = container.MetadataDeviceServiceClientFrom(dic.Get)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: #653


## What is the new behavior?
Added creation and initialization SecretProvider during bootstrap for both secure and non-secure modes
Added InsecureSecrets and SecretStore config to device-simple as samples and used to test initializing SecretProvider in secure mode.
APIs to take advantage of the SecretProvider  are TBD in future PRs

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->
This PR is about just about creating and initializing the Secret Provider. Using it come in following PR.
**Do the following to test this PR:**

- clone latest developer scripts repo
- Modify developer-scripts/releases/nightly-build/compose-files/docker-compose-nexus.yml as follows:
  - Add `ADD_SECRETSTORE_TOKENS: "device-simple"` to `environment` section for `vault-worker` 
 
```
    environment:
      SECRETSTORE_SETUP_DONE_FLAG: /tmp/edgex/secrets/edgex-consul/.secretstore-setup-done
      ADD_SECRETSTORE_TOKENS: "device-simple"
    hostname: edgex-vault-worker
```

- Run compose from developer-scripts/releases/nightly-build/compose-files
  - `make run`
- build Device SDK from branch for this PR (i.e. clone the branch)

**Run Device Simple in secure mode**
- cd to `example/cmd/device-simple/`
- sudo EDGEX_SECURITY_SECRET_STORE=true ./device-simple
  - Need to run as root to access vault token file
- Verify service starts successfully with the following in the log messages:

```
level=INFO ts=2021-01-08T21:44:12.7857283Z app=device-simple source=secret.go:51 msg="Creating SecretClient"
level=INFO ts=2021-01-08T21:44:12.7872455Z app=device-simple source=secret.go:58 msg="Reading secret store configuration and authentication token"
level=INFO ts=2021-01-08T21:44:12.7873587Z app=device-simple source=secret.go:70 msg="Attempting to create secret client"
level=INFO ts=2021-01-08T21:44:12.805743Z app=device-simple source=secret.go:75 msg="Created SecretClient"
```

**Run Device Simple in non-secure mode**
- EDGEX_SECURITY_SECRET_STORE=false ./device-simple
- Verify service starts successfully without any log message about SecretClient

## Other information

