### PR TITLE
feat: add Event tagging capability

### DIFF
--- a/internal/application/command_test.go
+++ b/internal/application/command_test.go
@@ -49,6 +49,7 @@ func mockDic() *di.Container {
 		DeviceResourceName: "test-resource",
 		Type:               "String",
 		Value:              "test-value",
+		Tags:               make(map[string]string),
 	}
 	driverMock.On("HandleReadCommands", "test-device", testProtocols, []sdkModels.CommandRequest{cr}).Return(nil, nil)
 	driverMock.On("HandleWriteCommands", "test-device", testProtocols, []sdkModels.CommandRequest{cr}, []*sdkModels.CommandValue{cv}).Return(nil)

--- a/internal/transformer/transform.go
+++ b/internal/transformer/transform.go
@@ -43,6 +43,7 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 
 	var transformsOK = true
 	origin := getUniqueOrigin()
+	tags := make(map[string]string)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
 	readings := make([]dtos.BaseReading, 0, config.Device.MaxCmdOps)
@@ -100,6 +101,10 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 			}
 		}
 
+		for key, value := range cv.Tags {
+			tags[key] = value
+		}
+
 		reading, err := commandValueToReading(cv, device.Name, device.ProfileName, dr.Properties.MediaType, origin)
 		if err != nil {
 			return nil, errors.NewCommonEdgeXWrapper(err)
@@ -121,6 +126,7 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 		eventDTO := dtos.NewEvent(device.ProfileName, device.Name, sourceName)
 		eventDTO.Readings = readings
 		eventDTO.Origin = origin
+		eventDTO.Tags = tags
 
 		return &eventDTO, nil
 	} else {

--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -36,6 +36,9 @@ type CommandValue struct {
 	// contained in the CommandValue was read by the ProtocolDriver
 	// instance.
 	Origin int64
+	// Tags allows device service to add custom information to the Event in order to
+	// help identify its origin or otherwise label it before it is send to north side.
+	Tags map[string]string
 }
 
 // NewCommandValue create a CommandValue according to the valueType supplied.
@@ -48,7 +51,8 @@ func NewCommandValue(deviceResourceName string, valueType string, value interfac
 	return &CommandValue{
 		DeviceResourceName: deviceResourceName,
 		Type:               valueType,
-		Value:              value}, nil
+		Value:              value,
+		Tags:               make(map[string]string)}, nil
 }
 
 // ValueToString returns the string format of the value.


### PR DESCRIPTION
add Tags field in CommandValue struct to allow driver implementor
add custom information if required.

Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number: fix #915 


## What is the new behavior?
developer can add custom information in `CommandValue`, for example:
```Go
cv, _ := dsModels.NewCommandValue(deviceResourceName, v2.ValueTypeInt32, readingValue)
cv.Tags["foo"] = "bar"
```


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
