### PR TITLE
feat: add request size middleware for devicecommand

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -20,6 +20,9 @@ Timeout = 20000
 Labels = []
 EnableAsyncReadings = true
 AsyncBufferSize = 1
+# MaxRequestSize limit the request body size in byte of put command
+# value 0 unlimit the request size.
+MaxRequestSize = 0
 
 [Registry]
 Host = 'localhost'

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -54,6 +54,8 @@ type ServiceInfo struct {
 	EnableAsyncReadings bool
 	// AsyncBufferSize defines the size of asynchronous channel
 	AsyncBufferSize int
+	// MaxRequestSize defines the maximum size of http request body in bytes
+	MaxRequestSize int64
 }
 
 // DeviceInfo is a struct which contains device specific configuration settings.

--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -31,6 +31,9 @@ func (c *RestController) Command(writer http.ResponseWriter, request *http.Reque
 	var reserved url.Values
 	vars := mux.Vars(request)
 	correlationID := request.Header.Get(sdkCommon.CorrelationHeader)
+	if correlationID == "" {
+		correlationID, _ = request.Context().Value(sdkCommon.CorrelationHeader).(string)
+	}
 
 	// read request body for SET command
 	if request.Method == http.MethodPut {

--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -7,6 +7,7 @@
 package http
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/application"
 	sdkCommon "github.com/edgexfoundry/device-sdk-go/v2/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 )
 
 func (c *RestController) Command(writer http.ResponseWriter, request *http.Request) {
@@ -37,7 +39,11 @@ func (c *RestController) Command(writer http.ResponseWriter, request *http.Reque
 
 	// read request body for SET command
 	if request.Method == http.MethodPut {
-		requestBody, err = readBodyAsString(request)
+		requestBody, err = readBodyAsString(request, container.ConfigurationFrom(c.dic.Get).Service.MaxRequestSize)
+		if err != nil {
+			c.sendEdgexError(writer, request, err, v2.ApiDeviceNameCommandNameRoute)
+			return
+		}
 	}
 	// parse query parameter
 	queryParams, reserved, err = filterQueryParams(request.URL.RawQuery)
@@ -67,15 +73,18 @@ func (c *RestController) Command(writer http.ResponseWriter, request *http.Reque
 
 	// return event in http response if specified (default yes)
 	if ok, exist := reserved[v2.ReturnEvent]; !exist || ok[0] == v2.ValueYes {
-		// TODO: the usage of CBOR encoding for binary reading is under discussion
 		c.sendResponse(writer, request, v2.ApiDeviceNameCommandNameRoute, res, http.StatusOK)
 	}
 }
 
-func readBodyAsString(req *http.Request) (string, errors.EdgeX) {
+func readBodyAsString(req *http.Request, maxRequestSize int64) (string, errors.EdgeX) {
 	defer req.Body.Close()
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
+		if err.Error() == "http: request body too large" {
+			errMsg := fmt.Sprintf("request size exceed Service.MaxRequestSize(%d)", maxRequestSize)
+			return "", errors.NewCommonEdgeX(errors.KindLimitExceeded, errMsg, err)
+		}
 		return "", errors.NewCommonEdgeX(errors.KindServerError, "failed to read request body", err)
 	}
 

--- a/internal/controller/http/correlation/handler.go
+++ b/internal/controller/http/correlation/handler.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2020 IOTech Ltd
+// Copyright (C) 2019-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,9 +9,7 @@ package correlation
 import (
 	"context"
 
-	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 func IdFromContext(ctx context.Context) string {
@@ -20,12 +18,4 @@ func IdFromContext(ctx context.Context) string {
 		hdr = ""
 	}
 	return hdr
-}
-
-func LoggingClientFromContext(ctx context.Context) logger.LoggingClient {
-	lc, ok := ctx.Value(bootstrapContainer.LoggingClientInterfaceName).(logger.LoggingClient)
-	if !ok {
-		lc = nil
-	}
-	return lc
 }

--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -9,10 +9,12 @@ package correlation
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/google/uuid"
 )
 
@@ -36,6 +38,17 @@ func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler 
 			lc.Trace("Begin request", clients.CorrelationHeader, correlationId, "path", r.URL.Path)
 			next.ServeHTTP(w, r)
 			lc.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
+		})
+	}
+}
+
+func RequestLimitMiddleware(n int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, v2.ApiDeviceRoute) && n > 0 {
+				r.Body = http.MaxBytesReader(w, r.Body, n)
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/google/uuid"
 )
@@ -33,11 +34,15 @@ func ManageHeader(next http.Handler) http.Handler {
 func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			begin := time.Now()
-			correlationId := IdFromContext(r.Context())
-			lc.Trace("Begin request", clients.CorrelationHeader, correlationId, "path", r.URL.Path)
-			next.ServeHTTP(w, r)
-			lc.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
+			if lc.LogLevel() == models.TraceLog {
+				begin := time.Now()
+				correlationId := IdFromContext(r.Context())
+				lc.Trace("Begin request", clients.CorrelationHeader, correlationId, "path", r.URL.Path)
+				next.ServeHTTP(w, r)
+				lc.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
+			} else {
+				next.ServeHTTP(w, r)
+			}
 		})
 	}
 }

--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2020 IOTech Ltd
+// Copyright (C) 2019-2021 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/google/uuid"
 )
 
