### PR TITLE
refactor: remove ValueType enumeration in Go-SDK

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/google/uuid"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
@@ -48,11 +49,11 @@ func CommandValueToReading(cv *dsModels.CommandValue, devName string, mediaType 
 		encoding = dsModels.DefaultFloatEncoding
 	}
 
-	reading := &contract.Reading{Name: cv.DeviceResourceName, Device: devName, ValueType: cv.ValueTypeToString()}
-	if cv.Type == dsModels.Binary {
+	reading := &contract.Reading{Name: cv.DeviceResourceName, Device: devName, ValueType: cv.Type}
+	if cv.Type == v2.ValueTypeBool {
 		reading.BinaryValue = cv.BinValue
 		reading.MediaType = mediaType
-	} else if cv.Type == dsModels.Float32 || cv.Type == dsModels.Float64 {
+	} else if cv.Type == v2.ValueTypeFloat32 || cv.Type == v2.ValueTypeFloat64 {
 		reading.Value = cv.ValueToString(encoding)
 		reading.FloatEncoding = encoding
 	} else {

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 )
 
 // Note, every HTTP request to ServeHTTP is made in a separate goroutine, which
@@ -146,7 +147,7 @@ func execReadDeviceResource(
 		m := common.FilterQueryParams(queryParams, lc)
 		req.Attributes[common.URLRawQuery] = m.Encode()
 	}
-	req.Type = dsModels.ParseValueType(dr.Properties.Value.Type)
+	req.Type = dr.Properties.Value.Type
 	reqs = append(reqs, req)
 
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
@@ -221,7 +222,7 @@ func cvsToEvent(
 		reading := common.CommandValueToReading(cv, device.Name, dr.Properties.Value.MediaType, dr.Properties.Value.FloatEncoding)
 		readings = append(readings, *reading)
 
-		if cv.Type == dsModels.Binary {
+		if cv.Type == v2.ValueTypeBinary {
 			lc.Debug(fmt.Sprintf("Handler - execReadCmd: device: %s DeviceResource: %v reading: binary value", device.Name, cv.DeviceResourceName))
 		} else {
 			lc.Debug(fmt.Sprintf("Handler - execReadCmd: device: %s DeviceResource: %v reading: %v", device.Name, cv.DeviceResourceName, reading))
@@ -296,7 +297,7 @@ func execReadCmd(
 			m := common.FilterQueryParams(queryParams, lc)
 			reqs[i].Attributes[common.URLRawQuery] = m.Encode()
 		}
-		reqs[i].Type = dsModels.ParseValueType(dr.Properties.Value.Type)
+		reqs[i].Type = dr.Properties.Value.Type
 	}
 
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)

--- a/internal/handler/command_test.go
+++ b/internal/handler/command_test.go
@@ -18,14 +18,13 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/mock"
-	dsModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -170,62 +169,62 @@ func TestCreateCommandValueForParam(t *testing.T) {
 		valueType   string
 		op          *contract.ResourceOperation
 		v           string
-		parseCheck  dsModels.ValueType
+		parseCheck  string
 		expectErr   bool
 	}{
-		{"DeviceResourceNotFound", mock.ProfileBool, typeBool, &contract.ResourceOperation{}, "", dsModels.Bool, true},
-		{"BoolTruePass", mock.ProfileBool, typeBool, &operationSetBool, "true", dsModels.Bool, false},
-		{"BoolFalsePass", mock.ProfileBool, typeBool, &operationSetBool, "false", dsModels.Bool, false},
-		{"BoolTrueFail", mock.ProfileBool, typeBool, &operationSetBool, "error", dsModels.Bool, true},
-		{"Int8Pass", mock.ProfileInt, typeInt8, &operationSetInt8, "12", dsModels.Int8, false},
-		{"Int8NegativePass", mock.ProfileInt, typeInt8, &operationSetInt8, "-12", dsModels.Int8, false},
-		{"Int8WordFail", mock.ProfileInt, typeInt8, &operationSetInt8, "hello", dsModels.Int8, true},
-		{"Int8OverflowFail", mock.ProfileInt, typeInt8, &operationSetInt8, "9999999999", dsModels.Int8, true},
-		{"Int16Pass", mock.ProfileInt, typeInt16, &operationSetInt16, "12", dsModels.Int16, false},
-		{"Int16NegativePass", mock.ProfileInt, typeInt16, &operationSetInt16, "-12", dsModels.Int16, false},
-		{"Int16WordFail", mock.ProfileInt, typeInt16, &operationSetInt16, "hello", dsModels.Int16, true},
-		{"Int16OverflowFail", mock.ProfileInt, typeInt16, &operationSetInt16, "9999999999", dsModels.Int16, true},
-		{"Int32Pass", mock.ProfileInt, typeInt32, &operationSetInt32, "12", dsModels.Int32, false},
-		{"Int32NegativePass", mock.ProfileInt, typeInt32, &operationSetInt32, "-12", dsModels.Int32, false},
-		{"Int32WordFail", mock.ProfileInt, typeInt32, &operationSetInt32, "hello", dsModels.Int32, true},
-		{"Int32OverflowFail", mock.ProfileInt, typeInt32, &operationSetInt32, "9999999999", dsModels.Int32, true},
-		{"Int64Pass", mock.ProfileInt, typeInt64, &operationSetInt64, "12", dsModels.Int64, false},
-		{"Int64NegativePass", mock.ProfileInt, typeInt64, &operationSetInt64, "-12", dsModels.Int64, false},
-		{"Int64WordFail", mock.ProfileInt, typeInt64, &operationSetInt64, "hello", dsModels.Int64, true},
-		{"Int64OverflowFail", mock.ProfileInt, typeInt64, &operationSetInt64, "99999999999999999999", dsModels.Int64, true},
-		{"Uint8Pass", mock.ProfileUint, typeUint8, &operationSetUint8, "12", dsModels.Uint8, false},
-		{"Uint8NegativeFail", mock.ProfileUint, typeUint8, &operationSetUint8, "-12", dsModels.Uint8, true},
-		{"Uint8WordFail", mock.ProfileUint, typeUint8, &operationSetUint8, "hello", dsModels.Uint8, true},
-		{"Uint8OverflowFail", mock.ProfileUint, typeUint8, &operationSetUint8, "9999999999", dsModels.Uint8, true},
-		{"Uint16Pass", mock.ProfileUint, typeUint16, &operationSetUint16, "12", dsModels.Uint16, false},
-		{"Uint16NegativeFail", mock.ProfileUint, typeUint16, &operationSetUint16, "-12", dsModels.Uint16, true},
-		{"Uint16WordFail", mock.ProfileUint, typeUint16, &operationSetUint16, "hello", dsModels.Uint16, true},
-		{"Uint16OverflowFail", mock.ProfileUint, typeUint16, &operationSetUint16, "9999999999", dsModels.Uint16, true},
-		{"Uint32Pass", mock.ProfileUint, typeUint32, &operationSetUint32, "12", dsModels.Uint32, false},
-		{"Uint32NegativeFail", mock.ProfileUint, typeUint32, &operationSetUint32, "-12", dsModels.Uint32, true},
-		{"Uint32WordFail", mock.ProfileUint, typeUint32, &operationSetUint32, "hello", dsModels.Uint32, true},
-		{"Uint32OverflowFail", mock.ProfileUint, typeUint32, &operationSetUint32, "9999999999", dsModels.Uint32, true},
-		{"Uint64Pass", mock.ProfileUint, typeUint64, &operationSetUint64, "12", dsModels.Uint64, false},
-		{"Uint64NegativeFail", mock.ProfileUint, typeUint64, &operationSetUint64, "-12", dsModels.Uint64, true},
-		{"Uint64WordFail", mock.ProfileUint, typeUint64, &operationSetUint64, "hello", dsModels.Uint64, true},
-		{"Uint64OverflowFail", mock.ProfileUint, typeUint64, &operationSetUint64, "99999999999999999999", dsModels.Uint64, true},
-		{"Float32Pass", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "12.000", dsModels.Float32, false},
-		{"Float32PassWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "QUAAAA==", dsModels.Float32, false},
-		{"Float32PassWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "0.123123e-05", dsModels.Float32, false},
-		{"Float32PassNegativePass", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "-12.000", dsModels.Float32, false},
-		{"Float32PassNegativePassWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "wUAAAA==", dsModels.Float32, false},
-		{"Float32PassNegativePassWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "-0.123123e-05", dsModels.Float32, false},
-		{"Float32PassWordFail", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "hello", dsModels.Float32, true},
-		{"Float32PassOverflowFail", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "440282346638528859811704183484516925440.0000000000000000", dsModels.Float32, true},
-		{"Float32PassOverflowFailWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "f+////////8=", dsModels.Float32, true},
-		{"Float32PassOverflowFailWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "12.000e+38", dsModels.Float32, true},
-		{"Float64Pass", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "12.000", dsModels.Float64, false},
-		{"Float64PassWithBase64String", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "QCgAAAAAAAA=", dsModels.Float64, false},
-		{"Float64PassWithENotation", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "0.12345e-16", dsModels.Float64, false},
-		{"Float64PassNegativePass", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "-12.000", dsModels.Float64, false},
-		{"Float64PassNegativePassWithBase64String", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "wCgAAAAAAAA=", dsModels.Float64, false},
-		{"Float64PassNegativePassWithENotation", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "-0.12345e-16", dsModels.Float64, false},
-		{"Float64PassWordFail", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "hello", dsModels.Float64, true},
+		{"DeviceResourceNotFound", mock.ProfileBool, typeBool, &contract.ResourceOperation{}, "", v2.ValueTypeBool, true},
+		{"BoolTruePass", mock.ProfileBool, typeBool, &operationSetBool, "true", v2.ValueTypeBool, false},
+		{"BoolFalsePass", mock.ProfileBool, typeBool, &operationSetBool, "false", v2.ValueTypeBool, false},
+		{"BoolTrueFail", mock.ProfileBool, typeBool, &operationSetBool, "error", v2.ValueTypeBool, true},
+		{"Int8Pass", mock.ProfileInt, typeInt8, &operationSetInt8, "12", v2.ValueTypeInt8, false},
+		{"Int8NegativePass", mock.ProfileInt, typeInt8, &operationSetInt8, "-12", v2.ValueTypeInt8, false},
+		{"Int8WordFail", mock.ProfileInt, typeInt8, &operationSetInt8, "hello", v2.ValueTypeInt8, true},
+		{"Int8OverflowFail", mock.ProfileInt, typeInt8, &operationSetInt8, "9999999999", v2.ValueTypeInt8, true},
+		{"Int16Pass", mock.ProfileInt, typeInt16, &operationSetInt16, "12", v2.ValueTypeInt16, false},
+		{"Int16NegativePass", mock.ProfileInt, typeInt16, &operationSetInt16, "-12", v2.ValueTypeInt16, false},
+		{"Int16WordFail", mock.ProfileInt, typeInt16, &operationSetInt16, "hello", v2.ValueTypeInt16, true},
+		{"Int16OverflowFail", mock.ProfileInt, typeInt16, &operationSetInt16, "9999999999", v2.ValueTypeInt16, true},
+		{"Int32Pass", mock.ProfileInt, typeInt32, &operationSetInt32, "12", v2.ValueTypeInt32, false},
+		{"Int32NegativePass", mock.ProfileInt, typeInt32, &operationSetInt32, "-12", v2.ValueTypeInt32, false},
+		{"Int32WordFail", mock.ProfileInt, typeInt32, &operationSetInt32, "hello", v2.ValueTypeInt32, true},
+		{"Int32OverflowFail", mock.ProfileInt, typeInt32, &operationSetInt32, "9999999999", v2.ValueTypeInt32, true},
+		{"Int64Pass", mock.ProfileInt, typeInt64, &operationSetInt64, "12", v2.ValueTypeInt64, false},
+		{"Int64NegativePass", mock.ProfileInt, typeInt64, &operationSetInt64, "-12", v2.ValueTypeInt64, false},
+		{"Int64WordFail", mock.ProfileInt, typeInt64, &operationSetInt64, "hello", v2.ValueTypeInt64, true},
+		{"Int64OverflowFail", mock.ProfileInt, typeInt64, &operationSetInt64, "99999999999999999999", v2.ValueTypeInt64, true},
+		{"Uint8Pass", mock.ProfileUint, typeUint8, &operationSetUint8, "12", v2.ValueTypeUint8, false},
+		{"Uint8NegativeFail", mock.ProfileUint, typeUint8, &operationSetUint8, "-12", v2.ValueTypeUint8, true},
+		{"Uint8WordFail", mock.ProfileUint, typeUint8, &operationSetUint8, "hello", v2.ValueTypeUint8, true},
+		{"Uint8OverflowFail", mock.ProfileUint, typeUint8, &operationSetUint8, "9999999999", v2.ValueTypeUint8, true},
+		{"Uint16Pass", mock.ProfileUint, typeUint16, &operationSetUint16, "12", v2.ValueTypeUint16, false},
+		{"Uint16NegativeFail", mock.ProfileUint, typeUint16, &operationSetUint16, "-12", v2.ValueTypeUint16, true},
+		{"Uint16WordFail", mock.ProfileUint, typeUint16, &operationSetUint16, "hello", v2.ValueTypeUint16, true},
+		{"Uint16OverflowFail", mock.ProfileUint, typeUint16, &operationSetUint16, "9999999999", v2.ValueTypeUint16, true},
+		{"Uint32Pass", mock.ProfileUint, typeUint32, &operationSetUint32, "12", v2.ValueTypeUint32, false},
+		{"Uint32NegativeFail", mock.ProfileUint, typeUint32, &operationSetUint32, "-12", v2.ValueTypeUint32, true},
+		{"Uint32WordFail", mock.ProfileUint, typeUint32, &operationSetUint32, "hello", v2.ValueTypeUint32, true},
+		{"Uint32OverflowFail", mock.ProfileUint, typeUint32, &operationSetUint32, "9999999999", v2.ValueTypeUint32, true},
+		{"Uint64Pass", mock.ProfileUint, typeUint64, &operationSetUint64, "12", v2.ValueTypeUint64, false},
+		{"Uint64NegativeFail", mock.ProfileUint, typeUint64, &operationSetUint64, "-12", v2.ValueTypeUint64, true},
+		{"Uint64WordFail", mock.ProfileUint, typeUint64, &operationSetUint64, "hello", v2.ValueTypeUint64, true},
+		{"Uint64OverflowFail", mock.ProfileUint, typeUint64, &operationSetUint64, "99999999999999999999", v2.ValueTypeUint64, true},
+		{"Float32Pass", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "12.000", v2.ValueTypeFloat32, false},
+		{"Float32PassWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "QUAAAA==", v2.ValueTypeFloat32, false},
+		{"Float32PassWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "0.123123e-05", v2.ValueTypeFloat32, false},
+		{"Float32PassNegativePass", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "-12.000", v2.ValueTypeFloat32, false},
+		{"Float32PassNegativePassWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "wUAAAA==", v2.ValueTypeFloat32, false},
+		{"Float32PassNegativePassWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "-0.123123e-05", v2.ValueTypeFloat32, false},
+		{"Float32PassWordFail", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "hello", v2.ValueTypeFloat32, true},
+		{"Float32PassOverflowFail", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "440282346638528859811704183484516925440.0000000000000000", v2.ValueTypeFloat32, true},
+		{"Float32PassOverflowFailWithBase64String", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "f+////////8=", v2.ValueTypeFloat32, true},
+		{"Float32PassOverflowFailWithENotation", mock.ProfileFloat, typeFloat32, &operationSetFloat32, "12.000e+38", v2.ValueTypeFloat32, true},
+		{"Float64Pass", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "12.000", v2.ValueTypeFloat64, false},
+		{"Float64PassWithBase64String", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "QCgAAAAAAAA=", v2.ValueTypeFloat64, false},
+		{"Float64PassWithENotation", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "0.12345e-16", v2.ValueTypeFloat64, false},
+		{"Float64PassNegativePass", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "-12.000", v2.ValueTypeFloat64, false},
+		{"Float64PassNegativePassWithBase64String", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "wCgAAAAAAAA=", v2.ValueTypeFloat64, false},
+		{"Float64PassNegativePassWithENotation", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "-0.12345e-16", v2.ValueTypeFloat64, false},
+		{"Float64PassWordFail", mock.ProfileFloat, typeFloat64, &operationSetFloat64, "hello", v2.ValueTypeFloat64, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
@@ -239,32 +238,32 @@ func TestCreateCommandValueForParam(t *testing.T) {
 				return
 			}
 			if cv != nil {
-				var check dsModels.ValueType
+				var check string
 				switch strings.ToLower(tt.valueType) {
 				case "bool":
-					check = dsModels.Bool
+					check = v2.ValueTypeBool
 				case "string":
-					check = dsModels.String
+					check = v2.ValueTypeString
 				case "uint8":
-					check = dsModels.Uint8
+					check = v2.ValueTypeUint8
 				case "uint16":
-					check = dsModels.Uint16
+					check = v2.ValueTypeUint16
 				case "uint32":
-					check = dsModels.Uint32
+					check = v2.ValueTypeUint32
 				case "uint64":
-					check = dsModels.Uint64
+					check = v2.ValueTypeUint64
 				case "int8":
-					check = dsModels.Int8
+					check = v2.ValueTypeInt8
 				case "int16":
-					check = dsModels.Int16
+					check = v2.ValueTypeInt16
 				case "int32":
-					check = dsModels.Int32
+					check = v2.ValueTypeInt32
 				case "int64":
-					check = dsModels.Int64
+					check = v2.ValueTypeInt64
 				case "float32":
-					check = dsModels.Float32
+					check = v2.ValueTypeFloat32
 				case "float64":
-					check = dsModels.Float64
+					check = v2.ValueTypeFloat64
 				}
 				if cv.Type != check {
 					t.Errorf("%s incorrect parsing. valueType: %s result: %v", tt.testName, tt.valueType, cv.Type)

--- a/internal/transformer/checkNaN.go
+++ b/internal/transformer/checkNaN.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ import (
 	"math"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 )
 
 // NaNError is used to throw the NaN error for the floating-point value
@@ -21,7 +22,7 @@ func (e NaNError) Error() string {
 
 func isNaN(cv *dsModels.CommandValue) (bool, error) {
 	switch cv.Type {
-	case dsModels.Float32:
+	case v2.ValueTypeFloat32:
 		v, err := cv.Float32Value()
 		if err != nil {
 			return false, err
@@ -29,7 +30,7 @@ func isNaN(cv *dsModels.CommandValue) (bool, error) {
 		if math.IsNaN(float64(v)) {
 			return true, nil
 		}
-	case dsModels.Float64:
+	case v2.ValueTypeFloat64:
 		v, err := cv.Float64Value()
 		if err != nil {
 			return false, err

--- a/internal/transformer/transformparam.go
+++ b/internal/transformer/transformparam.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2018-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,11 +14,12 @@ import (
 	dsModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 )
 
 func TransformWriteParameter(cv *dsModels.CommandValue, pv contract.PropertyValue, lc logger.LoggingClient) error {
 	var err error
-	if cv.Type == dsModels.String || cv.Type == dsModels.Bool || cv.Type == dsModels.Binary {
+	if cv.Type == v2.ValueTypeString || cv.Type == v2.ValueTypeBool || cv.Type == v2.ValueTypeBinary {
 		return nil // do nothing for String, Bool and Binary
 	}
 

--- a/internal/transformer/transformresult.go
+++ b/internal/transformer/transformresult.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2020 IOTech Ltd
+// Copyright (C) 2019-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,6 +21,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/requests/states/operating"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/google/uuid"
 )
 
@@ -36,7 +37,7 @@ const (
 )
 
 func TransformReadResult(cv *dsModels.CommandValue, pv contract.PropertyValue, lc logger.LoggingClient) error {
-	if cv.Type == dsModels.String || cv.Type == dsModels.Bool || cv.Type == dsModels.Binary {
+	if cv.Type == v2.ValueTypeString || cv.Type == v2.ValueTypeBool || cv.Type == v2.ValueTypeBinary {
 		return nil // do nothing for String, Bool and Binary
 	}
 	res, err := isNaN(cv)
@@ -50,7 +51,7 @@ func TransformReadResult(cv *dsModels.CommandValue, pv contract.PropertyValue, l
 	newValue := value
 
 	if pv.Mask != "" && pv.Mask != defaultMask &&
-		(cv.Type == dsModels.Uint8 || cv.Type == dsModels.Uint16 || cv.Type == dsModels.Uint32 || cv.Type == dsModels.Uint64) {
+		(cv.Type == v2.ValueTypeUint8 || cv.Type == v2.ValueTypeUint16 || cv.Type == v2.ValueTypeUint32 || cv.Type == v2.ValueTypeUint64) {
 		newValue, err = transformReadMask(newValue, pv.Mask, lc)
 		if err != nil {
 			return err
@@ -58,7 +59,7 @@ func TransformReadResult(cv *dsModels.CommandValue, pv contract.PropertyValue, l
 	}
 
 	if pv.Shift != "" && pv.Shift != defaultShift &&
-		(cv.Type == dsModels.Uint8 || cv.Type == dsModels.Uint16 || cv.Type == dsModels.Uint32 || cv.Type == dsModels.Uint64) {
+		(cv.Type == v2.ValueTypeUint8 || cv.Type == v2.ValueTypeUint16 || cv.Type == v2.ValueTypeUint32 || cv.Type == v2.ValueTypeUint64) {
 		newValue, err = transformReadShift(newValue, pv.Shift, lc)
 		if err != nil {
 			return fmt.Errorf("transform failed for device resource '%v', error: %w ", cv.DeviceResourceName, err)
@@ -532,52 +533,52 @@ func commandValueForTransform(cv *dsModels.CommandValue) (interface{}, error) {
 	var v interface{}
 	var err error = nil
 	switch cv.Type {
-	case dsModels.Uint8:
+	case v2.ValueTypeUint8:
 		v, err = cv.Uint8Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Uint16:
+	case v2.ValueTypeUint16:
 		v, err = cv.Uint16Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Uint32:
+	case v2.ValueTypeUint32:
 		v, err = cv.Uint32Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Uint64:
+	case v2.ValueTypeUint64:
 		v, err = cv.Uint64Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Int8:
+	case v2.ValueTypeInt8:
 		v, err = cv.Int8Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Int16:
+	case v2.ValueTypeInt16:
 		v, err = cv.Int16Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Int32:
+	case v2.ValueTypeInt32:
 		v, err = cv.Int32Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Int64:
+	case v2.ValueTypeInt64:
 		v, err = cv.Int64Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Float32:
+	case v2.ValueTypeFloat32:
 		v, err = cv.Float32Value()
 		if err != nil {
 			return 0, err
 		}
-	case dsModels.Float64:
+	case v2.ValueTypeFloat64:
 		v, err = cv.Float64Value()
 		if err != nil {
 			return 0, err

--- a/internal/transformer/transformresult_test.go
+++ b/internal/transformer/transformresult_test.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2020 IOTech Ltd
+// Copyright (C) 2019-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,7 @@ import (
 	dsModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 )
 
 var lc logger.LoggingClient
@@ -45,8 +46,8 @@ func TestTransformReadResult_base_unt8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -91,8 +92,8 @@ func TestTransformReadResult_scale_unt8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -137,8 +138,8 @@ func TestTransformReadResult_offset_unt8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -183,8 +184,8 @@ func TestTransformReadResult_base_unt16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -229,8 +230,8 @@ func TestTransformReadResult_scale_uint16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -275,8 +276,8 @@ func TestTransformReadResult_offset_uint16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -321,8 +322,8 @@ func TestTransformReadResult_base_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -367,8 +368,8 @@ func TestTransformReadResult_scale_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -413,8 +414,8 @@ func TestTransformReadResult_offset_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -459,8 +460,8 @@ func TestTransformReadResult_base_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 
@@ -486,8 +487,8 @@ func TestTransformReadResult_scale_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 
@@ -513,8 +514,8 @@ func TestTransformReadResult_offset_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 
@@ -540,8 +541,8 @@ func TestTransformReadResult_base_int8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int8)
+	if cv.Type != v2.ValueTypeInt8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt8)
 	}
 }
 
@@ -586,8 +587,8 @@ func TestTransformReadResult_scale_int8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v", result, expected)
 	}
-	if cv.Type != dsModels.Int8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int8)
+	if cv.Type != v2.ValueTypeInt8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt8)
 	}
 }
 
@@ -632,8 +633,8 @@ func TestTransformReadResult_offset_int8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int8)
+	if cv.Type != v2.ValueTypeInt8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt8)
 	}
 }
 
@@ -678,8 +679,8 @@ func TestTransformReadResult_base_int16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int16)
+	if cv.Type != v2.ValueTypeInt16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt16)
 	}
 }
 
@@ -724,8 +725,8 @@ func TestTransformReadResult_scale_int16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int16)
+	if cv.Type != v2.ValueTypeInt16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt16)
 	}
 }
 
@@ -770,8 +771,8 @@ func TestTransformReadResult_offset_int16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int16)
+	if cv.Type != v2.ValueTypeInt16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt16)
 	}
 }
 
@@ -816,8 +817,8 @@ func TestTransformReadResult_base_int32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int32)
+	if cv.Type != v2.ValueTypeInt32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt32)
 	}
 }
 
@@ -862,8 +863,8 @@ func TestTransformReadResult_scale_int32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int32)
+	if cv.Type != v2.ValueTypeInt32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt32)
 	}
 }
 
@@ -908,8 +909,8 @@ func TestTransformReadResult_offset_int32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int32)
+	if cv.Type != v2.ValueTypeInt32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt32)
 	}
 }
 
