### PR TITLE
fix: fix set command resourceOperation mapping

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -343,12 +343,17 @@ func (c *CommandProcessor) WriteDeviceCommand() edgexErr.EdgeX {
 		}
 
 		// write value mapping
+		var match bool
 		if len(ro.Mappings) > 0 {
-			newValue, ok := ro.Mappings[value]
-			if ok {
-				value = newValue
-			} else {
-				lc.Warn(fmt.Sprintf("ResourceOperation %s mapping value (%s) failed with the mapping table: %v", ro.DeviceResource, value, ro.Mappings))
+			for k, v := range ro.Mappings {
+				if v == value {
+					value = k
+					match = true
+					break
+				}
+			}
+			if !match {
+				lc.Warnf("ResourceOperation %s mapping value (%s) failed with the mapping table: %v", ro.DeviceResource, value, ro.Mappings)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
v2 device profile defines same resourceOperations for put/set command
the mapping field is default used by get command, so for set command we should do the mapping in reverse order.

## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
