### PR TITLE
fix: add device OperatingState check in device command API

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -74,6 +74,10 @@ func CommandHandler(isRead bool, sendEvent bool, correlationID string, vars map[
 	if device.AdminState == models.Locked {
 		return res, edgexErr.NewCommonEdgeX(edgexErr.KindServiceLocked, fmt.Sprintf("device %s locked", device.Name), nil)
 	}
+	// check device's OperatingState
+	if device.OperatingState == models.Down {
+		return res, edgexErr.NewCommonEdgeX(edgexErr.KindServiceLocked, fmt.Sprintf("device %s OperatingState is DOWN", device.Name), nil)
+	}
 	// the device service will perform some operations(e.g. update LastConnected timestamp,
 	// push returning event to core-data) after a device is successfully interacted with if
 	// it has been configured to do so, and those operation apply to every protocol and

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/application"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/common"
-	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 )
 
 type Executor struct {
@@ -49,12 +48,6 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, buffer chan bool
 			if e.stop {
 				return
 			}
-			ds := container.DeviceServiceFrom(dic.Get)
-			if ds.AdminState == models.Locked {
-				lc.Info("AutoEvent - stopped for locked device service")
-				return
-			}
-
 			lc.Debugf("AutoEvent - reading %s", e.sourceName)
 			evt, err := readResource(e, dic)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
According to v2 api dcoument:

status code 423 is returned, **If the device or service is locked (admin state) or disabled (operating state).**

SDK now only checks the AdminState of Device and DeviceService, the check on OperatingState of Device is missing. 



## Issue Number: fix #853 


## What is the new behavior?
add the check on OperatingState of Device to meet the spec.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
