### PR TITLE
fix: modify function updateAssociatedProfile return errors

### DIFF
--- a/internal/application/callback.go
+++ b/internal/application/callback.go
@@ -240,7 +240,6 @@ func UpdateDeviceService(updateDeviceServiceRequest requests.UpdateDeviceService
 // updateAssociatedProfile updates the profile specified in AddDeviceRequest or UpdateDeviceRequest
 // to stay consistent with core metadata.
 func updateAssociatedProfile(profileName string, dic *di.Container) errors.EdgeX {
-	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	dpc := container.MetadataDeviceProfileClientFrom(dic.Get)
 
 	res, err := dpc.DeviceProfileByName(context.Background(), profileName)
@@ -256,10 +255,12 @@ func updateAssociatedProfile(profileName string, dic *di.Container) errors.EdgeX
 			errMsg := fmt.Sprintf("failed to add profile %s", profileName)
 			return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 		}
+		return nil
 	}
 	err = cache.Profiles().Update(dtos.ToDeviceProfileModel(res.Profile))
 	if err != nil {
-		lc.Warnf("failed to to update profile %s in cache, using the original one", profileName)
+		errMsg := fmt.Sprintf("failed to to update profile %s in cache, using the original one", profileName)
+		return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
 	return nil


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
1. if profile not exist, after adding profile to cache map, update profile again
2. if update profile failed, return nil

## Issue Number:


## What is the new behavior?
1. if profile not exist, after adding profile to cache map, dont need to update profile again
2. if update profile failed, return err just like add profile failed

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
