### PR TITLE
fix: Stop AutoEvents if the Device is locked

### DIFF
--- a/internal/application/callback.go
+++ b/internal/application/callback.go
@@ -113,8 +113,14 @@ func UpdateDevice(updateDeviceRequest requests.UpdateDeviceRequest, dic *di.Cont
 		return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
-	lc.Debugf("starting AutoEvents for device %s", device.Name)
-	container.ManagerFrom(dic.Get).RestartForDevice(device.Name)
+	autoEventManager := container.ManagerFrom(dic.Get)
+	if device.AdminState == models.Locked {
+		lc.Debugf("stopping AutoEvents for the locked device %s", device.Name)
+		autoEventManager.StopForDevice(device.Name)
+	} else {
+		lc.Debugf("starting AutoEvents for device %s", device.Name)
+		autoEventManager.RestartForDevice(device.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
When the Device Update callback is executed, stop AutoEvents if the
adminState of the Device becomes LOCKED.
Fix https://github.com/edgexfoundry/device-sdk-go/issues/1008

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) 
- [ ] Docs have been added / updated (for bug fixes / features) 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
When the Device Update callback is executed, always restart the AutoEvents.


## Issue Number:
Fix #1008

## What is the new behavior?
When the Device Update callback is executed, stop AutoEvents if the adminState of the Device becomes `LOCKED`.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
