### PR TITLE
fix: sync v2 query parameter with ADR

### DIFF
--- a/internal/v2/controller/http/command.go
+++ b/internal/v2/controller/http/command.go
@@ -20,7 +20,7 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/v2/application"
 )
 
-const SDKPostEventReserved = "ds-postevent"
+const SDKPostEventReserved = "ds-pushevent"
 const SDKReturnEventReserved = "ds-returnevent"
 const QueryParameterValueYes = "yes"
 const QueryParameterValueNo = "no"

--- a/openapi/v2/device-sdk.yaml
+++ b/openapi/v2/device-sdk.yaml
@@ -901,7 +901,7 @@ paths:
             type: string
           example: allValues
         - in: query
-          name: ds-postevent
+          name: ds-pushevent
           schema:
             type: string
             enum:


### PR DESCRIPTION
update query parameter, ds-postevent, to ds-pushevent

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
v2 API is using the incorrect query parameter `ds-postevent`, should be `ds-pushevent`

## Issue Number: fix #758 


## What is the new behavior?
SDK will accept the correct query parameter `ds-pushevent`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
