### PR TITLE
fix: Add missing StringArray value type for commandValue

### DIFF
--- a/example/cmd/device-simple/res/profiles/Simple-Driver.yaml
+++ b/example/cmd/device-simple/res/profiles/Simple-Driver.yaml
@@ -45,6 +45,13 @@ deviceResources:
         valueType: "Int32"
         readWrite: "RW"
   -
+    name: "StringArray"
+    isHidden: false
+    description: "String array"
+    properties:
+      valueType: "StringArray"
+      readWrite: "RW"
+  -
     name: "Uint8Array"
     isHidden: false
     description: "Unsigned 8bit array"

--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -38,6 +38,7 @@ type SimpleDriver struct {
 	yRotation     int32
 	zRotation     int32
 	counter       interface{}
+	stringArray   []string
 	serviceConfig *config.ServiceConfig
 }
 
@@ -84,6 +85,7 @@ func (s *SimpleDriver) Initialize(lc logger.LoggingClient, asyncCh chan<- *sdkMo
 		"f1": "ABC",
 		"f2": 123,
 	}
+	s.stringArray = []string{"foo", "bar"}
 
 	ds := service.RunningService()
 
@@ -163,6 +165,9 @@ func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[strin
 			}
 			cvb, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeBinary, buf.Bytes())
 			res[0] = cvb
+		} else if reqs[0].DeviceResourceName == "StringArray" {
+			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeStringArray, s.stringArray)
+			res[0] = cv
 		} else if reqs[0].DeviceResourceName == "Uint8Array" {
 			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeUint8Array, []uint8{0, 1, 2})
 			res[0] = cv
@@ -218,6 +223,11 @@ func (s *SimpleDriver) HandleWriteCommands(deviceName string, protocols map[stri
 		case "Zrotation":
 			if s.zRotation, err = params[i].Int32Value(); err != nil {
 				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be Int32, parameter: %s", params[i].String())
+				return err
+			}
+		case "StringArray":
+			if s.stringArray, err = params[i].StringArrayValue(); err != nil {
+				err := fmt.Errorf("SimpleDriver.HandleWriteCommands; the data type of parameter should be string array, parameter: %s", params[i].String())
 				return err
 			}
 		case "Uint8Array":

--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -391,6 +391,14 @@ func createCommandValueFromDeviceResource(dr models.DeviceResource, value interf
 	switch dr.Properties.ValueType {
 	case common.ValueTypeString:
 		result, err = sdkModels.NewCommandValue(dr.Name, common.ValueTypeString, v)
+	case common.ValueTypeStringArray:
+		var arr []string
+		err = json.Unmarshal([]byte(v), &arr)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to convert set parameter %s to ValueType %s", v, dr.Properties.ValueType)
+			return result, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
+		}
+		result, err = sdkModels.NewCommandValue(dr.Name, common.ValueTypeStringArray, arr)
 	case common.ValueTypeBool:
 		var value bool
 		value, err = strconv.ParseBool(v)

--- a/pkg/models/commandvalue.go
+++ b/pkg/models/commandvalue.go
@@ -125,6 +125,21 @@ func (cv *CommandValue) StringValue() (string, error) {
 	return value, nil
 }
 
+// StringArrayValue returns the value in an array of bool type, and returns error if the Type is not BoolArray.
+func (cv *CommandValue) StringArrayValue() ([]string, error) {
+	var value []string
+	if cv.Type != common.ValueTypeStringArray {
+		errMsg := fmt.Sprintf("cannot convert %s to %s", cv.Type, common.ValueTypeStringArray)
+		return value, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
+	}
+	value, ok := cv.Value.([]string)
+	if !ok {
+		errMsg := fmt.Sprintf("failed to transfrom %v to %T", cv.Value, value)
+		return value, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
+	}
+	return value, nil
+}
+
 // Uint8Value returns the value in uint8 data type, and returns error if the Type is not Uint8.
 func (cv *CommandValue) Uint8Value() (uint8, error) {
 	var value uint8
@@ -456,6 +471,8 @@ func validate(valueType string, value interface{}) error {
 	switch valueType {
 	case common.ValueTypeString:
 		_, ok = value.(string)
+	case common.ValueTypeStringArray:
+		_, ok = value.([]string)
 	case common.ValueTypeBool:
 		_, ok = value.(bool)
 	case common.ValueTypeBoolArray:

--- a/pkg/models/commandvalue_test.go
+++ b/pkg/models/commandvalue_test.go
@@ -48,6 +48,7 @@ func Test_validate(t *testing.T) {
 		{"invalid - binary payload exceeds MaxBinaryBytes size", common.ValueTypeBinary, exceedBinary, true},
 		{"valid - binary payload doesn't exceed MaxBinaryBytes size", common.ValueTypeBinary, []byte{1, 2, 3}, false},
 		{"valid - normal type", common.ValueTypeInt8, int8(8), false},
+		{"valid - string array value type", common.ValueTypeStringArray, []string{"foo", "bar"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,6 +77,9 @@ func TestCommandValue_ValueToString(t *testing.T) {
 	rand.Read(binaryValue)
 	binaryCommandValue, err := NewCommandValue("test-resource", common.ValueTypeBinary, binaryValue)
 	require.NoError(t, err)
+	stringArrayValue := []string{"foo", "bar"}
+	stringArrayCommandValue, err := NewCommandValue("test-resource", common.ValueTypeStringArray, stringArrayValue)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name     string
@@ -88,6 +92,7 @@ func TestCommandValue_ValueToString(t *testing.T) {
 		{"valid - CommandValue with string Value", stringCommandValue, "string"},
 		{"valid - CommandValue with boolean Value", boolCommandValue, "true"},
 		{"valid - CommandValue with binary Value", binaryCommandValue, fmt.Sprintf("Binary: [%v...]", string(binaryValue[:20]))},
+		{"valid - CommandValue with string array Value", stringArrayCommandValue, fmt.Sprintf("%v", stringArrayValue)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -169,6 +174,34 @@ func TestCommandValue_StringValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := tt.cv.StringValue()
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.Equal(t, res, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCommandValue_StringArrayValue(t *testing.T) {
+	value := []string{"foo", "bar"}
+	valid := &CommandValue{DeviceResourceName: "test-resource", Type: common.ValueTypeStringArray, Value: value}
+	invalidType := &CommandValue{DeviceResourceName: "test-resource", Type: common.ValueTypeBinary, Value: value}
+	invalidValue := &CommandValue{DeviceResourceName: "test-resource", Type: common.ValueTypeStringArray, Value: true}
+
+	tests := []struct {
+		name        string
+		cv          *CommandValue
+		expected    []string
+		expectedErr bool
+	}{
+		{"valid - CommandValue with []string Value", valid, value, false},
+		{"invalid - ValueType is not StringArray", invalidType, value, true},
+		{"invalid - Value is not []string", invalidValue, value, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := tt.cv.StringArrayValue()
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
Closes #1052

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact the doc
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run the simple device 
2. Execute a Set command
3. Execute a Get command to check the value that should be changed.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->