### PR TITLE
Issue 749 - Optimize the error log 

### DIFF
--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -126,7 +126,7 @@ func (c *RestController) commandFunc(w http.ResponseWriter, req *http.Request) {
 	event, appErr := handler.CommandHandler(vars, body, req.Method, req.URL.RawQuery, c.dic)
 
 	if appErr != nil {
-                http.Error(w, fmt.Sprintf("%s", appErr.Message()), appErr.Code())
+		http.Error(w, fmt.Sprintf("%s", appErr.Message()), appErr.Code())
 	} else if event != nil {
 		ec := container.CoredataEventClientFrom(c.dic.Get)
 		if event.HasBinaryValue() {

--- a/internal/controller/restfuncs.go
+++ b/internal/controller/restfuncs.go
@@ -126,7 +126,7 @@ func (c *RestController) commandFunc(w http.ResponseWriter, req *http.Request) {
 	event, appErr := handler.CommandHandler(vars, body, req.Method, req.URL.RawQuery, c.dic)
 
 	if appErr != nil {
-		http.Error(w, fmt.Sprintf("%s %s", appErr.Message(), req.URL.Path), appErr.Code())
+                http.Error(w, fmt.Sprintf("%s", appErr.Message()), appErr.Code())
 	} else if event != nil {
 		ec := container.CoredataEventClientFrom(c.dic.Get)
 		if event.HasBinaryValue() {

--- a/internal/controller/restfuncs_test.go
+++ b/internal/controller/restfuncs_test.go
@@ -162,7 +162,7 @@ func TestCommandNoDevice(t *testing.T) {
 	}
 
 	body := strings.TrimSpace(rr.Body.String())
-	expected := "Device: " + badDeviceId + " not found; GET " + clients.ApiDeviceRoute + "/" + badDeviceId + "/" + testCmd
+	expected := "Device: " + badDeviceId + " not found; GET"
 
 	if body != expected {
 		t.Errorf("No Device: handler returned wrong body:\nexpected: %s\ngot:      %s", expected, body)

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -302,7 +302,7 @@ func execReadCmd(
 
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
-		msg := fmt.Sprintf("Handler - execReadCmd: error for Device: %s cmd: %s, %v", device.Name, cmd, err)
+                msg := fmt.Sprintf("Read Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
 		return nil, common.NewServerError(msg, err)
 	}
 
@@ -424,7 +424,7 @@ func execWriteCmd(
 
 	err = driver.HandleWriteCommands(device.Name, device.Protocols, reqs, cvs)
 	if err != nil {
-		msg := fmt.Sprintf("Handler - execWriteCmd: error for Device: %s cmd: %s, %v", device.Name, cmd, err)
+                msg := fmt.Sprintf("Write Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
 		return common.NewServerError(msg, err)
 	}
 

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -302,7 +302,7 @@ func execReadCmd(
 
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
-                msg := fmt.Sprintf("Read Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
+		msg := fmt.Sprintf("Read Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
 		return nil, common.NewServerError(msg, err)
 	}
 
@@ -424,7 +424,7 @@ func execWriteCmd(
 
 	err = driver.HandleWriteCommands(device.Name, device.Protocols, reqs, cvs)
 	if err != nil {
-                msg := fmt.Sprintf("Write Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
+		msg := fmt.Sprintf("Write Error - %v; Device Name: %s; CMD: %s", err, device.Name, cmd)
 		return common.NewServerError(msg, err)
 	}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The error log was not readable for the end user. Below was the old error log:
Handler - execReadCmd: error for Device: Modbus-TCP-Device-2 cmd: Current, modbus: exception '2' (illegal data address), function '131' /api/v1/device/6c2ffedd-6b54-4443-bf9e-130395d5a402/Current

## Issue Number:
749

## What is the new behavior?
The new error log is readable and looks like below:
Read Error - modbus: exception '2' (illegal data address), function '131'; Device Name: Modbus-TCP-Device-2; CMD: Current

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->
None
## Other information
None