### PR TITLE
refactor: Replace file based with use of Secret Provider to get Access Tokens

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -65,6 +65,7 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
 # Must also add `ADD_SECRETSTORE_TOKENS: "device-simple"` to vault-worker environment so it generates
 # the token and secret store in vault for 'device-simple'
 [SecretStore]
+Type = 'vault'
 Host = 'localhost'
 Port = 8200
 Path = '/v1/secret/edgex/device-simple/'

--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -20,13 +20,11 @@ Timeout = 20000
 Labels = []
 EnableAsyncReadings = true
 AsyncBufferSize = 1
-ConfigAccessTokenFile = '/tmp/edgex/secrets/device-simple/consul-token' # ignored in non-secure mode
 
 [Registry]
 Host = 'localhost'
 Port = 8500
 Type = 'consul'
-AccessTokenFile = '/tmp/edgex/secrets/device-simple/consul-token' # ignored in non-secure mode
 
 [Clients]
   [Clients.edgex-core-data]

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.29
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.32
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4
 	github.com/google/uuid v1.2.0

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -54,8 +54,6 @@ type ServiceInfo struct {
 	EnableAsyncReadings bool
 	// AsyncBufferSize defines the size of asynchronous channel
 	AsyncBufferSize int
-	// ConfigAccessTokenFile is the location of the access token to use with the Configuration Provider client
-	ConfigAccessTokenFile string
 }
 
 // DeviceInfo is a struct which contains device specific configuration settings.
@@ -128,16 +126,15 @@ func (m MessageQueueInfo) URL() string {
 
 func (s ServiceInfo) GetBootstrapServiceInfo() config.ServiceInfo {
 	return config.ServiceInfo{
-		BootTimeout:           s.BootTimeout,
-		CheckInterval:         s.CheckInterval,
-		Host:                  s.Host,
-		Port:                  s.Port,
-		ServerBindAddr:        s.ServerBindAddr,
-		Protocol:              s.Protocol,
-		StartupMsg:            s.StartupMsg,
-		MaxResultCount:        s.MaxResultCount,
-		Timeout:               s.Timeout,
-		ConfigAccessTokenFile: s.ConfigAccessTokenFile,
+		BootTimeout:    s.BootTimeout,
+		CheckInterval:  s.CheckInterval,
+		Host:           s.Host,
+		Port:           s.Port,
+		ServerBindAddr: s.ServerBindAddr,
+		Protocol:       s.Protocol,
+		StartupMsg:     s.StartupMsg,
+		MaxResultCount: s.MaxResultCount,
+		Timeout:        s.Timeout,
 	}
 }
 

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -71,8 +71,8 @@ func Main(serviceName string, serviceVersion string, proto interface{}, ctx cont
 		ds.config,
 		startupTimer,
 		ds.dic,
+		true,
 		[]interfaces.BootstrapHandler{
-			handlers.SecureProviderBootstrapHandler,
 			httpServer.BootstrapHandler,
 			clients.BootstrapHandler,
 			autoevent.BootstrapHandler,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -158,12 +158,10 @@ func (s *DeviceService) Stop(force bool) {
 // custom configuration. It uses the same command line flags to process the custom config in the same manner
 // as the standard configuration.
 func (s *DeviceService) LoadCustomConfig(customConfig UpdatableConfig, sectionName string) error {
-	lc := bootstrapContainer.LoggingClientFrom(s.dic.Get)
 	if s.configProcessor == nil {
-		s.configProcessor = bootstrapConfig.NewProcessorForCustomConfig(lc, s.flags, s.ctx, s.wg, s.dic)
+		s.configProcessor = bootstrapConfig.NewProcessorForCustomConfig(s.flags, s.ctx, s.wg, s.dic)
 	}
 	return s.configProcessor.LoadCustomConfigSection(customConfig, sectionName)
-
 }
 
 // ListenForCustomConfigChanges uses the Config Processor from go-mod-bootstrap to attempt to listen for


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Currently expecting the Registry/Config Access tokens to be retrieved for files using the file location config settings.

## Issue Number: #846

## What is the new behavior?
Now uses SecretProvider to retrieve the access tokens.
File location config settings have been removed


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: All App Services running with the secure Edgex Stack now need to have the SecretStore configured, a Vault token created and run with EDGEX_SECURITY_SECRET_STORE=true.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