@@ -954,8 +955,8 @@ func TestTransformReadResult_base_int64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int64)
+	if cv.Type != v2.ValueTypeInt64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt64)
 	}
 }
 
@@ -981,8 +982,8 @@ func TestTransformReadResult_scale_int64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int64)
+	if cv.Type != v2.ValueTypeInt64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt64)
 	}
 }
 
@@ -1008,8 +1009,8 @@ func TestTransformReadResult_offset_int64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Int64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Int64)
+	if cv.Type != v2.ValueTypeInt64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeInt64)
 	}
 }
 
@@ -1035,8 +1036,8 @@ func TestTransformReadResult_base_float32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float32)
+	if cv.Type != v2.ValueTypeFloat32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat32)
 	}
 }
 
@@ -1081,8 +1082,8 @@ func TestTransformReadResult_scale_float32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float32)
+	if cv.Type != v2.ValueTypeFloat32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat32)
 	}
 }
 
@@ -1127,8 +1128,8 @@ func TestTransformReadResult_offset_float32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float32)
+	if cv.Type != v2.ValueTypeFloat32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat32)
 	}
 }
 
@@ -1173,8 +1174,8 @@ func TestTransformReadResult_base_float64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float64)
+	if cv.Type != v2.ValueTypeFloat64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat64)
 	}
 }
 
