### PR TITLE
fix: update TestMetricsRequest to not fail when using -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DOCKER_TAG=$(VERSION)-dev
 
 GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-sdk-go/v2.Version=$(VERSION)" -trimpath -mod=readonly
 CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-sdk-go/v2.Version=$(VERSION)" -trimpath -mod=readonly -buildmode=pie
-#GOTESTFLAGS?=-race
+GOTESTFLAGS?=-race
 
 GIT_SHA=$(shell git rev-parse HEAD)
 

--- a/internal/controller/http/common_test.go
+++ b/internal/controller/http/common_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -117,13 +118,14 @@ func TestMetricsRequest(t *testing.T) {
 
 	assert.Equal(t, common.ApiVersion, actual.ApiVersion)
 	assert.Equal(t, serviceName, actual.ServiceName)
-	assert.NotZero(t, actual.Metrics.MemAlloc)
-	assert.NotZero(t, actual.Metrics.MemFrees)
-	assert.NotZero(t, actual.Metrics.MemLiveObjects)
-	assert.NotZero(t, actual.Metrics.MemMallocs)
-	assert.NotZero(t, actual.Metrics.MemSys)
-	assert.NotZero(t, actual.Metrics.MemTotalAlloc)
-	assert.NotNil(t, actual.Metrics.CpuBusyAvg)
+	// Since when -race flag is use some values may come back as 0 we need to use the max value to detect change
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemAlloc)
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemFrees)
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemLiveObjects)
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemMallocs)
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemSys)
+	assert.NotEqual(t, uint64(math.MaxUint64), actual.Metrics.MemTotalAlloc)
+	assert.NotEqual(t, 0, actual.Metrics.CpuBusyAvg)
 }
 
 func TestConfigRequest(t *testing.T) {


### PR DESCRIPTION
closes #1090

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) n/a
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) n/a
- [ ] I have opened a PR for the related docs change (if not, why?) n/a
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->