### PR TITLE
fix: remove hard-coded Content-Type in SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.14
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.49
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.53
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.3
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
@@ -47,7 +46,6 @@ func UpdateOperatingState(name string, state string, lc logger.LoggingClient, dc
 
 func SendEvent(event *dtos.Event, correlationID string, lc logger.LoggingClient, ec interfaces.EventClient) {
 	ctx := context.WithValue(context.Background(), CorrelationHeader, correlationID)
-	ctx = context.WithValue(ctx, clients.ContentType, clients.ContentTypeJSON)
 
 	req := requests.NewAddEventRequest(*event)
 	res, err := ec.Add(ctx, req)


### PR DESCRIPTION
EventClient will set the Content-Type dynamically based on the incoming
event(CBOR for binary and JSON for the other) so that we don't need to
do that in SDK

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?
this is the counterpart of https://github.com/edgexfoundry/go-mod-core-contracts/pull/550
more specific:
https://github.com/edgexfoundry/go-mod-core-contracts/blob/d27e56e5c274da1664efab3f1228ad305b025756/v2/clients/http/utils/common.go#L101-L104
so that we should not hard-code Content-Type in context.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
