### PR TITLE
refactor: Replace use of BurntSushi/toml with pelletier/go-toml

### DIFF
--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -1,8 +1,5 @@
 The following open source projects are referenced by Device Service SDK Go:
 
-BurntSushi/toml (MIT) https://github.com/BurntSushi/toml
-https://github.com/BurntSushi/toml/blob/master/COPYING
-
 gorilla/mux 1.6.2 (BSD-3) https://github.com/gorilla/mux
 https://github.com/gorilla/mux/blob/master/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@ module github.com/edgexfoundry/device-sdk-go/v2
 
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
-	github.com/BurntSushi/toml v0.3.1
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.32
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.34
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.8
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
+	github.com/pelletier/go-toml v1.9.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/internal/provision/devices.go
+++ b/internal/provision/devices.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
@@ -22,6 +21,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/models"
 	"github.com/google/uuid"
+	"github.com/pelletier/go-toml"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/common"


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #872 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->
use pelletier/go-toml to be consistent across EdgexFoundry go project, also BurntSushi/toml is unmaintained.

- [x] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
