### PR TITLE
refactor: Use common ServiceInfo struct and adjust code/configuration

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -1,3 +1,8 @@
+AsyncBufferSize = 1
+EnableAsyncReadings = true
+Labels = []
+UseMessageBus = false
+
 [Writable]
 LogLevel = 'INFO'
   # Example InsecureSecrets configuration that simulates SecretStore for when EDGEX_SECURITY_SECRET_STORE=false
@@ -10,21 +15,14 @@ LogLevel = 'INFO'
       password = ""
 
 [Service]
-BootTimeout = 30000
-CheckInterval = '10s'
+HealthCheckInterval = '10s'
 Host = 'localhost'
-ServerBindAddr = ''  # blank value defaults to Service.Host value
 Port = 59999 # Device serivce are assigned the 599xx range
-Protocol = 'http'
+ServerBindAddr = ''  # blank value defaults to Service.Host value
 StartupMsg = 'device simple started'
-Timeout = 20000
-Labels = []
-EnableAsyncReadings = true
-AsyncBufferSize = 1
 # MaxRequestSize limit the request body size in byte of put command
-# value 0 unlimit the request size.
-MaxRequestSize = 0
-UseMessageBus = false
+MaxRequestSize = 0 # value 0 unlimit the request size.
+RequestTimeout = '20s'
 
 [Registry]
 Host = 'localhost'

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-sdk-go/v2
 require (
 	bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.57
+	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.0.0-dev.58
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.0.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7

--- a/internal/autoevent/manager.go
+++ b/internal/autoevent/manager.go
@@ -39,7 +39,7 @@ func BootstrapHandler(
 		wg:              wg,
 		executorMap:     make(map[string][]*Executor),
 		dic:             dic,
-		autoeventBuffer: make(chan bool, config.Service.AsyncBufferSize),
+		autoeventBuffer: make(chan bool, config.AsyncBufferSize),
 	}
 
 	dic.Update(di.ServiceConstructorMap{

--- a/internal/clients/init_test.go
+++ b/internal/clients/init_test.go
@@ -8,6 +8,7 @@ package clients
 
 import (
 	"testing"
+	"time"
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
@@ -25,9 +26,9 @@ func TestCheckServiceAvailableByPingWithTimeoutError(test *testing.T) {
 			Protocol: "http",
 		},
 	}
-	config := &config.ConfigurationStruct{Service: config.ServiceInfo{Timeout: 1000}, Clients: clientConfig}
+	config := &config.ConfigurationStruct{Clients: clientConfig}
 	lc := logger.NewMockClient()
 
-	res := checkServiceAvailableByPing(clients.CoreDataServiceKey, config, lc)
+	res := checkServiceAvailableByPing(clients.CoreDataServiceKey, time.Duration(1000), config, lc)
 	assert.Equal(test, res, false, "request should be timeout and return false")
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -57,7 +57,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	ctx := context.WithValue(context.Background(), CorrelationHeader, correlationID)
 	req := requests.NewAddEventRequest(*event)
 
-	if configuration.Service.UseMessageBus {
+	if configuration.UseMessageBus {
 		mc := container.MessagingClientFrom(dic.Get)
 		bytes, encoding, err := req.Encode()
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,14 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the device service.
 type ConfigurationStruct struct {
+	// AsyncBufferSize defines the size of asynchronous channel
+	AsyncBufferSize int
+	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
+	EnableAsyncReadings bool
+	// Labels are properties applied to the device service to help with searching
+	Labels []string
+	// UseMessageBus indicates whether or not the Event are published directly to the MessageBus
+	UseMessageBus bool
 	// WritableInfo contains configuration settings that can be changed in the Registry .
 	Writable WritableInfo
 	// Clients is a map of services used by a DS.
@@ -19,7 +27,7 @@ type ConfigurationStruct struct {
 	// Registry contains registry-specific settings.
 	Registry bootstrapConfig.RegistryInfo
 	// Service contains DeviceService-specific settings.
-	Service ServiceInfo
+	Service bootstrapConfig.ServiceInfo
 	// Device contains device-specific configuration settings.
 	Device DeviceInfo
 	// Driver is a string map contains customized configuration for the protocol driver implemented based on Device SDK
@@ -67,7 +75,7 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	return bootstrapConfig.BootstrapConfiguration{
 		Clients:     c.Clients,
-		Service:     c.Service.GetBootstrapServiceInfo(),
+		Service:     c.Service,
 		Registry:    c.Registry,
 		SecretStore: c.SecretStore,
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -19,45 +19,6 @@ type WritableInfo struct {
 	InsecureSecrets config.InsecureSecrets
 }
 
-// ServiceInfo is a struct which contains service related configuration
-// settings.
-type ServiceInfo struct {
-	// BootTimeout indicates, in milliseconds, how long the service will retry connecting to upstream dependencies
-	// before giving up. Default is 30,000.
-	BootTimeout int
-	// Health check interval
-	CheckInterval string
-	// Host is the hostname or IP address of the service.
-	Host string
-	// Port is the HTTP port of the service.
-	Port int
-	// ServerBindAddr specifies an IP address or hostname
-	// for ListenAndServe to bind to, such as 0.0.0.0
-	ServerBindAddr string
-	// The protocol that should be used to call this service
-	Protocol string
-	// StartupMsg specifies a string to log once service
-	// initialization and startup is completed.
-	StartupMsg string
-	// MaxResultCount specifies the maximum size list supported
-	// in response to REST calls to other services.
-	MaxResultCount int
-	// Timeout (in milliseconds) specifies both
-	// - timeout for processing REST calls and
-	// - interval time the DS will wait between each retry call.
-	Timeout int
-	// Labels are properties applied to the device service to help with searching
-	Labels []string
-	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
-	EnableAsyncReadings bool
-	// AsyncBufferSize defines the size of asynchronous channel
-	AsyncBufferSize int
-	// MaxRequestSize defines the maximum size of http request body in bytes
-	MaxRequestSize int64
-	// UseMessageBus indicates whether or not the Event are published directly to the MessageBus
-	UseMessageBus bool
-}
-
 // DeviceInfo is a struct which contains device specific configuration settings.
 type DeviceInfo struct {
 	// DataTransform specifies whether or not the DS perform transformations
@@ -99,20 +60,6 @@ type DiscoveryInfo struct {
 	// Interval indicates how often the discovery process will be triggered.
 	// It represents as a duration string.
 	Interval string
-}
-
-func (s ServiceInfo) GetBootstrapServiceInfo() config.ServiceInfo {
-	return config.ServiceInfo{
-		BootTimeout:    s.BootTimeout,
-		CheckInterval:  s.CheckInterval,
-		Host:           s.Host,
-		Port:           s.Port,
-		ServerBindAddr: s.ServerBindAddr,
-		Protocol:       s.Protocol,
-		StartupMsg:     s.StartupMsg,
-		MaxResultCount: s.MaxResultCount,
-		Timeout:        s.Timeout,
-	}
 }
 
 // Telemetry provides metrics (on a given device service) to system management.

--- a/internal/messaging/messaging.go
+++ b/internal/messaging/messaging.go
@@ -35,7 +35,7 @@ import (
 func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
-	if config.Service.UseMessageBus == false {
+	if config.UseMessageBus == false {
 		lc.Info("Use of MessageBus disabled, skipping creation of messaging client")
 		return true
 	}

--- a/internal/messaging/messaging_test.go
+++ b/internal/messaging/messaging_test.go
@@ -56,15 +56,11 @@ func TestMain(m *testing.M) {
 
 func TestBootstrapHandler(t *testing.T) {
 	validNotUsingMessageBus := config.ConfigurationStruct{
-		Service: config.ServiceInfo{
-			UseMessageBus: false,
-		},
+		UseMessageBus: false,
 	}
 
 	validCreateClient := config.ConfigurationStruct{
-		Service: config.ServiceInfo{
-			UseMessageBus: true,
-		},
+		UseMessageBus: true,
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			Type:               messaging.ZeroMQ, // Use ZMQ so no issue connecting.
 			Protocol:           "http",
@@ -77,9 +73,7 @@ func TestBootstrapHandler(t *testing.T) {
 	}
 
 	invalidSecrets := config.ConfigurationStruct{
-		Service: config.ServiceInfo{
-			UseMessageBus: true,
-		},
+		UseMessageBus: true,
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			AuthMode:   messaging2.AuthModeCert,
 			SecretName: "redisdb",
@@ -87,9 +81,7 @@ func TestBootstrapHandler(t *testing.T) {
 	}
 
 	invalidNoConnect := config.ConfigurationStruct{
-		Service: config.ServiceInfo{
-			UseMessageBus: true,
-		},
+		UseMessageBus: true,
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			Type:       messaging.MQTT, // This will cause no connection since broker not available
 			Protocol:   "tcp",

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -39,7 +39,7 @@ func (s *DeviceService) processAsyncResults(ctx context.Context, wg *sync.WaitGr
 		wg.Done()
 	}()
 
-	working := make(chan bool, s.config.Service.AsyncBufferSize)
+	working := make(chan bool, s.config.AsyncBufferSize)
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -44,7 +44,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	}
 
 	if ds.AsyncReadings() {
-		ds.asyncCh = make(chan *models.AsyncValues, ds.config.Service.AsyncBufferSize)
+		ds.asyncCh = make(chan *models.AsyncValues, ds.config.AsyncBufferSize)
 		go ds.processAsyncResults(ctx, wg, dic)
 	}
 	if ds.DeviceDiscovery() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -23,6 +23,7 @@ import (
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
+	bootstrapTypes "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
@@ -133,7 +134,7 @@ func (s *DeviceService) Version() string {
 
 // AsyncReadings returns a bool value to indicate whether the asynchronous reading is enabled.
 func (s *DeviceService) AsyncReadings() bool {
-	return s.config.Service.EnableAsyncReadings
+	return s.config.EnableAsyncReadings
 }
 
 func (s *DeviceService) DeviceDiscovery() bool {
@@ -186,8 +187,8 @@ func (s *DeviceService) ListenForCustomConfigChanges(
 func (s *DeviceService) selfRegister() errors.EdgeX {
 	localDeviceService := models.DeviceService{
 		Name:        s.ServiceName,
-		Labels:      s.config.Service.Labels,
-		BaseAddress: s.config.Service.Protocol + "://" + s.config.Service.Host + ":" + strconv.FormatInt(int64(s.config.Service.Port), 10),
+		Labels:      s.config.Labels,
+		BaseAddress: bootstrapTypes.DefaultHttpProtocol + "://" + s.config.Service.Host + ":" + strconv.FormatInt(int64(s.config.Service.Port), 10),
 		AdminState:  models.Unlocked,
 	}
 	*s.deviceService = localDeviceService


### PR DESCRIPTION
# Note the extra setting have been moved to top level settings rather than arbitrary misc. section

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
SDK uses own version of ServiceInfo with extra settings

## Issue Number: #939


## What is the new behavior?
SDK now uses common version of ServiceInfo 
Extra settings moved to top level; config settings
Code refactored to adjust to chnages.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Device Service configuration items have changed

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
