### PR TITLE
fix: fix deviceProfileMap refer to the same object

### DIFF
--- a/internal/cache/profiles.go
+++ b/internal/cache/profiles.go
@@ -41,8 +41,8 @@ func newProfileCache(profiles []models.DeviceProfile) ProfileCache {
 	dpMap := make(map[string]*models.DeviceProfile, defaultSize)
 	drMap := make(map[string]map[string]models.DeviceResource, defaultSize)
 	dcMap := make(map[string]map[string]models.DeviceCommand, defaultSize)
-	for _, dp := range profiles {
-		dpMap[dp.Name] = &dp
+	for i, dp := range profiles {
+		dpMap[dp.Name] = &profiles[i]
 		drMap[dp.Name] = deviceResourceSliceToMap(dp.DeviceResources)
 		dcMap[dp.Name] = deviceCommandSliceToMap(dp.DeviceCommands)
 	}
@@ -76,7 +76,7 @@ func (p *profileCache) All() []models.DeviceProfile {
 	ps := make([]models.DeviceProfile, len(p.deviceProfileMap))
 	for _, profile := range p.deviceProfileMap {
 		ps[i] = *profile
-		i++
+		i += 1
 	}
 	return ps
 }


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
deviceProfileMap was accidentally initialized incorrectly, which will are refer to the same object.

## Issue Number: fix #871 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