@@ -1200,8 +1201,8 @@ func TestTransformReadResult_scale_float64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float32)
+	if cv.Type != v2.ValueTypeFloat32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat32)
 	}
 }
 
@@ -1227,8 +1228,8 @@ func TestTransformReadResult_offset_float64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Float64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Float64)
+	if cv.Type != v2.ValueTypeFloat64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeFloat64)
 	}
 }
 
@@ -1254,8 +1255,8 @@ func TestTransformReadResult_mask_uint8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -1281,8 +1282,8 @@ func TestTransformReadResult_mask_uint16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -1308,8 +1309,8 @@ func TestTransformReadResult_mask_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -1335,8 +1336,8 @@ func TestTransformReadResult_mask_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 
@@ -1378,8 +1379,8 @@ func TestTransformReadResult_shift_uint8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -1405,8 +1406,8 @@ func TestTransformReadResult_signedShift_uint8(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint8 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint8)
+	if cv.Type != v2.ValueTypeUint8 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint8)
 	}
 }
 
@@ -1432,8 +1433,8 @@ func TestTransformReadResult_shift_uint16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -1459,8 +1460,8 @@ func TestTransformReadResult_signedShift_uint16(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint16 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint16)
+	if cv.Type != v2.ValueTypeUint16 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint16)
 	}
 }
 
@@ -1486,8 +1487,8 @@ func TestTransformReadResult_shift_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -1513,8 +1514,8 @@ func TestTransformReadResult_signedShift_uint32(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint32 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint32)
+	if cv.Type != v2.ValueTypeUint32 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint32)
 	}
 }
 
@@ -1540,8 +1541,8 @@ func TestTransformReadResult_shift_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 
@@ -1567,8 +1568,8 @@ func TestTransformReadResult_signedShift_uint64(t *testing.T) {
 	if result != expected {
 		t.Fatalf("Unexpect test result, result '%v' should be '%v'", result, expected)
 	}
-	if cv.Type != dsModels.Uint64 {
-		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, dsModels.Uint64)
+	if cv.Type != v2.ValueTypeUint64 {
+		t.Fatalf("Unexpect test result, value type '%v' should be '%v'", cv.Type, v2.ValueTypeUint64)
 	}
 }
 

--- a/internal/v2/application/command.go
+++ b/internal/v2/application/command.go
@@ -154,7 +154,7 @@ func (c *CommandProcessor) ReadDeviceResource() (res responses.EventResponse, e 
 		}
 		req.Attributes[sdkCommon.URLRawQuery] = c.params
 	}
-	req.Type = dsModels.ParseValueType(c.deviceResource.Properties.Value.Type)
+	req.Type = c.deviceResource.Properties.Value.Type
 	reqs = append(reqs, req)
 
 	// execute protocol-specific read operation
@@ -218,7 +218,7 @@ func (c *CommandProcessor) ReadCommand() (res responses.EventResponse, e edgexEr
 			}
 			reqs[i].Attributes[sdkCommon.URLRawQuery] = c.params
 		}
-		reqs[i].Type = dsModels.ParseValueType(dr.Properties.Value.Type)
+		reqs[i].Type = dr.Properties.Value.Type
 	}
 
 	// execute protocol-specific read operation
