### PR TITLE
fix: Update ProfileCache when adding or updating the Provision Watcher

### DIFF
--- a/internal/controller/http/callback.go
+++ b/internal/controller/http/callback.go
@@ -121,7 +121,7 @@ func (c *RestController) AddProvisionWatcher(writer http.ResponseWriter, request
 		return
 	}
 
-	edgexErr := application.AddProvisionWatcher(addProvisionWatcherRequest, c.lc)
+	edgexErr := application.AddProvisionWatcher(addProvisionWatcherRequest, c.lc, c.dic)
 	if edgexErr == nil {
 		res := commonDTO.NewBaseResponse(addProvisionWatcherRequest.RequestId, "", http.StatusOK)
 		c.sendResponse(writer, request, common.ApiWatcherCallbackRoute, res, http.StatusOK)

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -30,11 +30,15 @@ func (s *DeviceService) AddProvisionWatcher(watcher models.ProvisionWatcher) (st
 
 	_, ok := cache.Profiles().ForName(watcher.ProfileName)
 	if !ok {
-		_, err := s.edgexClients.DeviceProfileClient.DeviceProfileByName(context.Background(), watcher.ProfileName)
+		res, err := s.edgexClients.DeviceProfileClient.DeviceProfileByName(context.Background(), watcher.ProfileName)
 		if err != nil {
 			errMsg := fmt.Sprintf("failed to find Profile %s for provision watcher %s", watcher.ProfileName, watcher.Name)
 			s.LoggingClient.Error(errMsg)
 			return "", err
+		}
+		err = cache.Profiles().Add(dtos.ToDeviceProfileModel(res.Profile))
+		if err != nil {
+			return "", errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
 		}
 	}
 	watcher.ServiceName = s.ServiceName

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -30,9 +30,12 @@ func (s *DeviceService) AddProvisionWatcher(watcher models.ProvisionWatcher) (st
 
 	_, ok := cache.Profiles().ForName(watcher.ProfileName)
 	if !ok {
-		errMsg := fmt.Sprintf("device profile %s doesn't exist for provision watcher %s", watcher.ProfileName, watcher.Name)
-		s.LoggingClient.Error(errMsg)
-		return "", errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
+		_, err := s.edgexClients.DeviceProfileClient.DeviceProfileByName(context.Background(), watcher.ProfileName)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to find Profile %s for provision watcher %s", watcher.ProfileName, watcher.Name)
+			s.LoggingClient.Error(errMsg)
+			return "", err
+		}
 	}
 	watcher.ServiceName = s.ServiceName
 


### PR DESCRIPTION
Update ProfileCache when adding or updating the Provision Watcher to stay consistent with core metadata

Closes #1053

Signed-off-by: bruce <weichou1229@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **not impact the unit test**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core services
2. Run the device-rfid-llrp-go based on the branch https://github.com/marcpfuller/device-rfid-llrp-go
3. check whether the provision watcher is added

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->