### PR TITLE
feat: Add /api/v2/secret endpoint to store a secret

### DIFF
--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -131,3 +131,6 @@ https://github.com/go-playground/validator/blob/master/LICENSE
 
 leodido/go-urn (MIT) https://github.com/leodido/go-urn
 https://github.com/leodido/go-urn/blob/master/LICENSE
+
+stretchr/objx (MIT) https://github.com/stretchr/objx
+https://github.com/stretchr/objx/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/edgexfoundry/go-mod-bootstrap v0.0.68
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.136
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.144
 	github.com/edgexfoundry/go-mod-registry v0.1.27
 	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/google/uuid v1.1.4

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -47,6 +47,7 @@ const (
 	APIV2DiscoveryRoute         = v2.ApiBase + "/discovery"
 	APIV2IdCommandRoute         = v2.ApiBase + "/device/{id}/{command}"
 	APIV2NameCommandRoute       = v2.ApiBase + "/device/name/{name}/{command}"
+	APIV2SecretsRoute           = v2.ApiBase + "/secrets"
 
 	IdVar        string = "id"
 	NameVar      string = "name"

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -47,7 +47,7 @@ const (
 	APIV2DiscoveryRoute         = v2.ApiBase + "/discovery"
 	APIV2IdCommandRoute         = v2.ApiBase + "/device/{id}/{command}"
 	APIV2NameCommandRoute       = v2.ApiBase + "/device/name/{name}/{command}"
-	APIV2SecretsRoute           = v2.ApiBase + "/secrets"
+	APIV2SecretRoute            = v2.ApiBase + "/secret"
 
 	IdVar        string = "id"
 	NameVar      string = "name"

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -79,6 +79,8 @@ func (c *RestController) InitV2RestRoutes() {
 	c.addReservedRoute(contractsV2.ApiConfigRoute, c.v2HttpController.Config).Methods(http.MethodGet)
 	c.addReservedRoute(contractsV2.ApiMetricsRoute, c.v2HttpController.Metrics).Methods(http.MethodGet)
 
+	c.addReservedRoute(sdkCommon.APIV2SecretsRoute, c.v2HttpController.Secrets).Methods(http.MethodPost)
+
 	c.addReservedRoute(sdkCommon.APIV2DiscoveryRoute, c.v2HttpController.Discovery).Methods(http.MethodPost)
 
 	c.addReservedRoute(sdkCommon.APIV2IdCommandRoute, c.v2HttpController.Command).Methods(http.MethodPut, http.MethodGet)

--- a/internal/controller/restrouter.go
+++ b/internal/controller/restrouter.go
@@ -79,7 +79,7 @@ func (c *RestController) InitV2RestRoutes() {
 	c.addReservedRoute(contractsV2.ApiConfigRoute, c.v2HttpController.Config).Methods(http.MethodGet)
 	c.addReservedRoute(contractsV2.ApiMetricsRoute, c.v2HttpController.Metrics).Methods(http.MethodGet)
 
-	c.addReservedRoute(sdkCommon.APIV2SecretsRoute, c.v2HttpController.Secrets).Methods(http.MethodPost)
+	c.addReservedRoute(sdkCommon.APIV2SecretRoute, c.v2HttpController.Secret).Methods(http.MethodPost)
 
 	c.addReservedRoute(sdkCommon.APIV2DiscoveryRoute, c.v2HttpController.Discovery).Methods(http.MethodPost)
 

--- a/internal/v2/controller/http/common.go
+++ b/internal/v2/controller/http/common.go
@@ -61,37 +61,37 @@ func (c *V2HttpController) Metrics(writer http.ResponseWriter, request *http.Req
 	c.sendResponse(writer, request, contractsV2.ApiMetricsRoute, response, http.StatusOK)
 }
 
-// Secrets handles the request to add Device Service exclusive secrets to the Secret Store
+// Secret handles the request to add Device Service exclusive secret to the Secret Store
 // It returns a response as specified by the V2 API swagger in openapi/v2
-func (c *V2HttpController) Secrets(writer http.ResponseWriter, request *http.Request) {
+func (c *V2HttpController) Secret(writer http.ResponseWriter, request *http.Request) {
 	defer func() {
 		_ = request.Body.Close()
 	}()
 
 	provider := bootstrapContainer.SecretProviderFrom(c.dic.Get)
-	secretRequest := common.SecretsRequest{}
+	secretRequest := common.SecretRequest{}
 	err := json.NewDecoder(request.Body).Decode(&secretRequest)
 	if err != nil {
 		edgexError := errors.NewCommonEdgeX(errors.KindContractInvalid, "JSON decode failed", err)
-		c.sendEdgexError(writer, request, edgexError, sdkCommon.APIV2SecretsRoute)
+		c.sendEdgexError(writer, request, edgexError, sdkCommon.APIV2SecretRoute)
 		return
 	}
 
-	path, secrets := c.prepareSecrets(secretRequest)
+	path, secrets := c.prepareSecret(secretRequest)
 
 	if err := provider.StoreSecrets(path, secrets); err != nil {
 		edgexError := errors.NewCommonEdgeX(errors.KindServerError, "Storing secrets failed", err)
-		c.sendEdgexError(writer, request, edgexError, sdkCommon.APIV2SecretsRoute)
+		c.sendEdgexError(writer, request, edgexError, sdkCommon.APIV2SecretRoute)
 		return
 	}
 
 	response := common.NewBaseResponse(secretRequest.RequestId, "", http.StatusCreated)
-	c.sendResponse(writer, request, sdkCommon.APIV2SecretsRoute, response, http.StatusCreated)
+	c.sendResponse(writer, request, sdkCommon.APIV2SecretRoute, response, http.StatusCreated)
 }
 
-func (c *V2HttpController) prepareSecrets(request common.SecretsRequest) (string, map[string]string) {
+func (c *V2HttpController) prepareSecret(request common.SecretRequest) (string, map[string]string) {
 	var secretsKV = make(map[string]string)
-	for _, secret := range request.Secrets {
+	for _, secret := range request.SecretData {
 		secretsKV[secret.Key] = secret.Value
 	}
 

--- a/internal/v2/controller/http/common.go
+++ b/internal/v2/controller/http/common.go
@@ -77,10 +77,10 @@ func (c *V2HttpController) Secret(writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	path, secrets := c.prepareSecret(secretRequest)
+	path, secret := c.prepareSecret(secretRequest)
 
-	if err := provider.StoreSecrets(path, secrets); err != nil {
-		edgexError := errors.NewCommonEdgeX(errors.KindServerError, "Storing secrets failed", err)
+	if err := provider.StoreSecrets(path, secret); err != nil {
+		edgexError := errors.NewCommonEdgeX(errors.KindServerError, "Storing secret failed", err)
 		c.sendEdgexError(writer, request, edgexError, sdkCommon.APIV2SecretRoute)
 		return
 	}
@@ -90,9 +90,9 @@ func (c *V2HttpController) Secret(writer http.ResponseWriter, request *http.Requ
 }
 
 func (c *V2HttpController) prepareSecret(request common.SecretRequest) (string, map[string]string) {
-	var secretsKV = make(map[string]string)
+	var secretKVs = make(map[string]string)
 	for _, secret := range request.SecretData {
-		secretsKV[secret.Key] = secret.Value
+		secretKVs[secret.Key] = secret.Value
 	}
 
 	path := strings.TrimSpace(request.Path)
@@ -106,5 +106,5 @@ func (c *V2HttpController) prepareSecret(request common.SecretRequest) (string, 
 		path = path[1:]
 	}
 
-	return path, secretsKV
+	return path, secretKVs
 }

--- a/internal/v2/controller/http/common_test.go
+++ b/internal/v2/controller/http/common_test.go
@@ -163,7 +163,7 @@ func TestConfigRequest(t *testing.T) {
 	assert.Equal(t, expectedConfig, actualConfig)
 }
 
-func TestSecretsRequest(t *testing.T) {
+func TestSecretRequest(t *testing.T) {
 	expectedRequestId := "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
 	config := &sdkCommon.ConfigurationStruct{}
 
@@ -203,8 +203,8 @@ func TestSecretsRequest(t *testing.T) {
 	validNoRequestId.RequestId = ""
 	badRequestId := validRequest
 	badRequestId.RequestId = "bad requestId"
-	noSecrets := validRequest
-	noSecrets.SecretData = []common.SecretDataKeyValue{}
+	noSecret := validRequest
+	noSecret.SecretData = []common.SecretDataKeyValue{}
 	missingSecretKey := validRequest
 	missingSecretKey.SecretData = []common.SecretDataKeyValue{
 		{Key: "", Value: "username"},
@@ -220,18 +220,18 @@ func TestSecretsRequest(t *testing.T) {
 		Name               string
 		Request            common.SecretRequest
 		ExpectedRequestId  string
-		SecretsPath        string
+		SecretPath         string
 		SecretStoreEnabled string
 		ErrorExpected      bool
 		ExpectedStatusCode int
 	}{
-		{"Valid - sub-path no trailing slash, SecretsPath has trailing slash", validRequest, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
-		{"Valid - sub-path only with trailing slash", validPathWithSlash, expectedRequestId, "my-secrets", "true", false, http.StatusCreated},
-		{"Valid - both trailing slashes", validPathWithSlash, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
+		{"Valid - sub-path no trailing slash, SecretPath has trailing slash", validRequest, expectedRequestId, "my-secret/", "true", false, http.StatusCreated},
+		{"Valid - sub-path only with trailing slash", validPathWithSlash, expectedRequestId, "my-secret", "true", false, http.StatusCreated},
+		{"Valid - both trailing slashes", validPathWithSlash, expectedRequestId, "my-secret/", "true", false, http.StatusCreated},
 		{"Valid - no requestId", validNoRequestId, "", "", "true", false, http.StatusCreated},
 		{"Invalid - no path", NoPath, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - bad requestId", badRequestId, "", "", "true", true, http.StatusBadRequest},
-		{"Invalid - no secrets", noSecrets, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - no secret", noSecret, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - missing secret key", missingSecretKey, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - missing secret value", missingSecretValue, "", "", "true", true, http.StatusBadRequest},
 		{"Invalid - No Secret Store", noSecretStore, "", "", "false", true, http.StatusInternalServerError},

--- a/internal/v2/controller/http/common_test.go
+++ b/internal/v2/controller/http/common_test.go
@@ -186,10 +186,10 @@ func TestSecretsRequest(t *testing.T) {
 	target := NewV2HttpController(dic)
 	assert.NotNil(t, target)
 
-	validRequest := common.SecretsRequest{
+	validRequest := common.SecretRequest{
 		BaseRequest: common.BaseRequest{RequestId: expectedRequestId},
 		Path:        "mqtt",
-		Secrets: []common.SecretsKeyValue{
+		SecretData: []common.SecretDataKeyValue{
 			{Key: "username", Value: "username"},
 			{Key: "password", Value: "password"},
 		},
@@ -204,13 +204,13 @@ func TestSecretsRequest(t *testing.T) {
 	badRequestId := validRequest
 	badRequestId.RequestId = "bad requestId"
 	noSecrets := validRequest
-	noSecrets.Secrets = []common.SecretsKeyValue{}
+	noSecrets.SecretData = []common.SecretDataKeyValue{}
 	missingSecretKey := validRequest
-	missingSecretKey.Secrets = []common.SecretsKeyValue{
+	missingSecretKey.SecretData = []common.SecretDataKeyValue{
 		{Key: "", Value: "username"},
 	}
 	missingSecretValue := validRequest
-	missingSecretValue.Secrets = []common.SecretsKeyValue{
+	missingSecretValue.SecretData = []common.SecretDataKeyValue{
 		{Key: "username", Value: ""},
 	}
 	noSecretStore := validRequest
@@ -218,7 +218,7 @@ func TestSecretsRequest(t *testing.T) {
 
 	tests := []struct {
 		Name               string
-		Request            common.SecretsRequest
+		Request            common.SecretRequest
 		ExpectedRequestId  string
 		SecretsPath        string
 		SecretStoreEnabled string
@@ -246,12 +246,12 @@ func TestSecretsRequest(t *testing.T) {
 
 			reader := strings.NewReader(string(jsonData))
 
-			req, err := http.NewRequest(http.MethodPost, sdkCommon.APIV2SecretsRoute, reader)
+			req, err := http.NewRequest(http.MethodPost, sdkCommon.APIV2SecretRoute, reader)
 			require.NoError(t, err)
 			req.Header.Set(clients.CorrelationHeader, expectedCorrelationId)
 
 			recorder := httptest.NewRecorder()
-			handler := http.HandlerFunc(target.Secrets)
+			handler := http.HandlerFunc(target.Secret)
 			handler.ServeHTTP(recorder, req)
 
 			actualResponse := common.BaseResponse{}

--- a/internal/v2/controller/http/common_test.go
+++ b/internal/v2/controller/http/common_test.go
@@ -1,0 +1,297 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/secret"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	contractsV2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkCommon "github.com/edgexfoundry/device-sdk-go/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/internal/container"
+)
+
+var expectedCorrelationId = uuid.New().String()
+
+func TestPingRequest(t *testing.T) {
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	target := NewV2HttpController(dic)
+
+	recorder := doRequest(t, http.MethodGet, contractsV2.ApiPingRoute, target.Ping, nil)
+
+	actual := common.PingResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &actual)
+	require.NoError(t, err)
+
+	_, err = time.Parse(time.UnixDate, actual.Timestamp)
+	assert.NoError(t, err)
+
+	require.Equal(t, contractsV2.ApiVersion, actual.ApiVersion)
+}
+
+func TestVersionRequest(t *testing.T) {
+	expectedServiceVersion := "1.2.5"
+	expectedSdkVersion := "1.3.1"
+
+	sdkCommon.ServiceVersion = expectedServiceVersion
+	sdkCommon.SDKVersion = expectedSdkVersion
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	target := NewV2HttpController(dic)
+
+	recorder := doRequest(t, http.MethodGet, contractsV2.ApiVersion, target.Version, nil)
+
+	actual := common.VersionSdkResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &actual)
+	require.NoError(t, err)
+
+	assert.Equal(t, contractsV2.ApiVersion, actual.ApiVersion)
+	assert.Equal(t, expectedServiceVersion, actual.Version)
+	assert.Equal(t, expectedSdkVersion, actual.SdkVersion)
+}
+
+func TestMetricsRequest(t *testing.T) {
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	target := NewV2HttpController(dic)
+
+	recorder := doRequest(t, http.MethodGet, contractsV2.ApiMetricsRoute, target.Metrics, nil)
+
+	actual := common.MetricsResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &actual)
+	require.NoError(t, err)
+
+	assert.Equal(t, contractsV2.ApiVersion, actual.ApiVersion)
+	assert.NotZero(t, actual.Metrics.MemAlloc)
+	assert.NotZero(t, actual.Metrics.MemFrees)
+	assert.NotZero(t, actual.Metrics.MemLiveObjects)
+	assert.NotZero(t, actual.Metrics.MemMallocs)
+	assert.NotZero(t, actual.Metrics.MemSys)
+	assert.NotZero(t, actual.Metrics.MemTotalAlloc)
+	assert.NotNil(t, actual.Metrics.CpuBusyAvg)
+}
+
+func TestConfigRequest(t *testing.T) {
+	expectedConfig := sdkCommon.ConfigurationStruct{
+		Writable: sdkCommon.WritableInfo{
+			LogLevel: "DEBUG",
+		},
+		Registry: bootstrapConfig.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+	}
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &expectedConfig
+		},
+	})
+
+	target := NewV2HttpController(dic)
+
+	recorder := doRequest(t, http.MethodGet, contractsV2.ApiConfigRoute, target.Config, nil)
+
+	actualResponse := common.ConfigResponse{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+	require.NoError(t, err)
+
+	assert.Equal(t, contractsV2.ApiVersion, actualResponse.ApiVersion)
+
+	// actualResponse.Config is an interface{} so need to re-marshal/un-marshal into sdkCommon.ConfigurationStruct
+	configJson, err := json.Marshal(actualResponse.Config)
+	require.NoError(t, err)
+	require.Less(t, 0, len(configJson))
+
+	actualConfig := sdkCommon.ConfigurationStruct{}
+	err = json.Unmarshal(configJson, &actualConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedConfig, actualConfig)
+}
+
+func TestSecretsRequest(t *testing.T) {
+	expectedRequestId := "82eb2e26-0f24-48aa-ae4c-de9dac3fb9bc"
+	config := &sdkCommon.ConfigurationStruct{}
+
+	mockProvider := &mocks.SecretProvider{}
+	mockProvider.On("StoreSecrets", "/mqtt", map[string]string{"password": "password", "username": "username"}).Return(nil)
+	mockProvider.On("StoreSecrets", "/no", map[string]string{"password": "password", "username": "username"}).Return(errors.New("Invalid w/o Vault"))
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return config
+		},
+		bootstrapContainer.SecretProviderName: func(get di.Get) interface{} {
+			return mockProvider
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+	})
+
+	target := NewV2HttpController(dic)
+	assert.NotNil(t, target)
+
+	validRequest := common.SecretsRequest{
+		BaseRequest: common.BaseRequest{RequestId: expectedRequestId},
+		Path:        "mqtt",
+		Secrets: []common.SecretsKeyValue{
+			{Key: "username", Value: "username"},
+			{Key: "password", Value: "password"},
+		},
+	}
+
+	NoPath := validRequest
+	NoPath.Path = ""
+	validPathWithSlash := validRequest
+	validPathWithSlash.Path = "/mqtt"
+	validNoRequestId := validRequest
+	validNoRequestId.RequestId = ""
+	badRequestId := validRequest
+	badRequestId.RequestId = "bad requestId"
+	noSecrets := validRequest
+	noSecrets.Secrets = []common.SecretsKeyValue{}
+	missingSecretKey := validRequest
+	missingSecretKey.Secrets = []common.SecretsKeyValue{
+		{Key: "", Value: "username"},
+	}
+	missingSecretValue := validRequest
+	missingSecretValue.Secrets = []common.SecretsKeyValue{
+		{Key: "username", Value: ""},
+	}
+	noSecretStore := validRequest
+	noSecretStore.Path = "no"
+
+	tests := []struct {
+		Name               string
+		Request            common.SecretsRequest
+		ExpectedRequestId  string
+		SecretsPath        string
+		SecretStoreEnabled string
+		ErrorExpected      bool
+		ExpectedStatusCode int
+	}{
+		{"Valid - sub-path no trailing slash, SecretsPath has trailing slash", validRequest, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
+		{"Valid - sub-path only with trailing slash", validPathWithSlash, expectedRequestId, "my-secrets", "true", false, http.StatusCreated},
+		{"Valid - both trailing slashes", validPathWithSlash, expectedRequestId, "my-secrets/", "true", false, http.StatusCreated},
+		{"Valid - no requestId", validNoRequestId, "", "", "true", false, http.StatusCreated},
+		{"Invalid - no path", NoPath, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - bad requestId", badRequestId, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - no secrets", noSecrets, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - missing secret key", missingSecretKey, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - missing secret value", missingSecretValue, "", "", "true", true, http.StatusBadRequest},
+		{"Invalid - No Secret Store", noSecretStore, "", "", "false", true, http.StatusInternalServerError},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			_ = os.Setenv(secret.EnvSecretStore, testCase.SecretStoreEnabled)
+
+			jsonData, err := json.Marshal(testCase.Request)
+			require.NoError(t, err)
+
+			reader := strings.NewReader(string(jsonData))
+
+			req, err := http.NewRequest(http.MethodPost, sdkCommon.APIV2SecretsRoute, reader)
+			require.NoError(t, err)
+			req.Header.Set(clients.CorrelationHeader, expectedCorrelationId)
+
+			recorder := httptest.NewRecorder()
+			handler := http.HandlerFunc(target.Secrets)
+			handler.ServeHTTP(recorder, req)
+
+			actualResponse := common.BaseResponse{}
+			err = json.Unmarshal(recorder.Body.Bytes(), &actualResponse)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase.ExpectedStatusCode, recorder.Result().StatusCode, "HTTP status code not as expected")
+			assert.Equal(t, contractsV2.ApiVersion, actualResponse.ApiVersion, "Api Version not as expected")
+			assert.Equal(t, testCase.ExpectedStatusCode, actualResponse.StatusCode, "BaseResponse status code not as expected")
+
+			if testCase.ErrorExpected {
+				assert.NotEmpty(t, actualResponse.Message, "Message is empty")
+				return // Test complete for error cases
+			}
+
+			assert.Equal(t, testCase.ExpectedRequestId, actualResponse.RequestId, "RequestID not as expected")
+			assert.Empty(t, actualResponse.Message, "Message not empty, as expected")
+		})
+	}
+}
+
+func doRequest(t *testing.T, method string, api string, handler http.HandlerFunc, body io.Reader) *httptest.ResponseRecorder {
+	req, err := http.NewRequest(method, api, body)
+	require.NoError(t, err)
+	req.Header.Set(clients.CorrelationHeader, expectedCorrelationId)
+
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	expectedStatusCode := http.StatusOK
+	if method == http.MethodPost {
+		expectedStatusCode = http.StatusMultiStatus
+	}
+
+	assert.Equal(t, expectedStatusCode, recorder.Code, "Wrong status code")
+	assert.Equal(t, clients.ContentTypeJSON, recorder.HeaderMap.Get(clients.ContentType), "Content type not set or not JSON")
+	assert.Equal(t, expectedCorrelationId, recorder.HeaderMap.Get(clients.CorrelationHeader), "CorrelationHeader not as expected")
+
+	require.NotEmpty(t, recorder.Body.String(), "Response body is empty")
+
+	return recorder
+}

--- a/internal/v2/controller/http/controller.go
+++ b/internal/v2/controller/http/controller.go
@@ -76,6 +76,6 @@ func (c *V2HttpController) sendEdgexError(
 	correlationID := request.Header.Get(sdkCommon.CorrelationHeader)
 	c.lc.Error(err.Error(), sdkCommon.CorrelationHeader, correlationID)
 	c.lc.Debug(err.DebugMessages(), sdkCommon.CorrelationHeader, correlationID)
-	response := common.NewBaseResponse("", err.Message(), err.Code())
+	response := common.NewBaseResponse("", err.Error(), err.Code())
 	c.sendResponse(writer, request, api, response, err.Code())
 }

--- a/openapi/v2/device-sdk.yaml
+++ b/openapi/v2/device-sdk.yaml
@@ -481,6 +481,39 @@ components:
             value:
               description: "A string representation of the reading's value"
               type: string
+    SecretsRequest:
+      allOf:
+        - $ref: '#/components/schemas/BaseRequest'
+      description: Defines the secret data to be stored
+      type: object
+      properties:
+        path:
+          description: Specifies the type or location in the secret to store
+          type: string
+          example: "mqtt-incoming"
+        secrets:
+          description: A list of the key/value pairs of secrets to store
+          type: array
+          items:
+            $ref: '#/components/schemas/SecretsKeyValue'
+      required:
+        - path
+        - secrets
+    SecretsKeyValue:
+      description: Defines the key/value pair of the secret
+      type: object
+      properties:
+        key:
+          description: The key to identify the secret
+          type: string
+          example: "username"
+        value:
+          description: The value of the secret
+          type: string
+          example: "mqtt-user"
+      required:
+        - key
+        - value
     SettingRequest:
       description: "Defines new values to be written to device resources, as part of an actuation (put) command to a device"
       additionalProperties:
@@ -1186,6 +1219,48 @@ paths:
             schema:
               $ref: '#/components/schemas/SettingRequest'
         required: true
+
+  /secrets:
+    parameters:
+      - $ref: '#/components/parameters/correlatedRequestHeader'
+    post:
+      summary: Stores secret(s) to the secure Secret Store
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/SecretsRequest'
+        required: true
+      responses:
+        '201':
+          description: "Created"
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
+        '400':
+          description: "Invalid request."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: "An unexpected error happened on the server."
+          headers:
+            X-Correlation-ID:
+              $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 
   /discovery:
     post:

--- a/openapi/v2/device-sdk.yaml
+++ b/openapi/v2/device-sdk.yaml
@@ -481,26 +481,26 @@ components:
             value:
               description: "A string representation of the reading's value"
               type: string
-    SecretsRequest:
+    SecretRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
       description: Defines the secret data to be stored
       type: object
       properties:
         path:
-          description: Specifies the type or location in the secret to store
+          description: Specifies the location within the secret to store
           type: string
-          example: "mqtt-incoming"
-        secrets:
-          description: A list of the key/value pairs of secrets to store
+          example: "credentials"
+        secretData:
+          description: A list of the key/value pairs of secret data to store
           type: array
           items:
-            $ref: '#/components/schemas/SecretsKeyValue'
+            $ref: '#/components/schemas/SecretDataKeyValue'
       required:
         - path
-        - secrets
-    SecretsKeyValue:
-      description: Defines the key/value pair of the secret
+        - secretData
+    SecretDataKeyValue:
+      description: Defines a key/value pair of the secret data
       type: object
       properties:
         key:
@@ -1220,17 +1220,17 @@ paths:
               $ref: '#/components/schemas/SettingRequest'
         required: true
 
-  /secrets:
+  /secret:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
     post:
-      summary: Stores secret(s) to the secure Secret Store
+      summary: Stores a secret to the secure Secret Store
       requestBody:
         content:
           application/json:
             schema:
               allOf:
-                - $ref: '#/components/schemas/SecretsRequest'
+                - $ref: '#/components/schemas/SecretRequest'
         required: true
       responses:
         '201':


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
No way to store secrets for the instance of a device service 


## Issue Number: #705


## What is the new behavior?

/api/v2/secret endpoint add to store exclusive secrets for the running device service instance.

This PR is dependent on PR https://github.com/edgexfoundry/device-sdk-go/pull/707

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