@@ -455,7 +455,7 @@ func (c *CommandProcessor) commandValuesToEvent(cvs []*dsModels.CommandValue, cm
 		reading := commandValueToReading(cv, c.device.Name, dr.Properties.Value.MediaType, dr.Properties.Value.FloatEncoding)
 		readings = append(readings, reading)
 
-		if cv.Type == dsModels.Binary {
+		if cv.Type == v2.ValueTypeBinary {
 			lc.Debug(fmt.Sprintf("device: %s DeviceResource: %v reading: binary value", c.device.Name, cv.DeviceResourceName), sdkCommon.CorrelationHeader, c.correlationID)
 		} else {
 			lc.Debug(fmt.Sprintf("device: %s DeviceResource: %v reading: %v", c.device.Name, cv.DeviceResourceName, reading), sdkCommon.CorrelationHeader, c.correlationID)
@@ -718,8 +718,8 @@ func commandValueToReading(cv *dsModels.CommandValue, deviceName string, mediaTy
 		encoding = dsModels.DefaultFloatEncoding
 	}
 
-	reading := dtos.BaseReading{ResourceName: cv.DeviceResourceName, DeviceName: deviceName, ValueType: cv.ValueTypeToString()}
-	if cv.Type == dsModels.Binary {
+	reading := dtos.BaseReading{ResourceName: cv.DeviceResourceName, DeviceName: deviceName, ValueType: cv.Type}
+	if cv.Type == v2.ValueTypeBinary {
 		reading.BinaryValue = cv.BinValue
 		reading.MediaType = mediaType
 	} else {

--- a/pkg/models/commandrequest.go
+++ b/pkg/models/commandrequest.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2019 IOTech Ltd
+// Copyright (C) 2019-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,5 +14,5 @@ type CommandRequest struct {
 	// Attributes is a key/value map to represent the attributes of the Device Resource
 	Attributes map[string]string
 	// Type is the data type of the Device Resource
-	Type ValueType
+	Type string
 }

--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2018-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,86 +17,8 @@ import (
 	"strconv"
 	"strings"
 
-	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
-)
-
-// ValueType indicates the type of value being passed back
-// from a ProtocolDriver instance.
-type ValueType int
-
-const (
-	// Bool indicates that the value is a bool,
-	// stored in CommandValue's boolRes member.
-	Bool ValueType = iota
-	// BoolArray indicates that the value is array of bool,
-	// store in CommandValue's stringValue member.
-	BoolArray
-	// String indicates that the value is a string,
-	// stored in CommandValue's stringRes member.
-	String
-	// Uint8 indicates that the value is a uint8 that
-	// is stored in CommandValue's NumericRes member.
-	Uint8
-	// Uint8Array indicates that the value is array of uint8,
-	// store in CommandValue's stringValue member.
-	Uint8Array
-	// Uint16 indicates that the value is a uint16 that
-	// is stored in CommandValue's NumericRes member.
-	Uint16
-	// Uint16Array indicates that the value is array of uint16,
-	// store in CommandValue's stringValue member.
-	Uint16Array
-	// Uint32 indicates that the value is a uint32 that
-	// is stored in CommandValue's NumericRes member.
-	Uint32
-	// Uint32Array indicates that the value is array of uint32,
-	// store in CommandValue's stringValue member.
-	Uint32Array
-	// Uint64 indicates that the value is a uint64 that
-	// is stored in CommandValue's NumericRes member.
-	Uint64
-	// Uint64Array indicates that the value is array of uint64,
-	// store in CommandValue's stringValue member.
-	Uint64Array
-	// Int8 indicates that the value is a int8 that
-	// is stored in CommandValue's NumericRes member.
-	Int8
-	// Int8Array indicates that the value is array of int8,
-	// store in CommandValue's stringValue member.
-	Int8Array
-	// Int16 indicates that the value is a int16 that
-	// is stored in CommandValue's NumericRes member.
-	Int16
-	// Int16Array indicates that the value is array of int16,
-	// store in CommandValue's stringValue member.
-	Int16Array
-	// Int32 indicates that the value is a int32 that
-	// is stored in CommandValue's NumericRes member.
-	Int32
-	// Int32Array indicates that the value is array of int32,
-	// store in CommandValue's stringValue member.
-	Int32Array
-	// Int64 indicates that the value is a int64 that
-	// is stored in CommandValue's NumericRes member.
-	Int64
-	// Int64Array indicates that the value is array of int64,
-	// store in CommandValue's stringValue member.
-	Int64Array
-	// Float32 indicates that the value is a float32 that
-	// is stored in CommandValue's NumericRes member.
-	Float32
-	// Float32Array indicates that the value is array of float32,
-	// store in CommandValue's stringValue member.
-	Float32Array
-	// Float64 indicates that the value is a float64 that
-	// is stored in CommandValue's NumericRes member.
-	Float64
-	// Float64Array indicates that the value is array of float64,
-	// store in CommandValue's stringValue member.
-	Float64Array
-	// Binary indicates that the value is a binary payload that
-	// is stored in CommandValue's ByteArrRes member.
-	Binary
+	"github.com/edgexfoundry/go-mod-core-contracts/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
 const (
@@ -105,65 +27,8 @@ const (
 	MaxBinaryBytes = 16777216
 	// DefaultFoloatEncoding indicates the representation of floating value of reading.
 	// It would be configurable in system level in the future
-	DefaultFloatEncoding = contract.Base64Encoding
+	DefaultFloatEncoding = models.Base64Encoding
 )
-
-// ParseValueType could get ValueType from type name in string format
-// if the type name cannot be parsed correctly, return String ValueType
-func ParseValueType(typeName string) ValueType {
-	switch strings.ToUpper(typeName) {
-	case "BOOL":
-		return Bool
-	case "BOOLARRAY":
-		return BoolArray
-	case "STRING":
-		return String
-	case "UINT8":
-		return Uint8
-	case "UINT8ARRAY":
-		return Uint8Array
-	case "UINT16":
-		return Uint16
-	case "UINT16ARRAY":
-		return Uint16Array
-	case "UINT32":
-		return Uint32
-	case "UINT32ARRAY":
-		return Uint32Array
-	case "UINT64":
-		return Uint64
-	case "UINT64ARRAY":
-		return Uint64Array
-	case "INT8":
-		return Int8
-	case "INT8ARRAY":
-		return Int8Array
-	case "INT16":
-		return Int16
-	case "INT16ARRAY":
-		return Int16Array
-	case "INT32":
-		return Int32
-	case "INT32ARRAY":
-		return Int32Array
-	case "INT64":
-		return Int64
-	case "INT64ARRAY":
-		return Int64Array
-	case "FLOAT32":
-		return Float32
-	case "FLOAT32ARRAY":
-		return Float32Array
-	case "FLOAT64":
-		return Float64
-	case "FLOAT64ARRAY":
-		return Float64Array
-	case "BINARY":
-		return Binary
-	default:
-		return String
-	}
-}
 
 // CommandValue is the struct to represent the reading value of a Get command coming
 // from ProtocolDrivers or the parameter of a Put command sending to ProtocolDrivers.
@@ -178,7 +43,7 @@ type CommandValue struct {
 	// value was returned from the ProtocolDriver instance in
 	// response to HandleCommand being called to handle a single
 	// ResourceOperation.
-	Type ValueType
+	Type string
 	// NumericValue is a byte slice with a maximum capacity of
 	// 64 bytes, used to hold a numeric value returned by a
 	// ProtocolDriver instance. The value can be converted to
@@ -193,7 +58,7 @@ type CommandValue struct {
 
 // NewBoolValue creates a CommandValue of Type Bool with the given value.
 func NewBoolValue(DeviceResourceName string, origin int64, value bool) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Bool}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeBool}
 	err = encodeValue(cv, value)
 	return
 }
@@ -204,7 +69,7 @@ func NewBoolArrayValue(DeviceResourceName string, origin int64, value []bool) (c
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               BoolArray,
+		Type:               v2.ValueTypeBoolArray,
 		stringValue:        string(jsonValue),
 	}
 
@@ -213,13 +78,13 @@ func NewBoolArrayValue(DeviceResourceName string, origin int64, value []bool) (c
 
 // NewStringValue creates a CommandValue of Type string with the given value.
 func NewStringValue(DeviceResourceName string, origin int64, value string) (cv *CommandValue) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: String, stringValue: value}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeString, stringValue: value}
 	return
 }
 
 // NewUint8Value creates a CommandValue of Type Uint8 with the given value.
 func NewUint8Value(DeviceResourceName string, origin int64, value uint8) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Uint8}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeUint8}
 	err = encodeValue(cv, value)
 	return
 }
@@ -230,7 +95,7 @@ func NewUint8ArrayValue(DeviceResourceName string, origin int64, value []uint8) 
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Uint8Array,
+		Type:               v2.ValueTypeUint8Array,
 		stringValue:        strings.Join(strings.Fields(fmt.Sprintf("%d", value)), ","),
 		BinValue:           jsonValue,
 	}
@@ -240,7 +105,7 @@ func NewUint8ArrayValue(DeviceResourceName string, origin int64, value []uint8) 
 
 // NewUint16Value creates a CommandValue of Type Uint16 with the given value.
 func NewUint16Value(DeviceResourceName string, origin int64, value uint16) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Uint16}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeUint16}
 	err = encodeValue(cv, value)
 	return
 }
@@ -251,7 +116,7 @@ func NewUint16ArrayValue(DeviceResourceName string, origin int64, value []uint16
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Uint16Array,
+		Type:               v2.ValueTypeUint16Array,
 		stringValue:        strings.Join(strings.Fields(fmt.Sprintf("%d", value)), ","),
 		BinValue:           jsonValue,
 	}
@@ -261,7 +126,7 @@ func NewUint16ArrayValue(DeviceResourceName string, origin int64, value []uint16
 
 // NewUint32Value creates a CommandValue of Type Uint32 with the given value.
 func NewUint32Value(DeviceResourceName string, origin int64, value uint32) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Uint32}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeUint32}
 	err = encodeValue(cv, value)
 	return
 }
@@ -272,7 +137,7 @@ func NewUint32ArrayValue(DeviceResourceName string, origin int64, value []uint32
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Uint32Array,
+		Type:               v2.ValueTypeUint32Array,
 		stringValue:        strings.Join(strings.Fields(fmt.Sprintf("%d", value)), ","),
 		BinValue:           jsonValue,
 	}
@@ -282,7 +147,7 @@ func NewUint32ArrayValue(DeviceResourceName string, origin int64, value []uint32
 
 // NewUint64Value creates a CommandValue of Type Uint64 with the given value.
 func NewUint64Value(DeviceResourceName string, origin int64, value uint64) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Uint64}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeUint64}
 	err = encodeValue(cv, value)
 	return
 }
