### PR TITLE
fix: rm unused pkg/service function params

### DIFF
--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -27,7 +27,7 @@ import (
 
 var instanceName string
 
-func Main(serviceName string, serviceVersion string, proto interface{}, ctx context.Context, cancel context.CancelFunc, router *mux.Router, _ chan<- bool) {
+func Main(serviceName string, serviceVersion string, proto interface{}, ctx context.Context, cancel context.CancelFunc, router *mux.Router) {
 	startupTimer := startup.NewStartUpTimer(serviceName)
 
 	additionalUsage :=
@@ -38,7 +38,7 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 	sdkFlags.FlagSet.StringVar(&instanceName, "i", "", "")
 	sdkFlags.Parse(os.Args[1:])
 
-	serviceName = setServiceName(serviceName, sdkFlags.Profile())
+	serviceName = setServiceName(serviceName)
 	ds = &DeviceService{}
 	ds.Initialize(serviceName, serviceVersion, proto)
 
@@ -71,7 +71,7 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 	ds.Stop(false)
 }
 
-func setServiceName(name string, _ string) string {
+func setServiceName(name string) string {
 	envValue := os.Getenv(common.EnvInstanceName)
 	if len(envValue) > 0 {
 		instanceName = envValue

--- a/pkg/startup/bootstrap.go
+++ b/pkg/startup/bootstrap.go
@@ -16,5 +16,5 @@ import (
 
 func Bootstrap(serviceName string, serviceVersion string, driver interface{}) {
 	ctx, cancel := context.WithCancel(context.Background())
-	service.Main(serviceName, serviceVersion, driver, ctx, cancel, mux.NewRouter(), nil)
+	service.Main(serviceName, serviceVersion, driver, ctx, cancel, mux.NewRouter())
 }


### PR DESCRIPTION
Cleanup unused function parameters which had been converted to use the blank identifier.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
This change doesn't impact the behavior of services based on the SDK.

## Issue Number:  fix #721

## What is the new behavior?
NA

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

See issue description for more details.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
