### PR TITLE
feat: add GetProfileByName function API

### DIFF
--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -62,7 +62,7 @@ func (s *DeviceService) GetDeviceByName(name string) (models.Device, errors.Edge
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Device %s in cache", name)
-		s.LoggingClient.Info(msg)
+		s.LoggingClient.Error(msg)
 		return models.Device{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, msg, nil)
 	}
 	return device, nil

--- a/pkg/service/managedprofiles.go
+++ b/pkg/service/managedprofiles.go
@@ -50,6 +50,17 @@ func (s *DeviceService) DeviceProfiles() []models.DeviceProfile {
 	return cache.Profiles().All()
 }
 
+// GetProfileByName returns the Profile by its name if it exists in the cache, or returns an error.
+func (s *DeviceService) GetProfileByName(name string) (models.DeviceProfile, errors.EdgeX) {
+	profile, ok := cache.Profiles().ForName(name)
+	if !ok {
+		msg := fmt.Sprintf("failed to find Profile %s in cache", name)
+		s.LoggingClient.Error(msg)
+		return models.DeviceProfile{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, msg, nil)
+	}
+	return profile, nil
+}
+
 // RemoveDeviceProfileByName removes the specified DeviceProfile by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
 func (s *DeviceService) RemoveDeviceProfileByName(name string) errors.EdgeX {

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -58,7 +58,7 @@ func (s *DeviceService) GetProvisionWatcherByName(name string) (models.Provision
 	pw, ok := cache.ProvisionWatchers().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find ProvisionWatcher %s in cache", name)
-		s.LoggingClient.Info(msg)
+		s.LoggingClient.Error(msg)
 		return models.ProvisionWatcher{}, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, msg, nil)
 	}
 	return pw, nil


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
this is needed because profile models are no longer embedded in device models in v2.
Some device service (e.g. device-virtual) used to call `GetDeviceByName().Profiles` to retrieve the device profile, we need the counterpart api to do so.

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