@@ -293,7 +158,7 @@ func NewUint64ArrayValue(DeviceResourceName string, origin int64, value []uint64
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Uint64Array,
+		Type:               v2.ValueTypeUint64Array,
 		stringValue:        strings.Join(strings.Fields(fmt.Sprintf("%d", value)), ","),
 		BinValue:           jsonValue,
 	}
@@ -303,7 +168,7 @@ func NewUint64ArrayValue(DeviceResourceName string, origin int64, value []uint64
 
 // NewInt8Value creates a CommandValue of Type Int8 with the given value.
 func NewInt8Value(DeviceResourceName string, origin int64, value int8) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Int8}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeInt8}
 	err = encodeValue(cv, value)
 	return
 }
@@ -314,7 +179,7 @@ func NewInt8ArrayValue(DeviceResourceName string, origin int64, value []int8) (c
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Int8Array,
+		Type:               v2.ValueTypeInt8Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -323,7 +188,7 @@ func NewInt8ArrayValue(DeviceResourceName string, origin int64, value []int8) (c
 
 // NewInt16Value creates a CommandValue of Type Int16 with the given value.
 func NewInt16Value(DeviceResourceName string, origin int64, value int16) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Int16}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeInt16}
 	err = encodeValue(cv, value)
 	return
 }
@@ -334,7 +199,7 @@ func NewInt16ArrayValue(DeviceResourceName string, origin int64, value []int16) 
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Int16Array,
+		Type:               v2.ValueTypeInt16Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -343,7 +208,7 @@ func NewInt16ArrayValue(DeviceResourceName string, origin int64, value []int16) 
 
 // NewInt32Value creates a CommandValue of Type Int32 with the given value.
 func NewInt32Value(DeviceResourceName string, origin int64, value int32) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Int32}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeInt32}
 	err = encodeValue(cv, value)
 	return
 }
@@ -354,7 +219,7 @@ func NewInt32ArrayValue(DeviceResourceName string, origin int64, value []int32) 
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Int32Array,
+		Type:               v2.ValueTypeInt32Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -363,7 +228,7 @@ func NewInt32ArrayValue(DeviceResourceName string, origin int64, value []int32) 
 
 // NewInt64Value creates a CommandValue of Type Int64 with the given value.
 func NewInt64Value(DeviceResourceName string, origin int64, value int64) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Int64}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeInt64}
 	err = encodeValue(cv, value)
 	return
 }
@@ -374,7 +239,7 @@ func NewInt64ArrayValue(DeviceResourceName string, origin int64, value []int64) 
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Int64Array,
+		Type:               v2.ValueTypeInt64Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -383,7 +248,7 @@ func NewInt64ArrayValue(DeviceResourceName string, origin int64, value []int64) 
 
 // NewFloat32Value creates a CommandValue of Type Float32 with the given value.
 func NewFloat32Value(DeviceResourceName string, origin int64, value float32) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Float32}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeFloat32}
 	err = encodeValue(cv, value)
 	return
 }
@@ -394,7 +259,7 @@ func NewFloat32ArrayValue(DeviceResourceName string, origin int64, value []float
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Float32Array,
+		Type:               v2.ValueTypeFloat32Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -403,7 +268,7 @@ func NewFloat32ArrayValue(DeviceResourceName string, origin int64, value []float
 
 // NewFloat64Value creates a CommandValue of Type Float64 with the given value.
 func NewFloat64Value(DeviceResourceName string, origin int64, value float64) (cv *CommandValue, err error) {
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Float64}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeFloat64}
 	err = encodeValue(cv, value)
 	return
 }
