### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build: $(MICROSERVICES)
 	$(GOCGO) install -tags=safe
 
 example/cmd/device-simple/device-simple:
+	go mod tidy
 	$(GOCGO) build $(GOFLAGS) -o $@ ./example/cmd/device-simple
 
 docker:
@@ -29,6 +30,7 @@ docker:
 		.
 
 test:
+	go mod tidy
 	GO111MODULE=on go test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
 	GO111MODULE=on go vet ./...
 	gofmt -l .

--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -32,12 +32,12 @@ Port = 8500
 Type = 'consul'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48080
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48081

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/edgexfoundry/device-sdk-go/v2
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.52
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.89
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.54
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
 	github.com/google/uuid v1.2.0


### PR DESCRIPTION
**Dependent on edgexfoundry/go-mod-core-contracts#613**
**Dependent on https://github.com/edgexfoundry/go-mod-bootstrap/pull/216**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Service key constants have the edgex- prefix



## Issue Number:  #925 & #893


## What is the new behavior?
Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore



## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names used in configuration have changed.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
