### PR TITLE
refactor: Move top level individual config settings under Device section

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -1,8 +1,3 @@
-AsyncBufferSize = 1
-EnableAsyncReadings = true
-Labels = []
-UseMessageBus = false
-
 [Writable]
 LogLevel = 'INFO'
   # Example InsecureSecrets configuration that simulates SecretStore for when EDGEX_SECURITY_SECRET_STORE=false
@@ -89,6 +84,10 @@ RetryWaitPeriod = "1s"
   ProfilesDir = './res/profiles'
   DevicesDir = './res/devices'
   UpdateLastConnected = false
+  AsyncBufferSize = 1
+  EnableAsyncReadings = true
+  Labels = []
+  UseMessageBus = false
   [Device.Discovery]
     Enabled = false
     Interval = '30s'

--- a/internal/autoevent/manager.go
+++ b/internal/autoevent/manager.go
@@ -39,7 +39,7 @@ func BootstrapHandler(
 		wg:              wg,
 		executorMap:     make(map[string][]*Executor),
 		dic:             dic,
-		autoeventBuffer: make(chan bool, config.AsyncBufferSize),
+		autoeventBuffer: make(chan bool, config.Device.AsyncBufferSize),
 	}
 
 	dic.Update(di.ServiceConstructorMap{

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -57,7 +57,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	ctx := context.WithValue(context.Background(), CorrelationHeader, correlationID)
 	req := requests.NewAddEventRequest(*event)
 
-	if configuration.UseMessageBus {
+	if configuration.Device.UseMessageBus {
 		mc := container.MessagingClientFrom(dic.Get)
 		bytes, encoding, err := req.Encode()
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,6 @@ import (
 
 // ConfigurationStruct contains the configuration properties for the device service.
 type ConfigurationStruct struct {
-	// AsyncBufferSize defines the size of asynchronous channel
-	AsyncBufferSize int
-	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
-	EnableAsyncReadings bool
-	// Labels are properties applied to the device service to help with searching
-	Labels []string
-	// UseMessageBus indicates whether or not the Event are published directly to the MessageBus
-	UseMessageBus bool
 	// WritableInfo contains configuration settings that can be changed in the Registry .
 	Writable WritableInfo
 	// Clients is a map of services used by a DS.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -51,6 +51,14 @@ type DeviceInfo struct {
 	UpdateLastConnected bool
 
 	Discovery DiscoveryInfo
+	// AsyncBufferSize defines the size of asynchronous channel
+	AsyncBufferSize int
+	// EnableAsyncReadings to determine whether the Device Service would deal with the asynchronous readings
+	EnableAsyncReadings bool
+	// Labels are properties applied to the device service to help with searching
+	Labels []string
+	// UseMessageBus indicates whether or not the Event are published directly to the MessageBus
+	UseMessageBus bool
 }
 
 // DiscoveryInfo is a struct which contains configuration of device auto discovery.

--- a/internal/messaging/messaging.go
+++ b/internal/messaging/messaging.go
@@ -35,7 +35,7 @@ import (
 func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
-	if config.UseMessageBus == false {
+	if config.Device.UseMessageBus == false {
 		lc.Info("Use of MessageBus disabled, skipping creation of messaging client")
 		return true
 	}

--- a/internal/messaging/messaging_test.go
+++ b/internal/messaging/messaging_test.go
@@ -56,11 +56,15 @@ func TestMain(m *testing.M) {
 
 func TestBootstrapHandler(t *testing.T) {
 	validNotUsingMessageBus := config.ConfigurationStruct{
-		UseMessageBus: false,
+		Device: config.DeviceInfo{
+			UseMessageBus: false,
+		},
 	}
 
 	validCreateClient := config.ConfigurationStruct{
-		UseMessageBus: true,
+		Device: config.DeviceInfo{
+			UseMessageBus: true,
+		},
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			Type:               messaging.ZeroMQ, // Use ZMQ so no issue connecting.
 			Protocol:           "http",
@@ -73,7 +77,9 @@ func TestBootstrapHandler(t *testing.T) {
 	}
 
 	invalidSecrets := config.ConfigurationStruct{
-		UseMessageBus: true,
+		Device: config.DeviceInfo{
+			UseMessageBus: true,
+		},
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			AuthMode:   messaging2.AuthModeCert,
 			SecretName: "redisdb",
@@ -81,7 +87,9 @@ func TestBootstrapHandler(t *testing.T) {
 	}
 
 	invalidNoConnect := config.ConfigurationStruct{
-		UseMessageBus: true,
+		Device: config.DeviceInfo{
+			UseMessageBus: true,
+		},
 		MessageQueue: bootstrapConfig.MessageBusInfo{
 			Type:       messaging.MQTT, // This will cause no connection since broker not available
 			Protocol:   "tcp",

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -39,7 +39,7 @@ func (s *DeviceService) processAsyncResults(ctx context.Context, wg *sync.WaitGr
 		wg.Done()
 	}()
 
-	working := make(chan bool, s.config.AsyncBufferSize)
+	working := make(chan bool, s.config.Device.AsyncBufferSize)
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -44,7 +44,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	}
 
 	if ds.AsyncReadings() {
-		ds.asyncCh = make(chan *models.AsyncValues, ds.config.AsyncBufferSize)
+		ds.asyncCh = make(chan *models.AsyncValues, ds.config.Device.AsyncBufferSize)
 		go ds.processAsyncResults(ctx, wg, dic)
 	}
 	if ds.DeviceDiscovery() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -134,7 +134,7 @@ func (s *DeviceService) Version() string {
 
 // AsyncReadings returns a bool value to indicate whether the asynchronous reading is enabled.
 func (s *DeviceService) AsyncReadings() bool {
-	return s.config.EnableAsyncReadings
+	return s.config.Device.EnableAsyncReadings
 }
 
 func (s *DeviceService) DeviceDiscovery() bool {
@@ -187,7 +187,7 @@ func (s *DeviceService) ListenForCustomConfigChanges(
 func (s *DeviceService) selfRegister() errors.EdgeX {
 	localDeviceService := models.DeviceService{
 		Name:        s.ServiceName,
-		Labels:      s.config.Labels,
+		Labels:      s.config.Device.Labels,
 		BaseAddress: bootstrapTypes.DefaultHttpProtocol + "://" + s.config.Service.Host + ":" + strconv.FormatInt(int64(s.config.Service.Port), 10),
 		AdminState:  models.Unlocked,
 	}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Recent refactoring moved a few DS specific settings out of Service section (now common struct) to top level settings. Decision in DS WG 5/24/21 is to move these under the `[Device]` section.

## Issue Number: #943


## What is the new behavior?
Top level individual setting now moved under `[Device]` section

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
