### PR TITLE
feat: update profile cache to reflect new profile model

### DIFF
--- a/internal/cache/profiles_test.go
+++ b/internal/cache/profiles_test.go
@@ -141,56 +141,25 @@ func Test_profileCache_DeviceResource(t *testing.T) {
 	}
 }
 
-func Test_profileCache_CommandExists(t *testing.T) {
-	newProfileCache([]models.DeviceProfile{testProfile})
-
-	tests := []struct {
-		name     string
-		profile  string
-		cmd      string
-		method   string
-		expected bool
-	}{
-		{"Invalid - nonexistent Profile name", "nil", TestDeviceCommand, "GET", false},
-		{"Invalid - nonexistent Command name", TestProfile, "nil", "GET", false},
-		{"Invalid - invalid method", TestProfile, TestDeviceCommand, "INVALID", false},
-		{"Invalid - nonexistent method", TestProfile, TestDeviceCommand, "SET", false},
-		{"Valid", TestProfile, TestDeviceCommand, "gEt", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ok, _ := pc.CommandExists(tt.profile, tt.cmd, tt.method)
-			assert.Equal(t, ok, tt.expected)
-		})
-	}
-}
-
-func Test_profileCache_ResourceOperations(t *testing.T) {
+func Test_profileCache_DeviceCommand(t *testing.T) {
 	newProfileCache([]models.DeviceProfile{testProfile})
 
 	tests := []struct {
 		name          string
-		profile       string
-		cmd           string
-		method        string
-		res           []models.ResourceOperation
-		expectedError bool
+		profileName   string
+		commandName   string
+		deviceCommand models.DeviceCommand
+		expected      bool
 	}{
-		{"Invalid - nonexistent Profile name", "nil", TestDeviceCommand, "GET", nil, true},
-		{"Invalid - nonexistent Command name", TestProfile, "nil", "GET", nil, true},
-		{"Invalid - invalid method", TestProfile, TestDeviceCommand, "INVALID", nil, true},
-		{"Valid", TestProfile, TestDeviceCommand, "GET", testProfile.DeviceCommands[0].ResourceOperations, false},
+		{"Invalid - nonexistent Profile name", "nil", TestDeviceCommand, models.DeviceCommand{}, false},
+		{"Invalid - nonexistent Command name", TestProfile, "nil", models.DeviceCommand{}, false},
+		{"Valid", TestProfile, TestDeviceCommand, testProfile.DeviceCommands[0], true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := pc.ResourceOperations(tt.profile, tt.cmd, tt.method)
-			if tt.expectedError {
-				assert.NotNil(t, err)
-				assert.Nil(t, res)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, res, tt.res)
-			}
+			res, ok := pc.DeviceCommand(tt.profileName, tt.commandName)
+			assert.Equal(t, res, tt.deviceCommand, "DeviceResource returns wrong deviceResource")
+			assert.Equal(t, ok, tt.expected, "DeviceResource returns opposite result")
 		})
 	}
 }
@@ -202,18 +171,16 @@ func Test_profileCache_ResourceOperation(t *testing.T) {
 		name          string
 		profile       string
 		resource      string
-		method        string
 		res           models.ResourceOperation
 		expectedError bool
 	}{
-		{"Invalid - nonexistent Profile name", "nil", TestDeviceResource, "GET", models.ResourceOperation{}, true},
-		{"Invalid - nonexistent DeviceResource name", TestProfile, "nil", "GET", models.ResourceOperation{}, true},
-		{"Invalid - invalid method", TestProfile, TestDeviceResource, "INVALID", models.ResourceOperation{}, true},
-		{"Valid", TestProfile, TestDeviceResource, "Get", testProfile.DeviceCommands[0].ResourceOperations[0], false},
+		{"Invalid - nonexistent Profile name", "nil", TestDeviceResource, models.ResourceOperation{}, true},
+		{"Invalid - nonexistent DeviceResource name", TestProfile, "nil", models.ResourceOperation{}, true},
+		{"Valid", TestProfile, TestDeviceResource, testProfile.DeviceCommands[0].ResourceOperations[0], false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ro, err := pc.ResourceOperation(tt.profile, tt.resource, tt.method)
+			ro, err := pc.ResourceOperation(tt.profile, tt.resource)
 			if tt.expectedError {
 				assert.NotNil(t, err)
 				assert.Equal(t, ro, tt.res)

--- a/internal/transformer/transform.go
+++ b/internal/transformer/transform.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
-	"github.com/edgexfoundry/device-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 )
@@ -81,7 +80,7 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 		}
 
 		// ResourceOperation mapping
-		ro, err := cache.Profiles().ResourceOperation(device.ProfileName, cv.DeviceResourceName, common.GetCmdMethod)
+		ro, err := cache.Profiles().ResourceOperation(device.ProfileName, cv.DeviceResourceName)
 		if err != nil {
 			// this allows SDK to directly read deviceResource without deviceCommands defined.
 			lc.Debugf("failed to read ResourceOperation: %v", err)

--- a/pkg/service/managedprofiles.go
+++ b/pkg/service/managedprofiles.go
@@ -105,21 +105,20 @@ func (s *DeviceService) UpdateDeviceProfile(profile models.DeviceProfile) errors
 	return err
 }
 
-// ResourceOperation retrieves the first matched ResourceOperation instance from cache according to
-// the Device name, Device Resource name, and the method (get or set).
-func (s *DeviceService) ResourceOperation(deviceName string, deviceResource string, method string) (models.ResourceOperation, bool) {
+// DeviceCommand retrieves the specific DeviceCommand instance from cache according to
+// the Device name and Command name
+func (s *DeviceService) DeviceCommand(deviceName string, commandName string) (models.DeviceCommand, bool) {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		s.LoggingClient.Errorf("failed to find device %s in cache", deviceName)
-		return models.ResourceOperation{}, false
+		return models.DeviceCommand{}, false
 	}
 
-	ro, err := cache.Profiles().ResourceOperation(device.ProfileName, deviceResource, method)
-	if err != nil {
-		s.LoggingClient.Error(err.Error())
-		return ro, false
+	dc, ok := cache.Profiles().DeviceCommand(device.ProfileName, commandName)
+	if !ok {
+		return dc, false
 	}
-	return ro, true
+	return dc, true
 }
 
 // DeviceResource retrieves the specific DeviceResource instance from cache according to


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
profile cache design and implementation is not aligned with latest profile model: https://github.com/edgexfoundry/go-mod-core-contracts/pull/540

## Issue Number: fix #854 


## What is the new behavior?
update profile cache. Also status code 405 can now be correctly returned by device command while trying to read(write) a write-only(read-only) device command.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

`DeviceService.ResourceOperation` method has been updated to `DeviceService.DeviceCommand`

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
