### PR TITLE
refactor: return errors.Edgex in internal package, error in pkg package

### DIFF
--- a/internal/cache/provisionwatcher.go
+++ b/internal/cache/provisionwatcher.go
@@ -20,10 +20,10 @@ var (
 type ProvisionWatcherCache interface {
 	ForName(name string) (models.ProvisionWatcher, bool)
 	All() []models.ProvisionWatcher
-	Add(device models.ProvisionWatcher) error
-	Update(device models.ProvisionWatcher) error
-	RemoveByName(name string) error
-	UpdateAdminState(name string, state models.AdminState) error
+	Add(device models.ProvisionWatcher) errors.EdgeX
+	Update(device models.ProvisionWatcher) errors.EdgeX
+	RemoveByName(name string) errors.EdgeX
+	UpdateAdminState(name string, state models.AdminState) errors.EdgeX
 }
 
 type provisionWatcherCache struct {
@@ -69,14 +69,14 @@ func (p *provisionWatcherCache) All() []models.ProvisionWatcher {
 }
 
 // Add adds a new provision watcher to the cache.
-func (p *provisionWatcherCache) Add(watcher models.ProvisionWatcher) error {
+func (p *provisionWatcherCache) Add(watcher models.ProvisionWatcher) errors.EdgeX {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	return p.add(watcher)
 }
 
-func (p *provisionWatcherCache) add(watcher models.ProvisionWatcher) error {
+func (p *provisionWatcherCache) add(watcher models.ProvisionWatcher) errors.EdgeX {
 	if _, ok := p.pwMap[watcher.Name]; ok {
 		errMsg := fmt.Sprintf("ProvisionWatcher %s has already existed in cache", watcher.Name)
 		return errors.NewCommonEdgeX(errors.KindDuplicateName, errMsg, nil)
@@ -87,7 +87,7 @@ func (p *provisionWatcherCache) add(watcher models.ProvisionWatcher) error {
 }
 
 // Update updates the provision watcher in the cache
-func (p *provisionWatcherCache) Update(watcher models.ProvisionWatcher) error {
+func (p *provisionWatcherCache) Update(watcher models.ProvisionWatcher) errors.EdgeX {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -98,14 +98,14 @@ func (p *provisionWatcherCache) Update(watcher models.ProvisionWatcher) error {
 }
 
 // RemoveByName removes the specified provision watcher by name from the cache.
-func (p *provisionWatcherCache) RemoveByName(name string) error {
+func (p *provisionWatcherCache) RemoveByName(name string) errors.EdgeX {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
 	return p.removeByName(name)
 }
 
-func (p *provisionWatcherCache) removeByName(name string) error {
+func (p *provisionWatcherCache) removeByName(name string) errors.EdgeX {
 	_, ok := p.pwMap[name]
 	if !ok {
 		errMsg := fmt.Sprintf("failed to find ProvisionWatcher %s in cache", name)
@@ -117,7 +117,7 @@ func (p *provisionWatcherCache) removeByName(name string) error {
 }
 
 // UpdateAdminState updates the ProvisionWatcher admin state in cache by name.
-func (p *provisionWatcherCache) UpdateAdminState(name string, state models.AdminState) error {
+func (p *provisionWatcherCache) UpdateAdminState(name string, state models.AdminState) errors.EdgeX {
 	if state != models.Locked && state != models.Unlocked {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, "invalid AdminState", nil)
 	}

--- a/internal/clients/init.go
+++ b/internal/clients/init.go
@@ -9,7 +9,6 @@ package clients
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	v2clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/http"
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
@@ -64,21 +64,21 @@ func InitDependencyClients(ctx context.Context, wg *sync.WaitGroup, startupTimer
 	return true
 }
 
-func validateClientConfig(configuration *config.ConfigurationStruct) error {
+func validateClientConfig(configuration *config.ConfigurationStruct) errors.EdgeX {
 	if len(configuration.Clients[clients.CoreMetaDataServiceKey].Host) == 0 {
-		return fmt.Errorf("fatal error; Host setting for Core Metadata client not configured")
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fatal error; Host setting for Core Metadata client not configured", nil)
 	}
 
 	if configuration.Clients[clients.CoreMetaDataServiceKey].Port == 0 {
-		return fmt.Errorf("fatal error; Port setting for Core Metadata client not configured")
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fatal error; Port setting for Core Metadata client not configured", nil)
 	}
 
 	if len(configuration.Clients[clients.CoreDataServiceKey].Host) == 0 {
-		return fmt.Errorf("fatal error; Host setting for Core Data client not configured")
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fatal error; Host setting for Core Data client not configured", nil)
 	}
 
 	if configuration.Clients[clients.CoreDataServiceKey].Port == 0 {
-		return fmt.Errorf("fatal error; Port setting for Core Data client not configured")
+		return errors.NewCommonEdgeX(errors.KindContractInvalid, "fatal error; Port setting for Core Data client not configured", nil)
 	}
 
 	// TODO: validate other settings for sanity: maxcmdops, ...

--- a/internal/transformer/transformresult.go
+++ b/internal/transformer/transformresult.go
@@ -453,7 +453,9 @@ func transformReadShift(value interface{}, shift string) (interface{}, errors.Ed
 	return value, nil
 }
 
-func commandValueForTransform(cv *dsModels.CommandValue) (v interface{}, err errors.EdgeX) {
+func commandValueForTransform(cv *dsModels.CommandValue) (interface{}, errors.EdgeX) {
+	var v interface{}
+	var err error
 	switch cv.Type {
 	case v2.ValueTypeUint8:
 		v, err = cv.Uint8Value()
@@ -526,7 +528,7 @@ func checkAssertion(
 }
 
 func mapCommandValue(value *dsModels.CommandValue, mappings map[string]string) (*dsModels.CommandValue, bool) {
-	var err errors.EdgeX
+	var err error
 	var result *dsModels.CommandValue
 
 	newValue, ok := mappings[value.ValueToString()]

--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -39,7 +39,7 @@ type CommandValue struct {
 }
 
 // NewCommandValue create a CommandValue according to the valueType supplied.
-func NewCommandValue(deviceResourceName string, valueType string, value interface{}) (*CommandValue, errors.EdgeX) {
+func NewCommandValue(deviceResourceName string, valueType string, value interface{}) (*CommandValue, error) {
 	err := validate(valueType, value)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
@@ -66,7 +66,7 @@ func (cv *CommandValue) String() string {
 }
 
 // BoolValue returns the value in bool data type, and returns error if the Type is not Bool.
-func (cv *CommandValue) BoolValue() (bool, errors.EdgeX) {
+func (cv *CommandValue) BoolValue() (bool, error) {
 	var value bool
 	if cv.Type != v2.ValueTypeBool {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeBool)
@@ -81,7 +81,7 @@ func (cv *CommandValue) BoolValue() (bool, errors.EdgeX) {
 }
 
 // BoolArrayValue returns the value in an array of bool type, and returns error if the Type is not BoolArray.
-func (cv *CommandValue) BoolArrayValue() ([]bool, errors.EdgeX) {
+func (cv *CommandValue) BoolArrayValue() ([]bool, error) {
 	var value []bool
 	if cv.Type != v2.ValueTypeBoolArray {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeBoolArray)
@@ -96,7 +96,7 @@ func (cv *CommandValue) BoolArrayValue() ([]bool, errors.EdgeX) {
 }
 
 // StringValue returns the value in string data type, and returns error if the Type is not String.
-func (cv *CommandValue) StringValue() (string, errors.EdgeX) {
+func (cv *CommandValue) StringValue() (string, error) {
 	var value string
 	if cv.Type != v2.ValueTypeString {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeString)
@@ -111,7 +111,7 @@ func (cv *CommandValue) StringValue() (string, errors.EdgeX) {
 }
 
 // Uint8Value returns the value in uint8 data type, and returns error if the Type is not Uint8.
-func (cv *CommandValue) Uint8Value() (uint8, errors.EdgeX) {
+func (cv *CommandValue) Uint8Value() (uint8, error) {
 	var value uint8
 	if cv.Type != v2.ValueTypeUint8 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeUint8)
@@ -126,7 +126,7 @@ func (cv *CommandValue) Uint8Value() (uint8, errors.EdgeX) {
 }
 
 // Uint8ArrayValue returns the value in an array of uint8 type, and returns error if the Type is not Uint8Array.
-func (cv *CommandValue) Uint8ArrayValue() ([]uint8, errors.EdgeX) {
+func (cv *CommandValue) Uint8ArrayValue() ([]uint8, error) {
 	var value []uint8
 	if cv.Type != v2.ValueTypeUint8Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeUint8Array)
@@ -141,7 +141,7 @@ func (cv *CommandValue) Uint8ArrayValue() ([]uint8, errors.EdgeX) {
 }
 
 // Uint16Value returns the value in uint16 data type, and returns error if the Type is not Uint16.
-func (cv *CommandValue) Uint16Value() (uint16, errors.EdgeX) {
+func (cv *CommandValue) Uint16Value() (uint16, error) {
 	var value uint16
 	if cv.Type != v2.ValueTypeUint16 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeUint16)
@@ -156,7 +156,7 @@ func (cv *CommandValue) Uint16Value() (uint16, errors.EdgeX) {
 }
 
 // Uint16ArrayValue returns the value in an array of uint16 type, and returns error if the Type is not Uint16Array.
-func (cv *CommandValue) Uint16ArrayValue() ([]uint16, errors.EdgeX) {
+func (cv *CommandValue) Uint16ArrayValue() ([]uint16, error) {
 	var value []uint16
 	if cv.Type != v2.ValueTypeUint16Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeUint16Array)
@@ -171,7 +171,7 @@ func (cv *CommandValue) Uint16ArrayValue() ([]uint16, errors.EdgeX) {
 }
 
 // Uint32Value returns the value in uint32 data type, and returns error if the Type is not Uint32.
-func (cv *CommandValue) Uint32Value() (uint32, errors.EdgeX) {
+func (cv *CommandValue) Uint32Value() (uint32, error) {
 	var value uint32
 	if cv.Type != v2.ValueTypeUint32 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeUint32)
@@ -186,7 +186,7 @@ func (cv *CommandValue) Uint32Value() (uint32, errors.EdgeX) {
 }
 
 // Uint32ArrayValue returns the value in an array of uint32 type, and returns error if the Type is not Uint32Array.
-func (cv *CommandValue) Uint32ArrayValue() ([]uint32, errors.EdgeX) {
+func (cv *CommandValue) Uint32ArrayValue() ([]uint32, error) {
 	var value []uint32
 	if cv.Type != v2.ValueTypeUint32Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeUint32Array)
@@ -201,7 +201,7 @@ func (cv *CommandValue) Uint32ArrayValue() ([]uint32, errors.EdgeX) {
 }
 
 // Uint64Value returns the value in uint64 data type, and returns error if the Type is not Uint64.
-func (cv *CommandValue) Uint64Value() (uint64, errors.EdgeX) {
+func (cv *CommandValue) Uint64Value() (uint64, error) {
 	var value uint64
 	if cv.Type != v2.ValueTypeUint64 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeUint64)
@@ -216,7 +216,7 @@ func (cv *CommandValue) Uint64Value() (uint64, errors.EdgeX) {
 }
 
 // Uint64ArrayValue returns the value in an array of uint64 type, and returns error if the Type is not Uint64Array.
-func (cv *CommandValue) Uint64ArrayValue() ([]uint64, errors.EdgeX) {
+func (cv *CommandValue) Uint64ArrayValue() ([]uint64, error) {
 	var value []uint64
 	if cv.Type != v2.ValueTypeUint64Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeUint64Array)
@@ -231,7 +231,7 @@ func (cv *CommandValue) Uint64ArrayValue() ([]uint64, errors.EdgeX) {
 }
 
 // Int8Value returns the value in int8 data type, and returns error if the Type is not Int8.
-func (cv *CommandValue) Int8Value() (int8, errors.EdgeX) {
+func (cv *CommandValue) Int8Value() (int8, error) {
 	var value int8
 	if cv.Type != v2.ValueTypeInt8 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeInt8)
@@ -246,7 +246,7 @@ func (cv *CommandValue) Int8Value() (int8, errors.EdgeX) {
 }
 
 // Int8ArrayValue returns the value in an array of int8 type, and returns error if the Type is not Int8Array.
-func (cv *CommandValue) Int8ArrayValue() ([]int8, errors.EdgeX) {
+func (cv *CommandValue) Int8ArrayValue() ([]int8, error) {
 	var value []int8
 	if cv.Type != v2.ValueTypeInt8Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeInt8Array)
@@ -261,7 +261,7 @@ func (cv *CommandValue) Int8ArrayValue() ([]int8, errors.EdgeX) {
 }
 
 // Int16Value returns the value in int16 data type, and returns error if the Type is not Int16.
-func (cv *CommandValue) Int16Value() (int16, errors.EdgeX) {
+func (cv *CommandValue) Int16Value() (int16, error) {
 	var value int16
 	if cv.Type != v2.ValueTypeInt16 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeInt16)
@@ -276,7 +276,7 @@ func (cv *CommandValue) Int16Value() (int16, errors.EdgeX) {
 }
 
 // Int16ArrayValue returns the value in an array of int16 type, and returns error if the Type is not Int16Array.
-func (cv *CommandValue) Int16ArrayValue() ([]int16, errors.EdgeX) {
+func (cv *CommandValue) Int16ArrayValue() ([]int16, error) {
 	var value []int16
 	if cv.Type != v2.ValueTypeInt16Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeInt16Array)
@@ -291,7 +291,7 @@ func (cv *CommandValue) Int16ArrayValue() ([]int16, errors.EdgeX) {
 }
 
 // Int32Value returns the value in int32 data type, and returns error if the Type is not Int32.
-func (cv *CommandValue) Int32Value() (int32, errors.EdgeX) {
+func (cv *CommandValue) Int32Value() (int32, error) {
 	var value int32
 	if cv.Type != v2.ValueTypeInt32 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeInt32)
@@ -306,7 +306,7 @@ func (cv *CommandValue) Int32Value() (int32, errors.EdgeX) {
 }
 
 // Int32ArrayValue returns the value in an array of int32 type, and returns error if the Type is not Int32Array.
-func (cv *CommandValue) Int32ArrayValue() ([]int32, errors.EdgeX) {
+func (cv *CommandValue) Int32ArrayValue() ([]int32, error) {
 	var value []int32
 	if cv.Type != v2.ValueTypeInt32Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeInt32Array)
@@ -321,7 +321,7 @@ func (cv *CommandValue) Int32ArrayValue() ([]int32, errors.EdgeX) {
 }
 
 // Int64Value returns the value in int64 data type, and returns error if the Type is not Int64.
-func (cv *CommandValue) Int64Value() (int64, errors.EdgeX) {
+func (cv *CommandValue) Int64Value() (int64, error) {
 	var value int64
 	if cv.Type != v2.ValueTypeInt64 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeInt64)
@@ -336,7 +336,7 @@ func (cv *CommandValue) Int64Value() (int64, errors.EdgeX) {
 }
 
 // Int64ArrayValue returns the value in an array of int64 type, and returns error if the Type is not Int64Array.
-func (cv *CommandValue) Int64ArrayValue() ([]int64, errors.EdgeX) {
+func (cv *CommandValue) Int64ArrayValue() ([]int64, error) {
 	var value []int64
 	if cv.Type != v2.ValueTypeInt64Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeInt64Array)
@@ -351,7 +351,7 @@ func (cv *CommandValue) Int64ArrayValue() ([]int64, errors.EdgeX) {
 }
 
 // Float32Value returns the value in float32 data type, and returns error if the Type is not Float32.
-func (cv *CommandValue) Float32Value() (float32, errors.EdgeX) {
+func (cv *CommandValue) Float32Value() (float32, error) {
 	var value float32
 	if cv.Type != v2.ValueTypeFloat32 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeFloat32)
@@ -366,7 +366,7 @@ func (cv *CommandValue) Float32Value() (float32, errors.EdgeX) {
 }
 
 // Float32ArrayValue returns the value in an array of float32 type, and returns error if the Type is not Float32Array.
-func (cv *CommandValue) Float32ArrayValue() ([]float32, errors.EdgeX) {
+func (cv *CommandValue) Float32ArrayValue() ([]float32, error) {
 	var value []float32
 	if cv.Type != v2.ValueTypeFloat32Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeFloat32Array)
@@ -381,7 +381,7 @@ func (cv *CommandValue) Float32ArrayValue() ([]float32, errors.EdgeX) {
 }
 
 // Float64Value returns the value in float64 data type, and returns error if the Type is not Float64.
-func (cv *CommandValue) Float64Value() (float64, errors.EdgeX) {
+func (cv *CommandValue) Float64Value() (float64, error) {
 	var value float64
 	if cv.Type != v2.ValueTypeFloat64 {
 		errMsg := fmt.Sprintf("cannot convert CommandValue of %s to %s", cv.Type, v2.ValueTypeFloat64)
@@ -396,7 +396,7 @@ func (cv *CommandValue) Float64Value() (float64, errors.EdgeX) {
 }
 
 // Float64ArrayValue returns the value in an array of float64 type, and returns error if the Type is not Float64Array.
-func (cv *CommandValue) Float64ArrayValue() ([]float64, errors.EdgeX) {
+func (cv *CommandValue) Float64ArrayValue() ([]float64, error) {
 	var value []float64
 	if cv.Type != v2.ValueTypeFloat64Array {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeFloat64Array)
@@ -411,7 +411,7 @@ func (cv *CommandValue) Float64ArrayValue() ([]float64, errors.EdgeX) {
 }
 
 // BinaryValue returns the value in []byte data type, and returns error if the Type is not Binary.
-func (cv *CommandValue) BinaryValue() ([]byte, errors.EdgeX) {
+func (cv *CommandValue) BinaryValue() ([]byte, error) {
 	var value []byte
 	if cv.Type != v2.ValueTypeBinary {
 		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, v2.ValueTypeBinary)
@@ -427,7 +427,7 @@ func (cv *CommandValue) BinaryValue() ([]byte, errors.EdgeX) {
 
 // validate checks if the given value can be converted to specified valueType by
 // performing type assertion
-func validate(valueType string, value interface{}) errors.EdgeX {
+func validate(valueType string, value interface{}) error {
 	var ok bool
 	switch valueType {
 	case v2.ValueTypeString:

--- a/pkg/service/managedautoevents.go
+++ b/pkg/service/managedautoevents.go
@@ -17,7 +17,7 @@ import (
 )
 
 // AddDeviceAutoEvent adds a new AutoEvent to the Device with given name
-func (s *DeviceService) AddDeviceAutoEvent(deviceName string, event models.AutoEvent) errors.EdgeX {
+func (s *DeviceService) AddDeviceAutoEvent(deviceName string, event models.AutoEvent) error {
 	found := false
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
@@ -51,7 +51,7 @@ func (s *DeviceService) AddDeviceAutoEvent(deviceName string, event models.AutoE
 }
 
 // RemoveDeviceAutoEvent removes an AutoEvent from the Device with given name
-func (s *DeviceService) RemoveDeviceAutoEvent(deviceName string, event models.AutoEvent) errors.EdgeX {
+func (s *DeviceService) RemoveDeviceAutoEvent(deviceName string, event models.AutoEvent) error {
 	device, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		msg := fmt.Sprintf("failed to find device %s cannot in cache", deviceName)

--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -24,7 +24,7 @@ import (
 
 // AddDevice adds a new Device to the Device Service and Core Metadata
 // Returns new Device id or non-nil error.
-func (s *DeviceService) AddDevice(device models.Device) (string, errors.EdgeX) {
+func (s *DeviceService) AddDevice(device models.Device) (string, error) {
 	if d, ok := cache.Devices().ForName(device.Name); ok {
 		return d.Id, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, Device %s exists", device.Name), nil)
 	}
@@ -58,7 +58,7 @@ func (s *DeviceService) Devices() []models.Device {
 }
 
 // GetDeviceByName returns the Device by its name if it exists in the cache, or returns an error.
-func (s *DeviceService) GetDeviceByName(name string) (models.Device, errors.EdgeX) {
+func (s *DeviceService) GetDeviceByName(name string) (models.Device, error) {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Device %s in cache", name)
@@ -70,7 +70,7 @@ func (s *DeviceService) GetDeviceByName(name string) (models.Device, errors.Edge
 
 // RemoveDeviceByName removes the specified Device by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceService) RemoveDeviceByName(name string) errors.EdgeX {
+func (s *DeviceService) RemoveDeviceByName(name string) error {
 	device, ok := cache.Devices().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find device %s in cache", name)
@@ -90,7 +90,7 @@ func (s *DeviceService) RemoveDeviceByName(name string) errors.EdgeX {
 
 // UpdateDevice updates the Device in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceService) UpdateDevice(device models.Device) errors.EdgeX {
+func (s *DeviceService) UpdateDevice(device models.Device) error {
 	_, ok := cache.Devices().ForName(device.Name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Device %s in cache", device.Name)
@@ -111,7 +111,7 @@ func (s *DeviceService) UpdateDevice(device models.Device) errors.EdgeX {
 
 // UpdateDeviceOperatingState updates the Device's OperatingState with given name
 // in Core Metadata and device service cache.
-func (s *DeviceService) UpdateDeviceOperatingState(deviceName string, state string) errors.EdgeX {
+func (s *DeviceService) UpdateDeviceOperatingState(deviceName string, state string) error {
 	d, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Device %s in cache", deviceName)

--- a/pkg/service/managedprofiles.go
+++ b/pkg/service/managedprofiles.go
@@ -23,7 +23,7 @@ import (
 
 // AddDeviceProfile adds a new DeviceProfile to the Device Service and Core Metadata
 // Returns new DeviceProfile id or non-nil error.
-func (s *DeviceService) AddDeviceProfile(profile models.DeviceProfile) (string, errors.EdgeX) {
+func (s *DeviceService) AddDeviceProfile(profile models.DeviceProfile) (string, error) {
 	if p, ok := cache.Profiles().ForName(profile.Name); ok {
 		return p.Id, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, Profile %s exists", profile.Name), nil)
 	}
@@ -51,7 +51,7 @@ func (s *DeviceService) DeviceProfiles() []models.DeviceProfile {
 }
 
 // GetProfileByName returns the Profile by its name if it exists in the cache, or returns an error.
-func (s *DeviceService) GetProfileByName(name string) (models.DeviceProfile, errors.EdgeX) {
+func (s *DeviceService) GetProfileByName(name string) (models.DeviceProfile, error) {
 	profile, ok := cache.Profiles().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Profile %s in cache", name)
@@ -63,7 +63,7 @@ func (s *DeviceService) GetProfileByName(name string) (models.DeviceProfile, err
 
 // RemoveDeviceProfileByName removes the specified DeviceProfile by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceService) RemoveDeviceProfileByName(name string) errors.EdgeX {
+func (s *DeviceService) RemoveDeviceProfileByName(name string) error {
 	profile, ok := cache.Profiles().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Profile %s in cache", name)
@@ -85,7 +85,7 @@ func (s *DeviceService) RemoveDeviceProfileByName(name string) errors.EdgeX {
 
 // UpdateDeviceProfile updates the DeviceProfile in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceService) UpdateDeviceProfile(profile models.DeviceProfile) errors.EdgeX {
+func (s *DeviceService) UpdateDeviceProfile(profile models.DeviceProfile) error {
 	_, ok := cache.Profiles().ForName(profile.Name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find Profile %s in cache", profile.Name)

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -22,7 +22,7 @@ import (
 
 // AddProvisionWatcher adds a new Watcher to the cache and Core Metadata
 // Returns new Watcher id or non-nil error.
-func (s *DeviceService) AddProvisionWatcher(watcher models.ProvisionWatcher) (string, errors.EdgeX) {
+func (s *DeviceService) AddProvisionWatcher(watcher models.ProvisionWatcher) (string, error) {
 	if pw, ok := cache.ProvisionWatchers().ForName(watcher.Name); ok {
 		return pw.Id,
 			errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, ProvisionWatcher %s exists", watcher.Name), nil)
@@ -54,7 +54,7 @@ func (s *DeviceService) ProvisionWatchers() []models.ProvisionWatcher {
 }
 
 // GetProvisionWatcherByName returns the Watcher by its name if it exists in the cache, or returns an error.
-func (s *DeviceService) GetProvisionWatcherByName(name string) (models.ProvisionWatcher, errors.EdgeX) {
+func (s *DeviceService) GetProvisionWatcherByName(name string) (models.ProvisionWatcher, error) {
 	pw, ok := cache.ProvisionWatchers().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find ProvisionWatcher %s in cache", name)
@@ -66,7 +66,7 @@ func (s *DeviceService) GetProvisionWatcherByName(name string) (models.Provision
 
 // RemoveProvisionWatcher removes the specified Watcher by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
-func (s *DeviceService) RemoveProvisionWatcher(name string) errors.EdgeX {
+func (s *DeviceService) RemoveProvisionWatcher(name string) error {
 	pw, ok := cache.ProvisionWatchers().ForName(name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find ProvisionWatcher %s in cache", name)
@@ -87,7 +87,7 @@ func (s *DeviceService) RemoveProvisionWatcher(name string) errors.EdgeX {
 
 // UpdateProvisionWatcher updates the Watcher in the cache and ensures that the
 // copy in Core Metadata is also updated.
-func (s *DeviceService) UpdateProvisionWatcher(watcher models.ProvisionWatcher) errors.EdgeX {
+func (s *DeviceService) UpdateProvisionWatcher(watcher models.ProvisionWatcher) error {
 	_, ok := cache.ProvisionWatchers().ForName(watcher.Name)
 	if !ok {
 		msg := fmt.Sprintf("failed to find ProvisionWatcher %s in cache", watcher.Name)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -140,7 +140,7 @@ func (s *DeviceService) DeviceDiscovery() bool {
 }
 
 // AddRoute allows leveraging the existing internal web server to add routes specific to Device Service.
-func (s *DeviceService) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) errors.EdgeX {
+func (s *DeviceService) AddRoute(route string, handler func(http.ResponseWriter, *http.Request), methods ...string) error {
 	return s.controller.AddRoute(route, handler, methods...)
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
`errors.Edgex` implements `error` interface, however normal error threw by standard library doesn't implement `errors.Edgex` 
A common scenario a device service developer might do:
```Go
val, err := customGetValueFunction()
cv, err := sdkModel.NewCommandValue(dr, valueType, val)
```
these code will throw a confusing `Type does not implement 'errors.Edgex...`

## Issue Number: fix #778 


## What is the new behavior?
use `errors.Edgex`in `internal` package for better logging/debugging; use normal error type in `pkg` package for better device service development experience. 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
