### PR TITLE
feat: Allow Get Command to pass parameters in the payload

### DIFF
--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -38,13 +38,11 @@ func (c *RestController) Command(writer http.ResponseWriter, request *http.Reque
 		correlationID, _ = request.Context().Value(common.CorrelationHeader).(string)
 	}
 
-	// read request body for SET command
-	if request.Method == http.MethodPut {
-		requestParamsMap, err = parseRequestBody(request, container.ConfigurationFrom(c.dic.Get).Service.MaxRequestSize)
-		if err != nil {
-			c.sendEdgexError(writer, request, err, common.ApiDeviceNameCommandNameRoute)
-			return
-		}
+	// read request body
+	requestParamsMap, err = parseRequestBody(request, container.ConfigurationFrom(c.dic.Get).Service.MaxRequestSize)
+	if err != nil {
+		c.sendEdgexError(writer, request, err, common.ApiDeviceNameCommandNameRoute)
+		return
 	}
 	// parse query parameter
 	queryParams, reserved, err = filterQueryParams(request.URL.RawQuery)


### PR DESCRIPTION
Read the Get Command parameters from the payload and pass parameters to the protocol driver as request attributes.

Closes #1042

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
 https://github.com/edgexfoundry/edgex-go/pull/3769

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core-service and device-simple
    - core-contracts branch: https://github.com/edgexfoundry/go-mod-core-contracts/pull/680
    - edgex-go branch: https://github.com/edgexfoundry/edgex-go/pull/3769
    - device-sdk-go branch: https://github.com/edgexfoundry/device-sdk-go/pull/1043
2. Execute Get command API with payload
3. Debug the protocol driver should receive the payload which is the attributes of the commandRequest.

https://github.com/edgexfoundry/device-sdk-go/blob/1be87f15213c05ab1957194b5dea87ff4eff74a4/pkg/models/commandrequest.go#L15

For example, the Get Command request contains the payload:
```
curl --location --request GET 'http://0.0.0.0:59882/api/v2/device/name/Simple-Device01/Switch' \
--header 'Content-Type: application/json' \
--data-raw ' {
    "foo":"123",
    "bar":{
        "foobar":"456"
    }
}'
```
The commandRequest should be
```
{
	DeviceResourceName: "..."
	Attributes :  {
                "foo":"123",
                "bar":{
                   "foobar":"456"
                           }
               }
	Type : "..."
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->