### PR TITLE
fix: device yaml  to Json  error

### DIFF
--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -30,9 +30,6 @@ https://github.com/hashicorp/go-immutable-radix/blob/master/LICENSE
 hashicorp/golang-lru (Mozilla Public License 2.0) https://github.com/hashicorp/golang-lru
 https://github.com/hashicorp/golang-lru/blob/master/LICENSE
 
-gopkg.in/yaml v2 (Apache 2.0) https://github.com/go-yaml/yaml/tree/v2
-https://github.com/go-yaml/yaml/blob/v2/LICENSE
-
 gopkg.in/yaml.v3 (MIT) https://github.com/go-yaml/yaml/tree/v3
 https://github.com/go-yaml/yaml/blob/v3/LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/pelletier/go-toml v1.9.3
 	github.com/stretchr/testify v1.7.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 
 go 1.16

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -21,7 +21,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/google/uuid"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (


### PR DESCRIPTION
when add some complex vaules to the attributes of deviceResources in the device profile, error happens. use gopkg.in/yaml.v3 instead of gopkg.in/yaml.v2

Fixes: #1013

Signed-off-by: wangshihui <wangshihui_1985@163.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