@@ -414,7 +279,7 @@ func NewFloat64ArrayValue(DeviceResourceName string, origin int64, value []float
 	cv = &CommandValue{
 		DeviceResourceName: DeviceResourceName,
 		Origin:             origin,
-		Type:               Float64Array,
+		Type:               v2.ValueTypeFloat64Array,
 		stringValue:        string(jsonValue),
 	}
 
@@ -422,13 +287,13 @@ func NewFloat64ArrayValue(DeviceResourceName string, origin int64, value []float
 }
 
 //NewCommandValue create a CommandValue according to the Type supplied.
-func NewCommandValue(DeviceResourceName string, origin int64, value interface{}, t ValueType) (cv *CommandValue, err error) {
+func NewCommandValue(DeviceResourceName string, origin int64, value interface{}, t string) (cv *CommandValue, err error) {
 	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: t}
 	switch t {
-	case Binary:
+	case v2.ValueTypeBinary:
 		// assign cv.BinValue
 		cv.BinValue = value.([]byte)
-	case String:
+	case v2.ValueTypeString:
 		cv.stringValue = value.(string)
 	default:
 		err = encodeValue(cv, value)
@@ -441,7 +306,7 @@ func NewBinaryValue(DeviceResourceName string, origin int64, value []byte) (cv *
 	if binary.Size(value) > MaxBinaryBytes {
 		return nil, fmt.Errorf("requested CommandValue payload exceeds limit for binary readings (%v bytes)", MaxBinaryBytes)
 	}
-	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: Binary, BinValue: value}
+	cv = &CommandValue{DeviceResourceName: DeviceResourceName, Origin: origin, Type: v2.ValueTypeBinary, BinValue: value}
 	return
 }
 
@@ -463,7 +328,7 @@ func decodeValue(reader io.Reader, value interface{}) error {
 // In EdgeX, float value has two kinds of representation, Base64, and eNotation.
 // Users can specify the floatEncoding in the properties value of the device profile, like floatEncoding: "Base64" or floatEncoding: "eNotation".
 func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
-	if cv.Type == String {
+	if cv.Type == v2.ValueTypeString {
 		str = cv.stringValue
 		return
 	}
@@ -471,90 +336,90 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 	reader := bytes.NewReader(cv.NumericValue)
 
 	switch cv.Type {
-	case Bool:
+	case v2.ValueTypeBool:
 		var res bool
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatBool(res)
-	case Uint8:
+	case v2.ValueTypeUint8:
 		var res uint8
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatUint(uint64(res), 10)
-	case Uint16:
+	case v2.ValueTypeUint16:
 		var res uint16
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatUint(uint64(res), 10)
-	case Uint32:
+	case v2.ValueTypeUint32:
 		var res uint32
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatUint(uint64(res), 10)
-	case Uint64:
+	case v2.ValueTypeUint64:
 		var res uint64
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatUint(res, 10)
-	case Int8:
+	case v2.ValueTypeInt8:
 		var res int8
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatInt(int64(res), 10)
-	case Int16:
+	case v2.ValueTypeInt16:
 		var res int16
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatInt(int64(res), 10)
-	case Int32:
+	case v2.ValueTypeInt32:
 		var res int32
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatInt(int64(res), 10)
-	case Int64:
+	case v2.ValueTypeInt64:
 		var res int64
 		err := binary.Read(reader, binary.BigEndian, &res)
 		if err != nil {
 			str = err.Error()
 		}
 		str = strconv.FormatInt(res, 10)
-	case Float32:
+	case v2.ValueTypeFloat32:
 		floatEncoding := getFloatEncoding(encoding)
 
-		if floatEncoding == contract.ENotation {
+		if floatEncoding == models.ENotation {
 			var res float32
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
-		} else if floatEncoding == contract.Base64Encoding {
+		} else if floatEncoding == models.Base64Encoding {
 			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
 		}
-	case Float64:
+	case v2.ValueTypeFloat64:
 		floatEncoding := getFloatEncoding(encoding)
 
-		if floatEncoding == contract.ENotation {
+		if floatEncoding == models.ENotation {
 			var res float64
 			binary.Read(reader, binary.BigEndian, &res)
 			str = fmt.Sprintf("%e", res)
-		} else if floatEncoding == contract.Base64Encoding {
+		} else if floatEncoding == models.Base64Encoding {
 			str = base64.StdEncoding.EncodeToString(cv.NumericValue)
 		}
-	case Binary:
+	case v2.ValueTypeBinary:
 		// produce string representation of first 20 bytes of binary value
 		str = fmt.Sprintf(fmt.Sprintf("Binary: [%v...]", string(cv.BinValue[:20])))
 	default:
@@ -565,68 +430,12 @@ func (cv *CommandValue) ValueToString(encoding ...string) (str string) {
 	return
 }
 
-// ValueTypeToString returns corresponding string representation of the ValueType.
-func (cv *CommandValue) ValueTypeToString() string {
-	switch cv.Type {
-	case Bool:
-		return contract.ValueTypeBool
-	case BoolArray:
-		return contract.ValueTypeBoolArray
-	case String:
-		return contract.ValueTypeString
-	case Uint8:
-		return contract.ValueTypeUint8
-	case Uint8Array:
-		return contract.ValueTypeUint8Array
-	case Uint16:
-		return contract.ValueTypeUint16
-	case Uint16Array:
-		return contract.ValueTypeUint16Array
-	case Uint32:
-		return contract.ValueTypeUint32
-	case Uint32Array:
-		return contract.ValueTypeUint32Array
-	case Uint64:
-		return contract.ValueTypeUint64
-	case Uint64Array:
-		return contract.ValueTypeUint64Array
-	case Int8:
-		return contract.ValueTypeInt8
-	case Int8Array:
-		return contract.ValueTypeInt8Array
-	case Int16:
-		return contract.ValueTypeInt16
-	case Int16Array:
-		return contract.ValueTypeInt16Array
-	case Int32:
-		return contract.ValueTypeInt32
-	case Int32Array:
-		return contract.ValueTypeInt32Array
-	case Int64:
-		return contract.ValueTypeInt64
-	case Int64Array:
-		return contract.ValueTypeInt64Array
-	case Float32:
-		return contract.ValueTypeFloat32
-	case Float32Array:
-		return contract.ValueTypeFloat32Array
-	case Float64:
-		return contract.ValueTypeFloat64
-	case Float64Array:
-		return contract.ValueTypeFloat64Array
-	case Binary:
-		return contract.ValueTypeBinary
-	default:
-		return ""
-	}
-}
-
 func getFloatEncoding(encoding []string) string {
 	if len(encoding) > 0 {
-		if encoding[0] == contract.Base64Encoding {
-			return contract.Base64Encoding
-		} else if encoding[0] == contract.ENotation {
-			return contract.ENotation
+		if encoding[0] == models.Base64Encoding {
+			return models.Base64Encoding
+		} else if encoding[0] == models.ENotation {
+			return models.ENotation
 		}
 	}
 
@@ -635,64 +444,8 @@ func getFloatEncoding(encoding []string) string {
 
 // String returns a string representation of a CommandValue instance.
 func (cv *CommandValue) String() (str string) {
-
 	originStr := fmt.Sprintf("Origin: %d, ", cv.Origin)
-
-	var typeStr string
-
-	switch cv.Type {
-	case Bool:
-		typeStr = "Bool: "
-	case BoolArray:
-		typeStr = "BoolArray: "
-	case String:
-		typeStr = "String: "
-	case Uint8:
-		typeStr = "Uint8: "
-	case Uint8Array:
-		typeStr = "Uint8Array: "
-	case Uint16:
-		typeStr = "Uint16: "
-	case Uint16Array:
-		typeStr = "Uint16Array: "
-	case Uint32:
-		typeStr = "Uint32: "
-	case Uint32Array:
-		typeStr = "Uint32Array: "
-	case Uint64:
-		typeStr = "Uint64: "
-	case Uint64Array:
-		typeStr = "Uint64Array: "
-	case Int8:
-		typeStr = "Int8: "
-	case Int8Array:
-		typeStr = "Int8Array: "
-	case Int16:
-		typeStr = "Int16: "
-	case Int16Array:
-		typeStr = "Int16Array: "
-	case Int32:
-		typeStr = "Int32: "
-	case Int32Array:
-		typeStr = "Int32Array: "
-	case Int64:
-		typeStr = "Int64: "
-	case Int64Array:
-		typeStr = "Int64Array: "
-	case Float32:
-		typeStr = "Float32: "
-	case Float32Array:
-		typeStr = "Float32Array: "
-	case Float64:
-		typeStr = "Float64: "
-	case Float64Array:
-		typeStr = "Float64Array: "
-	case Binary:
-		typeStr = "Binary: "
-	}
-
-	valueStr := typeStr + cv.ValueToString()
-
+	valueStr := cv.Type + ": " + cv.ValueToString()
 	str = originStr + valueStr
 
 	return
@@ -701,7 +454,7 @@ func (cv *CommandValue) String() (str string) {
 // BoolValue returns the value in bool data type, and returns error if the Type is not Bool.
 func (cv *CommandValue) BoolValue() (bool, error) {
 	var value bool
-	if cv.Type != Bool {
+	if cv.Type != v2.ValueTypeBool {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -711,7 +464,7 @@ func (cv *CommandValue) BoolValue() (bool, error) {
 // BoolArrayValue returns the value in an array of bool type, and returns error if the Type is not BoolArray.
 func (cv *CommandValue) BoolArrayValue() ([]bool, error) {
 	var value []bool
-	if cv.Type != BoolArray {
+	if cv.Type != v2.ValueTypeBoolArray {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -721,7 +474,7 @@ func (cv *CommandValue) BoolArrayValue() ([]bool, error) {
 // StringValue returns the value in string data type, and returns error if the Type is not String.
 func (cv *CommandValue) StringValue() (string, error) {
 	value := cv.stringValue
-	if cv.Type != String {
+	if cv.Type != v2.ValueTypeString {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	return value, nil
@@ -730,7 +483,7 @@ func (cv *CommandValue) StringValue() (string, error) {
 // Uint8Value returns the value in uint8 data type, and returns error if the Type is not Uint8.
 func (cv *CommandValue) Uint8Value() (uint8, error) {
 	var value uint8
-	if cv.Type != Uint8 {
+	if cv.Type != v2.ValueTypeUint8 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -740,7 +493,7 @@ func (cv *CommandValue) Uint8Value() (uint8, error) {
 // Uint8ArrayValue returns the value in an array of uint8 type, and returns error if the Type is not Uint8Array.
 func (cv *CommandValue) Uint8ArrayValue() ([]uint8, error) {
 	var value []uint8
-	if cv.Type != Uint8Array {
+	if cv.Type != v2.ValueTypeUint8Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal(cv.BinValue, &value)
@@ -750,7 +503,7 @@ func (cv *CommandValue) Uint8ArrayValue() ([]uint8, error) {
 // Uint16Value returns the value in uint16 data type, and returns error if the Type is not Uint16.
 func (cv *CommandValue) Uint16Value() (uint16, error) {
 	var value uint16
-	if cv.Type != Uint16 {
+	if cv.Type != v2.ValueTypeUint16 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -760,7 +513,7 @@ func (cv *CommandValue) Uint16Value() (uint16, error) {
 // Uint16ArrayValue returns the value in an array of uint16 type, and returns error if the Type is not Uint16Array.
 func (cv *CommandValue) Uint16ArrayValue() ([]uint16, error) {
 	var value []uint16
-	if cv.Type != Uint16Array {
+	if cv.Type != v2.ValueTypeUint16Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal(cv.BinValue, &value)
@@ -770,7 +523,7 @@ func (cv *CommandValue) Uint16ArrayValue() ([]uint16, error) {
 // Uint32Value returns the value in uint32 data type, and returns error if the Type is not Uint32.
 func (cv *CommandValue) Uint32Value() (uint32, error) {
 	var value uint32
-	if cv.Type != Uint32 {
+	if cv.Type != v2.ValueTypeUint32 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -780,7 +533,7 @@ func (cv *CommandValue) Uint32Value() (uint32, error) {
 // Uint32ArrayValue returns the value in an array of uint32 type, and returns error if the Type is not Uint32Array.
 func (cv *CommandValue) Uint32ArrayValue() ([]uint32, error) {
 	var value []uint32
-	if cv.Type != Uint32Array {
+	if cv.Type != v2.ValueTypeUint32Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal(cv.BinValue, &value)
@@ -790,7 +543,7 @@ func (cv *CommandValue) Uint32ArrayValue() ([]uint32, error) {
 // Uint64Value returns the value in uint64 data type, and returns error if the Type is not Uint64.
 func (cv *CommandValue) Uint64Value() (uint64, error) {
 	var value uint64
-	if cv.Type != Uint64 {
+	if cv.Type != v2.ValueTypeUint64 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -800,7 +553,7 @@ func (cv *CommandValue) Uint64Value() (uint64, error) {
 // Uint64ArrayValue returns the value in an array of uint64 type, and returns error if the Type is not Uint64Array.
 func (cv *CommandValue) Uint64ArrayValue() ([]uint64, error) {
 	var value []uint64
-	if cv.Type != Uint64Array {
+	if cv.Type != v2.ValueTypeUint64Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal(cv.BinValue, &value)
@@ -810,7 +563,7 @@ func (cv *CommandValue) Uint64ArrayValue() ([]uint64, error) {
 // Int8Value returns the value in int8 data type, and returns error if the Type is not Int8.
 func (cv *CommandValue) Int8Value() (int8, error) {
 	var value int8
-	if cv.Type != Int8 {
+	if cv.Type != v2.ValueTypeInt8 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -820,7 +573,7 @@ func (cv *CommandValue) Int8Value() (int8, error) {
 // Int8ArrayValue returns the value in an array of int8 type, and returns error if the Type is not Int8Array.
 func (cv *CommandValue) Int8ArrayValue() ([]int8, error) {
 	var value []int8
-	if cv.Type != Int8Array {
+	if cv.Type != v2.ValueTypeInt8Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -830,7 +583,7 @@ func (cv *CommandValue) Int8ArrayValue() ([]int8, error) {
 // Int16Value returns the value in int16 data type, and returns error if the Type is not Int16.
 func (cv *CommandValue) Int16Value() (int16, error) {
 	var value int16
-	if cv.Type != Int16 {
+	if cv.Type != v2.ValueTypeInt16 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -840,7 +593,7 @@ func (cv *CommandValue) Int16Value() (int16, error) {
 // Int16ArrayValue returns the value in an array of int16 type, and returns error if the Type is not Int16Array.
 func (cv *CommandValue) Int16ArrayValue() ([]int16, error) {
 	var value []int16
-	if cv.Type != Int16Array {
+	if cv.Type != v2.ValueTypeInt16Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -850,7 +603,7 @@ func (cv *CommandValue) Int16ArrayValue() ([]int16, error) {
 // Int32Value returns the value in int32 data type, and returns error if the Type is not Int32.
 func (cv *CommandValue) Int32Value() (int32, error) {
 	var value int32
-	if cv.Type != Int32 {
+	if cv.Type != v2.ValueTypeInt32 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -860,7 +613,7 @@ func (cv *CommandValue) Int32Value() (int32, error) {
 // Int32ArrayValue returns the value in an array of int32 type, and returns error if the Type is not Int32Array.
 func (cv *CommandValue) Int32ArrayValue() ([]int32, error) {
 	var value []int32
-	if cv.Type != Int32Array {
+	if cv.Type != v2.ValueTypeInt32Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -870,7 +623,7 @@ func (cv *CommandValue) Int32ArrayValue() ([]int32, error) {
 // Int64Value returns the value in int64 data type, and returns error if the Type is not Int64.
 func (cv *CommandValue) Int64Value() (int64, error) {
 	var value int64
-	if cv.Type != Int64 {
+	if cv.Type != v2.ValueTypeInt64 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -880,7 +633,7 @@ func (cv *CommandValue) Int64Value() (int64, error) {
 // Int64ArrayValue returns the value in an array of int64 type, and returns error if the Type is not Int64Array.
 func (cv *CommandValue) Int64ArrayValue() ([]int64, error) {
 	var value []int64
-	if cv.Type != Int64Array {
+	if cv.Type != v2.ValueTypeInt64Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -890,7 +643,7 @@ func (cv *CommandValue) Int64ArrayValue() ([]int64, error) {
 // Float32Value returns the value in float32 data type, and returns error if the Type is not Float32.
 func (cv *CommandValue) Float32Value() (float32, error) {
 	var value float32
-	if cv.Type != Float32 {
+	if cv.Type != v2.ValueTypeFloat32 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -900,7 +653,7 @@ func (cv *CommandValue) Float32Value() (float32, error) {
 // Float32ArrayValue returns the value in an array of float32 type, and returns error if the Type is not Float32Array.
 func (cv *CommandValue) Float32ArrayValue() ([]float32, error) {
 	var value []float32
-	if cv.Type != Float32Array {
+	if cv.Type != v2.ValueTypeFloat32Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -910,7 +663,7 @@ func (cv *CommandValue) Float32ArrayValue() ([]float32, error) {
 // Float64Value returns the value in float64 data type, and returns error if the Type is not Float64.
 func (cv *CommandValue) Float64Value() (float64, error) {
 	var value float64
-	if cv.Type != Float64 {
+	if cv.Type != v2.ValueTypeFloat64 {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := decodeValue(bytes.NewReader(cv.NumericValue), &value)
@@ -920,7 +673,7 @@ func (cv *CommandValue) Float64Value() (float64, error) {
 // Float64ArrayValue returns the value in an array of float64 type, and returns error if the Type is not Float64Array.
 func (cv *CommandValue) Float64ArrayValue() ([]float64, error) {
 	var value []float64
-	if cv.Type != Float64Array {
+	if cv.Type != v2.ValueTypeFloat64Array {
 		return value, fmt.Errorf("the data type is not %T", value)
 	}
 	err := json.Unmarshal([]byte(cv.stringValue), &value)
@@ -930,7 +683,7 @@ func (cv *CommandValue) Float64ArrayValue() ([]float64, error) {
 // BinaryValue returns the value in []byte data type, and returns error if the Type is not Binary.
 func (cv *CommandValue) BinaryValue() ([]byte, error) {
 	var value []byte
-	if cv.Type != Binary {
+	if cv.Type != v2.ValueTypeBinary {
 		return value, fmt.Errorf("the CommandValue (%s) data type (%v) is not binary", cv.String(), cv.Type)
 	}
 	return cv.BinValue, nil

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2020 IOTech Ltd
+// Copyright (C) 2020-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,13 +18,14 @@ import (
 	"time"
 
 	contract "github.com/edgexfoundry/go-mod-core-contracts/models"
+	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2"
 	"github.com/fxamacker/cbor/v2"
 )
 
 // Test NewCommandValue function
 func TestNewCommandValue(t *testing.T) {
 	// Test Bool
-	cv, err := NewCommandValue("resource", 0, true, Bool)
+	cv, err := NewCommandValue("resource", 0, true, v2.ValueTypeBool)
 	test, err2 := NewBoolValue("resource", 0, true)
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -37,7 +38,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test int8
-	cv, err = NewCommandValue("resource", 0, int8(5), Int8)
+	cv, err = NewCommandValue("resource", 0, int8(5), v2.ValueTypeInt8)
 	test, err2 = NewInt8Value("resource", 0, int8(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -50,7 +51,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test int16
-	cv, err = NewCommandValue("resource", 0, int16(5), Int16)
+	cv, err = NewCommandValue("resource", 0, int16(5), v2.ValueTypeInt16)
 	test, err2 = NewInt16Value("resource", 0, int16(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -63,7 +64,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test int32
-	cv, err = NewCommandValue("resource", 0, int32(5), Int32)
+	cv, err = NewCommandValue("resource", 0, int32(5), v2.ValueTypeInt32)
 	test, err2 = NewInt32Value("resource", 0, int32(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -76,7 +77,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test int64
-	cv, err = NewCommandValue("resource", 0, int64(5), Int64)
+	cv, err = NewCommandValue("resource", 0, int64(5), v2.ValueTypeInt64)
 	test, err2 = NewInt64Value("resource", 0, int64(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -89,7 +90,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test uint8
-	cv, err = NewCommandValue("resource", 0, uint8(5), Uint8)
+	cv, err = NewCommandValue("resource", 0, uint8(5), v2.ValueTypeUint8)
 	test, err2 = NewUint8Value("resource", 0, uint8(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -102,7 +103,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test uint16
-	cv, err = NewCommandValue("resource", 0, uint16(5), Uint16)
+	cv, err = NewCommandValue("resource", 0, uint16(5), v2.ValueTypeUint16)
 	test, err2 = NewUint16Value("resource", 0, uint16(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -115,7 +116,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test uint32
-	cv, err = NewCommandValue("resource", 0, uint32(5), Uint32)
+	cv, err = NewCommandValue("resource", 0, uint32(5), v2.ValueTypeUint32)
 	test, err2 = NewUint32Value("resource", 0, uint32(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -128,7 +129,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test uint64
-	cv, err = NewCommandValue("resource", 0, uint64(5), Uint64)
+	cv, err = NewCommandValue("resource", 0, uint64(5), v2.ValueTypeUint64)
 	test, err2 = NewUint64Value("resource", 0, uint64(5))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -141,7 +142,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test float32
-	cv, err = NewCommandValue("resource", 0, float32(5.8), Float32)
+	cv, err = NewCommandValue("resource", 0, float32(5.8), v2.ValueTypeFloat32)
 	test, err2 = NewFloat32Value("resource", 0, float32(5.8))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -154,7 +155,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test float64
-	cv, err = NewCommandValue("resource", 0, float64(5.8), Float64)
+	cv, err = NewCommandValue("resource", 0, float64(5.8), v2.ValueTypeFloat64)
 	test, err2 = NewFloat64Value("resource", 0, float64(5.8))
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -167,7 +168,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test string
-	cv, err = NewCommandValue("resource", 0, "test value", String)
+	cv, err = NewCommandValue("resource", 0, "test value", v2.ValueTypeString)
 	test = NewStringValue("resource", 0, "test value")
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -180,7 +181,7 @@ func TestNewCommandValue(t *testing.T) {
 	}
 
 	// Test binary
-	cv, err = NewCommandValue("resource", 0, []byte{1, 2, 3, 5, 8, 13}, Binary)
+	cv, err = NewCommandValue("resource", 0, []byte{1, 2, 3, 5, 8, 13}, v2.ValueTypeBinary)
 	test, err2 = NewBinaryValue("resource", 0, []byte{1, 2, 3, 5, 8, 13})
 	if err != nil || err2 != nil {
 		t.Errorf("Error creating command value")
@@ -198,7 +199,7 @@ func TestNewCommandValue(t *testing.T) {
 func TestNewBoolValue(t *testing.T) {
 	var value bool
 	cv, _ := NewBoolValue("resource", 0, value)
-	if cv.Type != Bool {
+	if cv.Type != v2.ValueTypeBool {
 		t.Errorf("NewBoolValue: invalid Type: %v", cv.Type)
 	}
 	if value == true {
@@ -217,7 +218,7 @@ func TestNewBoolValue(t *testing.T) {
 
 	value = true
 	cv, _ = NewBoolValue("resource", 0, value)
-	if cv.Type != Bool {
+	if cv.Type != v2.ValueTypeBool {
 		t.Errorf("NewBoolValue: invalid Type: %v #2", cv.Type)
 	}
 	if value == false {
@@ -239,7 +240,7 @@ func TestNewBoolValue(t *testing.T) {
 func TestNewBoolArrayValue(t *testing.T) {
 	var value = make([]bool, 1)
 	cv, _ := NewBoolArrayValue("resource", 0, value)
-	if cv.Type != BoolArray {
+	if cv.Type != v2.ValueTypeBoolArray {
 		t.Errorf("NewBoolArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[false]" {
@@ -258,7 +259,7 @@ func TestNewBoolArrayValue(t *testing.T) {
 func TestNewStringValue(t *testing.T) {
 	var value string
 	cv := NewStringValue("resource", 0, value)
-	if cv.Type != String {
+	if cv.Type != v2.ValueTypeString {
 		t.Errorf("NewStringValue: invalid Type: %v", cv.Type)
 	}
 	v, err := cv.StringValue()
@@ -271,7 +272,7 @@ func TestNewStringValue(t *testing.T) {
 
 	value = "this is a real string"
 	cv = NewStringValue("resource", 0, value)
-	if cv.Type != String {
+	if cv.Type != v2.ValueTypeString {
 		t.Errorf("NewStringValue: invalid Type: %v #2", cv.Type)
 	}
 	if value != cv.stringValue {
@@ -293,7 +294,7 @@ func TestNewStringValue(t *testing.T) {
 func TestNewUint8Value(t *testing.T) {
 	var value uint8
 	cv, _ := NewUint8Value("resource", 0, value)
-	if cv.Type != Uint8 {
+	if cv.Type != v2.ValueTypeUint8 {
 		t.Errorf("NewUint8Value: invalid Type: %v", cv.Type)
 	}
 	var res uint8
@@ -312,7 +313,7 @@ func TestNewUint8Value(t *testing.T) {
 
 	value = 42
 	cv, _ = NewUint8Value("resource", 0, value)
-	if cv.Type != Uint8 {
+	if cv.Type != v2.ValueTypeUint8 {
 		t.Errorf("NewUint8Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -337,7 +338,7 @@ func TestNewUint8Value(t *testing.T) {
 func TestNewUint8ArrayValue(t *testing.T) {
 	var value = make([]uint8, 1)
 	cv, _ := NewUint8ArrayValue("resource", 0, value)
-	if cv.Type != Uint8Array {
+	if cv.Type != v2.ValueTypeUint8Array {
 		t.Errorf("NewUint8ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -356,7 +357,7 @@ func TestNewUint8ArrayValue(t *testing.T) {
 func TestNewUint16Value(t *testing.T) {
 	var value uint16
 	cv, _ := NewUint16Value("resource", 0, value)
-	if cv.Type != Uint16 {
+	if cv.Type != v2.ValueTypeUint16 {
 		t.Errorf("NewUint16Value: invalid Type: %v", cv.Type)
 	}
 	var res uint16
@@ -375,7 +376,7 @@ func TestNewUint16Value(t *testing.T) {
 
 	value = 65535
 	cv, _ = NewUint16Value("resource", 0, value)
-	if cv.Type != Uint16 {
+	if cv.Type != v2.ValueTypeUint16 {
 		t.Errorf("NewUint16Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -400,7 +401,7 @@ func TestNewUint16Value(t *testing.T) {
 func TestNewUint16ArrayValue(t *testing.T) {
 	var value = make([]uint16, 1)
 	cv, _ := NewUint16ArrayValue("resource", 0, value)
-	if cv.Type != Uint16Array {
+	if cv.Type != v2.ValueTypeUint16Array {
 		t.Errorf("NewUint16ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -419,7 +420,7 @@ func TestNewUint16ArrayValue(t *testing.T) {
 func TestNewUint32Value(t *testing.T) {
 	var value uint32
 	cv, _ := NewUint32Value("resource", 0, value)
-	if cv.Type != Uint32 {
+	if cv.Type != v2.ValueTypeUint32 {
 		t.Errorf("NewUint32Value: invalid Type: %v", cv.Type)
 	}
 	var res uint32
@@ -438,7 +439,7 @@ func TestNewUint32Value(t *testing.T) {
 
 	value = 4294967295
 	cv, _ = NewUint32Value("resource", 0, value)
-	if cv.Type != Uint32 {
+	if cv.Type != v2.ValueTypeUint32 {
 		t.Errorf("NewUint32Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -464,7 +465,7 @@ func TestNewUint32Value(t *testing.T) {
 func TestNewUint32ArrayValue(t *testing.T) {
 	var value = make([]uint32, 1)
 	cv, _ := NewUint32ArrayValue("resource", 0, value)
-	if cv.Type != Uint32Array {
+	if cv.Type != v2.ValueTypeUint32Array {
 		t.Errorf("NewUint32ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -484,7 +485,7 @@ func TestNewUint64Value(t *testing.T) {
 	var value uint64
 	var origin int64 = 42
 	cv, _ := NewUint64Value("resource", origin, value)
-	if cv.Type != Uint64 {
+	if cv.Type != v2.ValueTypeUint64 {
 		t.Errorf("NewUint64Value: invalid Type: %v", cv.Type)
 	}
 	if cv.Origin != origin {
@@ -506,7 +507,7 @@ func TestNewUint64Value(t *testing.T) {
 
 	value = 18446744073709551615
 	cv, _ = NewUint64Value("resource", 0, value)
-	if cv.Type != Uint64 {
+	if cv.Type != v2.ValueTypeUint64 {
 		t.Errorf("NewUint64Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -531,7 +532,7 @@ func TestNewUint64Value(t *testing.T) {
 func TestNewUint64ArrayValue(t *testing.T) {
 	var value = make([]uint64, 1)
 	cv, _ := NewUint64ArrayValue("resource", 0, value)
-	if cv.Type != Uint64Array {
+	if cv.Type != v2.ValueTypeUint64Array {
 		t.Errorf("NewUint64ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -550,7 +551,7 @@ func TestNewUint64ArrayValue(t *testing.T) {
 func TestNewInt8Value(t *testing.T) {
 	var value int8 = -128
 	cv, _ := NewInt8Value("resource", 0, value)
-	if cv.Type != Int8 {
+	if cv.Type != v2.ValueTypeInt8 {
 		t.Errorf("NewInt8Value: invalid Type: %v", cv.Type)
 	}
 	var res int8
@@ -573,7 +574,7 @@ func TestNewInt8Value(t *testing.T) {
 
 	value = 127
 	cv, _ = NewInt8Value("resource", 0, value)
-	if cv.Type != Int8 {
+	if cv.Type != v2.ValueTypeInt8 {
 		t.Errorf("NewInt8Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -598,7 +599,7 @@ func TestNewInt8Value(t *testing.T) {
 func TestNewInt8ArrayValue(t *testing.T) {
 	var value = make([]int8, 1)
 	cv, _ := NewInt8ArrayValue("resource", 0, value)
-	if cv.Type != Int8Array {
+	if cv.Type != v2.ValueTypeInt8Array {
 		t.Errorf("NewInt8ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -617,7 +618,7 @@ func TestNewInt8ArrayValue(t *testing.T) {
 func TestNewInt16Value(t *testing.T) {
 	var value int16 = -32768
 	cv, _ := NewInt16Value("resource", 0, value)
-	if cv.Type != Int16 {
+	if cv.Type != v2.ValueTypeInt16 {
 		t.Errorf("NewInt16Value: invalid Type: %v", cv.Type)
 	}
 	var res int16
@@ -639,7 +640,7 @@ func TestNewInt16Value(t *testing.T) {
 
 	value = 32767
 	cv, _ = NewInt16Value("resource", 0, value)
-	if cv.Type != Int16 {
+	if cv.Type != v2.ValueTypeInt16 {
 		t.Errorf("NewInt16Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -664,7 +665,7 @@ func TestNewInt16Value(t *testing.T) {
 func TestNewInt16ArrayValue(t *testing.T) {
 	var value = make([]int16, 1)
 	cv, _ := NewInt16ArrayValue("resource", 0, value)
-	if cv.Type != Int16Array {
+	if cv.Type != v2.ValueTypeInt16Array {
 		t.Errorf("NewInt16ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -683,7 +684,7 @@ func TestNewInt16ArrayValue(t *testing.T) {
 func TestNewInt32Value(t *testing.T) {
 	var value int32 = -2147483648
 	cv, _ := NewInt32Value("resource", 0, value)
-	if cv.Type != Int32 {
+	if cv.Type != v2.ValueTypeInt32 {
 		t.Errorf("NewInt32Value: invalid Type: %v", cv.Type)
 	}
 	var res int32
@@ -705,7 +706,7 @@ func TestNewInt32Value(t *testing.T) {
 
 	value = 2147483647
 	cv, _ = NewInt32Value("resource", 0, value)
-	if cv.Type != Int32 {
+	if cv.Type != v2.ValueTypeInt32 {
 		t.Errorf("NewInt32Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -730,7 +731,7 @@ func TestNewInt32Value(t *testing.T) {
 func TestNewInt32ArrayValue(t *testing.T) {
 	var value = make([]int32, 1)
 	cv, _ := NewInt32ArrayValue("resource", 0, value)
-	if cv.Type != Int32Array {
+	if cv.Type != v2.ValueTypeInt32Array {
 		t.Errorf("NewInt32ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -750,7 +751,7 @@ func TestNewInt64Value(t *testing.T) {
 	var value int64 = -9223372036854775808
 	var origin int64 = 42
 	cv, _ := NewInt64Value("resource", origin, value)
-	if cv.Type != Int64 {
+	if cv.Type != v2.ValueTypeInt64 {
 		t.Errorf("NewInt64Value: invalid Type: %v", cv.Type)
 	}
 	if cv.Origin != origin {
@@ -775,7 +776,7 @@ func TestNewInt64Value(t *testing.T) {
 
 	value = 9223372036854775807
 	cv, _ = NewInt64Value("resource", 0, value)
-	if cv.Type != Int64 {
+	if cv.Type != v2.ValueTypeInt64 {
 		t.Errorf("NewInt64Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -800,7 +801,7 @@ func TestNewInt64Value(t *testing.T) {
 func TestNewInt64ArrayValue(t *testing.T) {
 	var value = make([]int64, 1)
 	cv, _ := NewInt64ArrayValue("resource", 0, value)
-	if cv.Type != Int64Array {
+	if cv.Type != v2.ValueTypeInt64Array {
 		t.Errorf("NewInt64ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -820,7 +821,7 @@ func TestNewFloat32Value(t *testing.T) {
 	var value float32 = math.SmallestNonzeroFloat32
 	var origin int64 = time.Now().UnixNano()
 	cv, _ := NewFloat32Value("resource", origin, value)
-	if cv.Type != Float32 {
+	if cv.Type != v2.ValueTypeFloat32 {
 		t.Errorf("NewFloat32Value: invalid Type: %v", cv.Type)
 	}
 	if cv.Origin != origin {
@@ -845,7 +846,7 @@ func TestNewFloat32Value(t *testing.T) {
 
 	value = math.MaxFloat32
 	cv, _ = NewFloat32Value("resource", 0, value)
-	if cv.Type != Float32 {
+	if cv.Type != v2.ValueTypeFloat32 {
 		t.Errorf("NewFloat32Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -870,7 +871,7 @@ func TestNewFloat32Value(t *testing.T) {
 func TestNewFloat32ArrayValue(t *testing.T) {
 	var value = make([]float32, 1)
 	cv, _ := NewFloat32ArrayValue("resource", 0, value)
-	if cv.Type != Float32Array {
+	if cv.Type != v2.ValueTypeFloat32Array {
 		t.Errorf("NewFloat32ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -890,7 +891,7 @@ func TestNewFloat64Value(t *testing.T) {
 	var value float64 = math.SmallestNonzeroFloat64
 	var origin int64 = time.Now().UnixNano()
 	cv, _ := NewFloat64Value("resource", origin, value)
-	if cv.Type != Float64 {
+	if cv.Type != v2.ValueTypeFloat64 {
 		t.Errorf("NewFloat64Value: invalid Type: %v", cv.Type)
 	}
 	if cv.Origin != origin {
@@ -915,7 +916,7 @@ func TestNewFloat64Value(t *testing.T) {
 
 	value = math.MaxFloat64
 	cv, _ = NewFloat64Value("resource", 0, value)
-	if cv.Type != Float64 {
+	if cv.Type != v2.ValueTypeFloat64 {
 		t.Errorf("NewFloat64Value: invalid Type: %v #3", cv.Type)
 	}
 	buf = bytes.NewReader(cv.NumericValue)
@@ -940,7 +941,7 @@ func TestNewFloat64Value(t *testing.T) {
 func TestNewFloat64ArrayValue(t *testing.T) {
 	var value = make([]float64, 1)
 	cv, _ := NewFloat64ArrayValue("resource", 0, value)
-	if cv.Type != Float64Array {
+	if cv.Type != v2.ValueTypeFloat64Array {
 		t.Errorf("NewFloat64ArrayValue: invalid Type: %v", cv.Type)
 	}
 	if cv.ValueToString() != "[0]" {
@@ -994,7 +995,7 @@ func TestNewBinaryValue(t *testing.T) {
 		t.Errorf("NewBinaryValue: Error invoking NewBinaryValue [%v]", errAssign)
 	}
 	// Confirm CommandValue particulars
-	if cv.Type != Binary {
+	if cv.Type != v2.ValueTypeBinary {
 		t.Errorf("Expected Binary type! invalid Type: %v", cv.Type)
 	}
 	if cv.Origin != origin {


### PR DESCRIPTION
use the string ValueType defined in core-contracts to avoid duplicate
and for easier usage.

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #468 


## What is the new behavior?
The `Type` field of `CommandValue` and `CommandRequest` models are updated to be built-in `string` type.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No


## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