@@ -27,25 +28,14 @@ func ManageHeader(next http.Handler) http.Handler {
 	})
 }
 
-func OnResponseComplete(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		begin := time.Now()
-		next.ServeHTTP(w, r)
-		correlationId := IdFromContext(r.Context())
-		lc := LoggingClientFromContext(r.Context())
-		if lc != nil {
-			lc.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
-		}
-	})
-}
-
-func OnRequestBegin(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		correlationId := IdFromContext(r.Context())
-		lc := LoggingClientFromContext(r.Context())
-		if lc != nil {
+func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			begin := time.Now()
+			correlationId := IdFromContext(r.Context())
 			lc.Trace("Begin request", clients.CorrelationHeader, correlationId, "path", r.URL.Path)
-		}
-		next.ServeHTTP(w, r)
-	})
+			next.ServeHTTP(w, r)
+			lc.Trace("Response complete", clients.CorrelationHeader, correlationId, "duration", time.Since(begin).String())
+		})
+	}
 }

--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -9,13 +9,11 @@ package correlation
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/google/uuid"
 )
 
@@ -50,7 +48,7 @@ func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler 
 func RequestLimitMiddleware(n int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if strings.HasPrefix(r.URL.Path, v2.ApiDeviceRoute) && n > 0 {
+			if n > 0 {
 				r.Body = http.MaxBytesReader(w, r.Body, n)
 			}
 			next.ServeHTTP(w, r)

--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -9,12 +9,11 @@
 package http
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
@@ -35,7 +34,7 @@ type RestController struct {
 }
 
 func NewRestController(r *mux.Router, dic *di.Container) *RestController {
-	lc := container.LoggingClientFrom(dic.Get)
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	return &RestController{
 		lc:             lc,
 		router:         r,
@@ -68,20 +67,12 @@ func (c *RestController) InitRestRoutes() {
 	c.addReservedRoute(v2.ApiServiceCallbackRoute, c.UpdateDeviceService).Methods(http.MethodPut)
 
 	c.router.Use(correlation.ManageHeader)
-	c.router.Use(correlation.OnResponseComplete)
-	c.router.Use(correlation.OnRequestBegin)
+	c.router.Use(correlation.LoggingMiddleware(c.lc))
 }
 
 func (c *RestController) addReservedRoute(route string, handler func(http.ResponseWriter, *http.Request)) *mux.Route {
 	c.reservedRoutes[route] = true
-	return c.router.HandleFunc(
-		route,
-		func(w http.ResponseWriter, r *http.Request) {
-			ctx := context.WithValue(r.Context(), container.LoggingClientInterfaceName, c.lc)
-			handler(
-				w,
-				r.WithContext(ctx))
-		})
+	return c.router.HandleFunc(route, handler)
 }
 
 func (c *RestController) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) errors.EdgeX {
@@ -89,14 +80,7 @@ func (c *RestController) AddRoute(route string, handler func(http.ResponseWriter
 		return errors.NewCommonEdgeX(errors.KindServerError, "route is reserved", nil)
 	}
 
-	c.router.HandleFunc(
-		route,
-		func(w http.ResponseWriter, r *http.Request) {
-			ctx := context.WithValue(r.Context(), container.LoggingClientInterfaceName, c.lc)
-			handler(
-				w,
-				r.WithContext(ctx))
-		}).Methods(methods...)
+	c.router.HandleFunc(route, handler).Methods(methods...)
 	c.lc.Debug("Route added", "route", route, "methods", fmt.Sprintf("%v", methods))
 
 	return nil

--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gorilla/mux"
 
 	sdkCommon "github.com/edgexfoundry/device-sdk-go/v2/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/controller/http/correlation"
 )
 
@@ -66,6 +67,7 @@ func (c *RestController) InitRestRoutes() {
 	c.addReservedRoute(v2.ApiWatcherCallbackNameRoute, c.DeleteProvisionWatcher).Methods(http.MethodDelete)
 	c.addReservedRoute(v2.ApiServiceCallbackRoute, c.UpdateDeviceService).Methods(http.MethodPut)
 
+	c.router.Use(correlation.RequestLimitMiddleware(container.ConfigurationFrom(c.dic.Get).Service.MaxRequestSize))
 	c.router.Use(correlation.ManageHeader)
 	c.router.Use(correlation.LoggingMiddleware(c.lc))
 }

--- a/internal/controller/http/restrouter_test.go
+++ b/internal/controller/http/restrouter_test.go
@@ -22,12 +22,15 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/config"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 )
 
 func TestAddRoute(t *testing.T) {
@@ -43,8 +46,11 @@ func TestAddRoute(t *testing.T) {
 
 	lc := logger.NewMockClient()
 	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return lc
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{}
 		},
 	})
 
@@ -90,8 +96,11 @@ func TestAddRoute(t *testing.T) {
 func TestInitRestRoutes(t *testing.T) {
 	lc := logger.NewMockClient()
 	dic := di.NewContainer(di.ServiceConstructorMap{
-		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return lc
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{}
 		},
 	})
 	r := mux.NewRouter()


### PR DESCRIPTION
- refactor MiddlewareFunc to correctly pass LoggingClient into it.
- add RequestLimitMiddleware

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #665


## What is the new behavior?
request size of put command is capped at `Service.MaxRequestSize` defined in configuration.toml file
if exceed, http status 413 will be returned

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
