### PR TITLE
refactor: Switch to 2.0 Consul path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.28
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.29
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4

--- a/internal/common/consts.go
+++ b/internal/common/consts.go
@@ -16,9 +16,7 @@ import (
 const (
 	EnvInstanceName = "EDGEX_INSTANCE_NAME"
 
-	ConfigStemDevice   = "edgex/devices/"
-	ConfigMajorVersion = "1.0/"
-
+	ConfigStemDevice = "edgex/devices/"
 	APIV2SecretRoute = v2.ApiBase + "/secret"
 
 	GetCmdMethod = "get"

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -67,7 +67,7 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 		cancel,
 		sdkFlags,
 		ds.ServiceName,
-		common.ConfigStemDevice+common.ConfigMajorVersion,
+		common.ConfigStemDevice,
 		ds.config,
 		startupTimer,
 		ds.dic,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Uses `/1.0/` path set by the SDK

## Issue Number: #845


## What is the new behavior?
Now uses the `/2.0/` path set by go-mod-bootstrap

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Consul configuration now under the /2.0/ path

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
