### PR TITLE
fix: fix bootstrap sequence related bugs

### DIFF
--- a/internal/autoevent/manager.go
+++ b/internal/autoevent/manager.go
@@ -63,18 +63,6 @@ func (m *manager) StartAutoEvents() {
 	}
 }
 
-func (m *manager) StopAutoEvents() {
-	m.mutex.Lock()
-	defer m.mutex.Unlock()
-
-	for deviceName, executors := range m.executorMap {
-		for _, executor := range executors {
-			executor.Stop()
-		}
-		delete(m.executorMap, deviceName)
-	}
-}
-
 func (m *manager) triggerExecutors(deviceName string, autoEvents []models.AutoEvent, dic *di.Container) []*Executor {
 	var executors []*Executor
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)

--- a/pkg/models/manager.go
+++ b/pkg/models/manager.go
@@ -8,8 +8,6 @@ package models
 type AutoEventManager interface {
 	// StartAutoEvents starts all the AutoEvents of the device service
 	StartAutoEvents()
-	// StopAutoEvents stops all the AutoEvents of the device service
-	StopAutoEvents()
 	// RestartForDevice restarts all the AutoEvents of the specific device
 	RestartForDevice(name string)
 	// StopForDevice stops all the AutoEvents of the specific device

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -47,6 +47,15 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return ds.config
 		},
+		container.DeviceServiceName: func(get di.Get) interface{} {
+			return ds.deviceService
+		},
+		container.ProtocolDriverName: func(get di.Get) interface{} {
+			return ds.driver
+		},
+		container.ProtocolDiscoveryName: func(get di.Get) interface{} {
+			return ds.discovery
+		},
 	})
 
 	httpServer := handlers.NewHttpServer(router, true)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -121,20 +121,22 @@ func (s *DeviceService) DeviceDiscovery() bool {
 }
 
 // AddRoute allows leveraging the existing internal web server to add routes specific to Device Service.
-func (s *DeviceService) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) error {
+func (s *DeviceService) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) errors.EdgeX {
 	return s.controller.AddRoute(route, handler, methods...)
 }
 
 // Stop shuts down the Service
 func (s *DeviceService) Stop(force bool) {
 	if s.initialized {
-		_ = s.driver.Stop(false)
+		err := s.driver.Stop(force)
+		if err != nil {
+			s.LoggingClient.Error(err.Error())
+		}
 	}
-	s.manager.StopAutoEvents()
 }
 
 // selfRegister register device service itself onto metadata.
-func (s *DeviceService) selfRegister() error {
+func (s *DeviceService) selfRegister() errors.EdgeX {
 	newDeviceService := models.DeviceService{
 		Name:        s.ServiceName,
 		Labels:      s.config.Service.Labels,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
There are 2 known issues related to the bootstrap sequence of SDK:
one is #825. Another is when restarting DeviceService, `selfRegister` will update DeviceService in Metadata to reflect the config change, which will eventually callback to device service callback route.
## Issue Number: fix #825 


## What is the new behavior?
updated sequence:
initRouter
|
initCache
|
ProtocolDriver.Initialize
|
selfRegister -> callback
|
LoadProfiles -> callback
|
LoadDevices -> callback -> ProtocolDriver.AddDevice 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
