### PR TITLE
feat: handle no readings generated gracefully

### DIFF
--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -75,7 +75,7 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, buffer chan bool
 				// By adding a buffer here, the user can use the Service.AsyncBufferSize configuration to control the goroutine for sending events.
 				go func() {
 					buffer <- true
-					common.SendEvent(*evt, "", lc, container.CoredataEventClientFrom(dic.Get))
+					common.SendEvent(evt, "", lc, container.CoredataEventClientFrom(dic.Get))
 					<-buffer
 				}()
 			} else {
@@ -94,7 +94,7 @@ func readResource(e *Executor, dic *di.Container) (event *dtos.Event, err errors
 	if err != nil {
 		return event, err
 	}
-	return &res, nil
+	return res, nil
 }
 
 func (e *Executor) compareReadings(readings []dtos.BaseReading) bool {

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -62,11 +62,11 @@ func UpdateOperatingState(name string, state string, lc logger.LoggingClient, dc
 	}
 }
 
-func SendEvent(event dtos.Event, correlationID string, lc logger.LoggingClient, ec interfaces.EventClient) {
+func SendEvent(event *dtos.Event, correlationID string, lc logger.LoggingClient, ec interfaces.EventClient) {
 	ctx := context.WithValue(context.Background(), CorrelationHeader, correlationID)
 	ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 
-	req := requests.NewAddEventRequest(event)
+	req := requests.NewAddEventRequest(*event)
 	res, err := ec.Add(ctx, req)
 	if err != nil {
 		lc.Errorf("failed to push event to core-data: %s", err)

--- a/internal/v2/controller/http/command.go
+++ b/internal/v2/controller/http/command.go
@@ -49,15 +49,15 @@ func (c *V2HttpController) Command(writer http.ResponseWriter, request *http.Req
 		sendEvent = true
 	}
 	isRead := request.Method == http.MethodGet
-	event, edgexErr := application.CommandHandler(isRead, sendEvent, correlationID, vars, requestBody, queryParams, c.dic)
+	eventDTO, edgexErr := application.CommandHandler(isRead, sendEvent, correlationID, vars, requestBody, queryParams, c.dic)
 	if edgexErr != nil {
 		c.sendEdgexError(writer, request, edgexErr, v2.ApiDeviceNameCommandNameRoute)
 		return
 	}
 
 	var res interface{}
-	if event.Id != "" {
-		res = responses.NewEventResponse("", "", http.StatusOK, event)
+	if eventDTO != nil {
+		res = responses.NewEventResponse("", "", http.StatusOK, *eventDTO)
 	} else {
 		res = common.NewBaseResponse("", "", http.StatusOK)
 	}


### PR DESCRIPTION
add a case to create empty event if no readings is generated from
device service driver implementation. Update the return eventDTO type
to pointer accordingly to easily judge if its an empty event and prevent
it from pushing to coredata if it's empty.

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #573 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
