### PR TITLE
fix: add Content-Type in context for MessageEnvelope

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -14,6 +14,7 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos"
@@ -58,10 +59,11 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 
 	if configuration.MessageQueue.Enabled {
 		mc := container.MessagingClientFrom(dic.Get)
-		bytes, _, err := req.Encode()
+		bytes, encoding, err := req.Encode()
 		if err != nil {
 			lc.Error(err.Error())
 		}
+		ctx = context.WithValue(ctx, clients.ContentType, encoding)
 		envelope := types.NewMessageEnvelope(bytes, ctx)
 		publishTopic := fmt.Sprintf("%s/%s/%s/%s", configuration.MessageQueue.PublishTopicPrefix, event.ProfileName, event.DeviceName, event.SourceName)
 		err = mc.Publish(envelope, publishTopic)


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Content-Type is ignored when pushing event with MessageBus.

## Issue Number: fix #858 


## What is the new behavior?
add the Content-Type for the MessageEnvelope

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
