### PR TITLE
feat: improve Event/Reading Origin logic

### DIFF
--- a/internal/transformer/transform_test.go
+++ b/internal/transformer/transform_test.go
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transformer
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getUniqueOrigin(t *testing.T) {
+	for i := 0; i < rand.Intn(1000); i++ {
+		t.Run(fmt.Sprintf("TestCase%d", i), func(t *testing.T) {
+			t.Parallel()
+			o1 := getUniqueOrigin()
+			o2 := getUniqueOrigin()
+			assert.NotEqual(t, o1, o2)
+		})
+	}
+}

--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -32,6 +32,10 @@ type CommandValue struct {
 	// Value holds value returned by a ProtocolDriver instance.
 	// The value can be converted to its native type by referring to ValueType.
 	Value interface{}
+	// Origin is an int64 value which indicates the time the reading
+	// contained in the CommandValue was read by the ProtocolDriver
+	// instance.
+	Origin int64
 }
 
 // NewCommandValue create a CommandValue according to the valueType supplied.


### PR DESCRIPTION
- add back the v1 mechanism to generate unique Origin for Event
- use the Origin from ProtocolDriver implementation if it was set for
the Reading, otherwise use the same Origin of the upstream Event

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #859, fix #860


## What is the new behavior?
Event origin would be unique under the same device service.
Reading origin could be assigned by ProtocolDriver implementation, otherwise it'll be the same as Event Origin. 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
