### PR TITLE
feat: process queryParams of url in put method and copy device resource attributes if queryParams is not empty

### DIFF
--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -140,8 +140,11 @@ func execReadDeviceResource(
 	req.DeviceResourceName = dr.Name
 	req.Attributes = dr.Attributes
 	if queryParams != "" {
-		if len(req.Attributes) <= 0 {
-			req.Attributes = make(map[string]string)
+		req.Attributes = make(map[string]string)
+		if len(dr.Attributes) > 0 {
+			for k, v := range dr.Attributes {
+				req.Attributes[k] = v
+			}
 		}
 		m := common.FilterQueryParams(queryParams, lc)
 		req.Attributes[common.URLRawQuery] = m.Encode()
@@ -290,8 +293,11 @@ func execReadCmd(
 		reqs[i].DeviceResourceName = dr.Name
 		reqs[i].Attributes = dr.Attributes
 		if queryParams != "" {
-			if len(reqs[i].Attributes) <= 0 {
-				reqs[i].Attributes = make(map[string]string)
+			reqs[i].Attributes = make(map[string]string)
+			if len(dr.Attributes) > 0 {
+				for k, v := range dr.Attributes {
+					reqs[i].Attributes[k] = v
+				}
 			}
 			m := common.FilterQueryParams(queryParams, lc)
 			reqs[i].Attributes[common.URLRawQuery] = m.Encode()

--- a/internal/handler/command_test.go
+++ b/internal/handler/command_test.go
@@ -403,7 +403,7 @@ func TestExecWriteCmd(t *testing.T) {
 					configuration.Device.MaxCmdOps = 128
 				}()
 			}
-			appErr := execWriteCmd(tt.device, tt.cmd, tt.params, driver, lc, configuration)
+			appErr := execWriteCmd(tt.device, tt.cmd, "", tt.params, driver, lc, configuration)
 			if !tt.expectErr && appErr != nil {
 				t.Errorf("%s expectErr:%v error:%v", tt.testName, tt.expectErr, appErr.Error())
 				return


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
copy device resource attributes if queryParams is not empty and process queryParams of url in `put` method(write functions)

## Issue Number: #730 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
