### PR TITLE
process queryParams of url in PUT request

### DIFF
--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2020 IOTech Ltd
+// Copyright (C) 2018-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -78,7 +78,7 @@ func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsMod
 
 // HandleReadCommands triggers a protocol Read operation for the specified device.
 func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[string]contract.ProtocolProperties, reqs []dsModels.CommandRequest) (res []*dsModels.CommandValue, err error) {
-	s.lc.Debug(fmt.Sprintf("SimpleDriver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols, reqs[0].DeviceResourceName, reqs[0].Attributes))
+	s.lc.Debugf("SimpleDriver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols, reqs[0].DeviceResourceName, reqs[0].Attributes)
 
 	if len(reqs) == 1 {
 		res = make([]*dsModels.CommandValue, 1)
@@ -138,7 +138,7 @@ func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[stri
 	var err error
 
 	for i, r := range reqs {
-		s.lc.Info(fmt.Sprintf("SimpleDriver.HandleWriteCommands: protocols: %v, resource: %v, parameters: %v", protocols, reqs[i].DeviceResourceName, params[i]))
+		s.lc.Debugf("SimpleDriver.HandleWriteCommands: protocols: %v, resource: %v, parameters: %v, attributes: %v", protocols, reqs[i].DeviceResourceName, params[i], reqs[i].Attributes)
 		switch r.DeviceResourceName {
 		case "SwitchButton":
 			if s.switchButton, err = params[i].BoolValue(); err != nil {
@@ -163,7 +163,7 @@ func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[stri
 		case "Uint8Array":
 			v, err := params[i].Uint8ArrayValue()
 			if err == nil {
-				s.lc.Debug(fmt.Sprint("Uint8 array value from write command: ", v))
+				s.lc.Debugf("Uint8 array value from write command: ", v)
 			} else {
 				return err
 			}
@@ -180,7 +180,7 @@ func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[stri
 func (s *SimpleDriver) Stop(force bool) error {
 	// Then Logging Client might not be initialized
 	if s.lc != nil {
-		s.lc.Debug(fmt.Sprintf("SimpleDriver.Stop called: force=%v", force))
+		s.lc.Debugf("SimpleDriver.Stop called: force=%v", force)
 	}
 	return nil
 }
@@ -188,21 +188,21 @@ func (s *SimpleDriver) Stop(force bool) error {
 // AddDevice is a callback function that is invoked
 // when a new Device associated with this Device Service is added
 func (s *SimpleDriver) AddDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
-	s.lc.Debug(fmt.Sprintf("a new Device is added: %s", deviceName))
+	s.lc.Debugf("a new Device is added: %s", deviceName)
 	return nil
 }
 
 // UpdateDevice is a callback function that is invoked
 // when a Device associated with this Device Service is updated
 func (s *SimpleDriver) UpdateDevice(deviceName string, protocols map[string]contract.ProtocolProperties, adminState contract.AdminState) error {
-	s.lc.Debug(fmt.Sprintf("Device %s is updated", deviceName))
+	s.lc.Debugf("Device %s is updated", deviceName)
 	return nil
 }
 
 // RemoveDevice is a callback function that is invoked
 // when a Device associated with this Device Service is removed
 func (s *SimpleDriver) RemoveDevice(deviceName string, protocols map[string]contract.ProtocolProperties) error {
-	s.lc.Debug(fmt.Sprintf("Device %s is removed", deviceName))
+	s.lc.Debugf("Device %s is removed", deviceName)
 	return nil
 }
 

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -90,7 +90,7 @@ func readResource(e *Executor, dic *di.Container) (event *dtos.Event, err errors
 	vars[v2.Name] = e.deviceName
 	vars[v2.Command] = e.resource
 
-	res, err := application.CommandHandler(true, false, "", vars, "", dic)
+	res, err := application.CommandHandler(true, false, "", vars, "", "", dic)
 	if err != nil {
 		return event, err
 	}


### PR DESCRIPTION
this is a rework of #732 on v2 command API.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
SDK ignores the queryParams on PUT request

## Issue Number: fix #730 


## What is the new behavior?
SDK will parse queryParams in PUT request and add it in `CommandRequest.Attributes`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->



## Other information
To verify:
1. add some attributes for DeviceResource, take device-simple for example:
```
    name: "Xrotation"
    description: "X axis rotation rate"
    properties:
        valueType: "Int32"
        readWrite: "RW"
    attributes:
      key: "value"
      foo: "bar"
```
2. launch device-simple
3. send requests with queryParams, you should be able to see the following logs:
```
# GET request
$ curl http://localhost:49990/api/v2/device/name/Simple-Device01/Xrotation?ds-pushevent=no&today=goodday
...
level=DEBUG ts=2021-02-19T03:10:49.915394Z app=device-simple source=simpledriver.go:81 msg="SimpleDriver.HandleReadCommands: protocols: map[other:map[Address:simple01 Port:300]] resource: Xrotation attributes: map[foo:bar key:value urlRawQuery:today=goodday]"

# PUT request
$ curl -X PUT -H "Content-Type: application/json" -d '{"Xrotation": "10"}' http://localhost:49990/api/v2/device/name/Simple-Device01/Xrotation?ds-pushevent=no&today=goodday
...
level=DEBUG ts=2021-02-19T03:17:19.373544Z app=device-simple source=simpledriver.go:141 msg="SimpleDriver.HandleWriteCommands: protocols: map[other:map[Address:simple01 Port:300]], resource: Xrotation, parameters: Origin: 1613704639373513000, Int32: 10, attributes: map[foo:bar key:value urlRawQuery:today=goodday]"

```
4. 
