### PR TITLE
feat: Implement ReadingUnits configuration for device profile changes

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -8,6 +8,8 @@ LogLevel = "INFO"
       [Writable.InsecureSecrets.DB.Secrets]
       username = ""
       password = ""
+  [Writable.Reading]
+  ReadingUnits = true
 
 [Service]
 HealthCheckInterval = "10s"

--- a/example/cmd/device-simple/res/profiles/Simple-Driver.json.example
+++ b/example/cmd/device-simple/res/profiles/Simple-Driver.json.example
@@ -34,7 +34,8 @@
       "description": "X axis rotation rate",
       "properties": {
         "valueType": "Int32",
-        "readWrite": "RW"
+        "readWrite": "RW",
+        "units": "rpm"
       }
     },
     {
@@ -43,7 +44,8 @@
       "description": "Y axis rotation rate",
       "properties": {
         "valueType": "Int32",
-        "readWrite": "RW"
+        "readWrite": "RW",
+        "units": "rpm"
       }
     },
     {
@@ -52,7 +54,8 @@
       "description": "Z axis rotation rate",
       "properties": {
         "valueType": "Int32",
-        "readWrite": "RW"
+        "readWrite": "RW",
+        "units": "rpm"
       }
     },
     {

--- a/example/cmd/device-simple/res/profiles/Simple-Driver.yaml
+++ b/example/cmd/device-simple/res/profiles/Simple-Driver.yaml
@@ -30,6 +30,7 @@ deviceResources:
     properties:
         valueType: "Int32"
         readWrite: "RW"
+        units: "rpm"
   -
     name: "Yrotation"
     isHidden: true
@@ -37,6 +38,7 @@ deviceResources:
     properties:
         valueType: "Int32"
         readWrite: "RW"
+        "units": "rpm"
   -
     name: "Zrotation"
     isHidden: true
@@ -44,6 +46,7 @@ deviceResources:
     properties:
         valueType: "Int32"
         readWrite: "RW"
+        "units": "rpm"
   -
     name: "StringArray"
     isHidden: false

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	bitbucket.org/bertimus9/systemstat v0.5.0
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.23
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9
 	github.com/edgexfoundry/go-mod-registry/v2 v2.1.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9 h1:q3IbjfovzgBvnPF3Ma9y
 github.com/edgexfoundry/go-mod-bootstrap/v2 v2.2.0-dev.9/go.mod h1:arWuBlvgtE3nCZ0BKHG3zxEXRVVt/Gpcr20m8ely7hc=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0 h1:wiLtHYo1QxImARJZt7TYj88cUhq1ANh8se4TBvFsYvw=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.1.0/go.mod h1:MvHit0MxBXN4bC8LL0NZRsw72ByRE1XwtVLQP9C+2vg=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20 h1:qsKWnEun+xHhN3FpaXHz6CUPFHca3KQmHLyTvRSzMbg=
-github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.20/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.23 h1:GFmw8QTMPUWUvDqGvxyRqfuIne03Vw9SOJ6trliItxw=
+github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0-dev.23/go.mod h1:jyfVSx7mI3u/o/oo10COxBRBvJ8O/9I3z2xAwPmNt/Q=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9 h1:AESiDfBaY+8ch7fQU0xxOQfhEjfaPoOCT051SqKXzT4=
 github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0-dev.9/go.mod h1:+X6C0h8ZTJe+lLU2AGJfiAzCJK3zL+yM6cej9VC+79E=
 github.com/edgexfoundry/go-mod-registry/v2 v2.1.0 h1:ks0ejtLLUYKuoKrUBbWxygCU7q2mBFJlHE/+dEzV2Gw=

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -17,6 +17,13 @@ type WritableInfo struct {
 	// Level is the logging level of writing log message
 	LogLevel        string
 	InsecureSecrets config.InsecureSecrets
+	Reading         Reading
+}
+
+// Reading is a struct which contains reading configuration settings.
+type Reading struct {
+	// ReadingUnits specifies whether or not to indicate the units of measure for the value in the reading
+	ReadingUnits bool
 }
 
 // DeviceInfo is a struct which contains device specific configuration settings.

--- a/internal/transformer/transform.go
+++ b/internal/transformer/transform.go
@@ -109,6 +109,10 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 		if err != nil {
 			return nil, errors.NewCommonEdgeXWrapper(err)
 		}
+		// ReadingUnits=true to include units in the reading
+		if config.Writable.Reading.ReadingUnits {
+			reading.Units = dr.Properties.Units
+		}
 		readings = append(readings, reading)
 
 		if cv.Type == common.ValueTypeBinary {

--- a/internal/transformer/transform_test.go
+++ b/internal/transformer/transform_test.go
@@ -6,13 +6,130 @@
 package transformer
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
 
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/config"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
+	sdkModels "github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
+	"github.com/edgexfoundry/device-sdk-go/v2/pkg/models/mocks"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+const (
+	TestDevice         = "testDevice"
+	TestDeviceService  = "testDeviceService"
+	TestProfile        = "testProfile"
+	TestDeviceResource = "testResource"
+	TestDeviceCommand  = "testCommand"
+	TestValue          = "testValue"
+	TestUnits          = "testUnits"
+)
+
+var TestProtocols map[string]dtos.ProtocolProperties
+
+func NewMockDIC() *di.Container {
+	cr := sdkModels.CommandRequest{
+		DeviceResourceName: TestDeviceResource,
+		Attributes:         nil,
+		Type:               common.ValueTypeString,
+	}
+	cv := &sdkModels.CommandValue{
+		DeviceResourceName: TestDeviceResource,
+		Type:               common.ValueTypeString,
+		Value:              TestValue,
+		Tags:               make(map[string]string),
+	}
+	driverMock := &mocks.ProtocolDriver{}
+	driverMock.On("HandleReadCommands", TestDevice, TestProtocols, []sdkModels.CommandRequest{cr}).Return(nil, nil)
+	driverMock.On("HandleWriteCommands", TestDevice, TestProtocols, []sdkModels.CommandRequest{cr}, []*sdkModels.CommandValue{cv}).Return(nil)
+
+	devices := responses.MultiDevicesResponse{
+		BaseWithTotalCountResponse: dtoCommon.BaseWithTotalCountResponse{},
+		Devices: []dtos.Device{
+			{
+				Name:           TestDevice,
+				AdminState:     models.Unlocked,
+				OperatingState: models.Up,
+				Protocols:      TestProtocols,
+				ServiceName:    TestDeviceService,
+				ProfileName:    TestProfile,
+			},
+		},
+	}
+	dcMock := &clientMocks.DeviceClient{}
+	dcMock.On("DevicesByServiceName", context.Background(), TestDeviceService, 0, -1).Return(devices, nil)
+
+	profile := responses.DeviceProfileResponse{
+		BaseResponse: dtoCommon.BaseResponse{},
+		Profile: dtos.DeviceProfile{
+			DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{Name: TestProfile},
+			DeviceResources: []dtos.DeviceResource{
+				{
+					Name: TestDeviceResource,
+					Properties: dtos.ResourceProperties{
+						ValueType:    common.ValueTypeString,
+						ReadWrite:    common.ReadWrite_RW,
+						DefaultValue: TestValue,
+						Units:        TestUnits,
+					},
+				},
+			},
+			DeviceCommands: []dtos.DeviceCommand{
+				{
+					Name:               TestDeviceCommand,
+					IsHidden:           false,
+					ReadWrite:          common.ReadWrite_RW,
+					ResourceOperations: []dtos.ResourceOperation{{DeviceResource: TestDeviceResource}},
+				},
+			},
+		},
+	}
+	dpcMock := &clientMocks.DeviceProfileClient{}
+	dpcMock.On("DeviceProfileByName", context.Background(), TestProfile).Return(profile, nil)
+
+	pwcMock := &clientMocks.ProvisionWatcherClient{}
+	pwcMock.On("ProvisionWatchersByServiceName", context.Background(), TestDeviceService, 0, -1).Return(responses.MultiProvisionWatchersResponse{}, nil)
+
+	configuration := &config.ConfigurationStruct{
+		Device: config.DeviceInfo{MaxCmdOps: 1},
+	}
+
+	return di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		container.ProtocolDriverName: func(get di.Get) interface{} {
+			return driverMock
+		},
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
+			return dcMock
+		},
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
+			return dpcMock
+		},
+		bootstrapContainer.ProvisionWatcherClientName: func(get di.Get) interface{} {
+			return pwcMock
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+	})
+}
 func Test_getUniqueOrigin(t *testing.T) {
 	// nolint: gosec
 	for i := 0; i < rand.Intn(1000); i++ {
@@ -21,6 +138,49 @@ func Test_getUniqueOrigin(t *testing.T) {
 			o1 := getUniqueOrigin()
 			o2 := getUniqueOrigin()
 			assert.NotEqual(t, o1, o2)
+		})
+	}
+}
+
+func TestCommandValuesToEventDTO_ReadingUnits(t *testing.T) {
+	dic := NewMockDIC()
+	err := cache.InitCache(TestDeviceService, dic)
+	require.NoError(t, err)
+
+	stringCommandValue, e := sdkModels.NewCommandValue(TestDeviceResource, common.ValueTypeString, TestValue)
+	require.NoError(t, e)
+
+	tests := []struct {
+		Name          string
+		CommandValues []*sdkModels.CommandValue
+		ReadingUnits  bool
+	}{
+		{"ReadingUnits is true, indicate Units in the Reading", []*sdkModels.CommandValue{stringCommandValue}, true},
+		{"ReadingUnits is false, not to indicate Units in the Reading", []*sdkModels.CommandValue{stringCommandValue}, false},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			configuration := container.ConfigurationFrom(dic.Get)
+			configuration.Writable.Reading.ReadingUnits = testCase.ReadingUnits
+			dic.Update(di.ServiceConstructorMap{
+				container.ConfigurationName: func(get di.Get) interface{} {
+					return configuration
+				},
+			})
+			event, err := CommandValuesToEventDTO(testCase.CommandValues, TestDevice, TestDeviceCommand, dic)
+			require.NoError(t, err)
+
+			assert.Equal(t, TestDevice, event.DeviceName)
+			assert.Equal(t, TestProfile, event.ProfileName)
+			assert.Equal(t, TestDeviceCommand, event.SourceName)
+			assert.Equal(t, TestDeviceResource, event.Readings[0].ResourceName)
+			if testCase.ReadingUnits {
+				assert.NotEmpty(t, event.Readings[0].Units, "units is not presented")
+				assert.Equal(t, TestUnits, event.Readings[0].Units)
+			} else {
+				assert.Empty(t, event.Readings[0].Units, "units is presented")
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>
https://github.com/edgexfoundry/edgex-docs/pull/727
## Testing Instructions
<!-- How can the reviewers test your change? -->
1. build the example device-simple from this branch and run with core services
2. `curl -ki http://localhost:59999/api/v2/device/name/Simple-Device01/Rotation` and verify the `units` in the readings
3. set `ReadingUnits` to `false` in the configuration.toml, and send `curl -ki http://localhost:59999/api/v2/device/name/Simple-Device01/Rotation` to verify the `units` is not in the readings
## New Dependency Instructions (If applicable)
N/A

Close #1120