### PR TITLE
fix: Add setting correlation id when Events created via AutoEvents

### DIFF
--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+	"github.com/google/uuid"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/application"
 	sdkCommon "github.com/edgexfoundry/device-sdk-go/v2/internal/common"
@@ -68,7 +69,9 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, buffer chan bool
 				// By adding a buffer here, the user can use the Service.AsyncBufferSize configuration to control the goroutine for sending events.
 				go func() {
 					buffer <- true
-					sdkCommon.SendEvent(evt, "", dic)
+					correlationId := uuid.NewString()
+					sdkCommon.SendEvent(evt, correlationId, dic)
+					lc.Tracef("AutoEvent - Sent new Event/Reading for '%s' source with Correlation Id '%s'", evt.SourceName, correlationId)
 					<-buffer
 				}()
 			} else {


### PR DESCRIPTION
fixes #1057

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **No units tests to update in this code**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Doesn't impact documentation**

## Testing Instructions
1. Run non secure EdgeX docker stack (stop Device Virtual container)
2. Enable **TRACE** logging for app-rules-engine via Consul
3. Clone branch for this PR
4. Clone Device Virtual
5. Update Device Virtual go.mod to use this branch
6. Build and run Device Virtual with **TRACE** level logging (may have to run second time if profiles not already in Core Metadata)
7. Verify Device Virtual logs has similar to the following: 
```
level=TRACE ts=2021-11-08T17:25:53.4135596Z app=device-virtual source=executor.go:74 msg="AutoEvent - Sent new Event/Reading for 'Bool' source with Correlation Id '006dcacf-ed95-468e-ae02-984e2c46952f'"
```
8. Stop Device Virtual
9. Verify App Rules Engine logs has similar to the following:
```
level=TRACE ts=2021-11-08T17:25:53.4203366Z app=app-rules-engine source=messaging.go:242 msg="MessageBus Trigger published message: X-Correlation-ID=006dcacf-ed95-468e-ae02-984e2c46952f"
```
10. Verify that the Correlation ID 's match for the last entries in each logs.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->