### PR TITLE
refactor: remove unimplemented InitCmd/RemoveCmd configuration (#956)

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -73,12 +73,8 @@ TokenFile = '/tmp/edgex/secrets/device-simple/secrets-token.json'
 
 [Device]
   DataTransform = true
-  InitCmd = ''
-  InitCmdArgs = ''
   MaxCmdOps = 128
   MaxCmdValueLen = 256
-  RemoveCmd = ''
-  RemoveCmdArgs = ''
   ProfilesDir = './res/profiles'
   DevicesDir = './res/devices'
   UpdateLastConnected = false

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -24,11 +24,6 @@ type DeviceInfo struct {
 	// DataTransform specifies whether or not the DS perform transformations
 	// specified by value descriptor on a actuation or query command.
 	DataTransform bool
-	// InitCmd specifies a device resource command which is automatically
-	// generated whenever a new device is added to the DS.
-	InitCmd string
-	// InitCmdArgs specify arguments to be used when building the InitCmd.
-	InitCmdArgs string
 	// MaxCmdOps defines the maximum number of resource operations that
 	// can be sent to a Driver in a single command.
 	MaxCmdOps int
@@ -36,11 +31,6 @@ type DeviceInfo struct {
 	// result (including the value descriptor name) that can be returned
 	// by a Driver.
 	MaxCmdValueLen int
-	// InitCmd specifies a device resource command which is automatically
-	// generated whenever a new device is removed from the DS.
-	RemoveCmd string
-	// RemoveCmdArgs specify arguments to be used when building the RemoveCmd.
-	RemoveCmdArgs string
 	// ProfilesDir specifies a directory which contains device profiles
 	// files which should be imported on startup.
 	ProfilesDir string


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Configuration struct and the example configuration file contain entries for obsolete options InitCmd / InitCmdArgs / RemoveCmd / RemoveCmdArgs

## Issue Number: #956 


## What is the new behavior?
Redundant code and configuration removed

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
