### PR TITLE
fix(configuration): add handling for custom config on /config endpoint

### DIFF
--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
@@ -32,6 +33,7 @@ type RestController struct {
 	reservedRoutes map[string]bool
 	dic            *di.Container
 	serviceName    string
+	customConfig   interfaces.UpdatableConfig
 }
 
 func NewRestController(r *mux.Router, dic *di.Container, serviceName string) *RestController {
@@ -43,6 +45,11 @@ func NewRestController(r *mux.Router, dic *di.Container, serviceName string) *Re
 		dic:            dic,
 		serviceName:    serviceName,
 	}
+}
+
+// SetCustomConfigInfo sets the custom configuration, which is used to include the service's custom config in the /config endpoint response.
+func (c *RestController) SetCustomConfigInfo(customConfig interfaces.UpdatableConfig) {
+	c.customConfig = customConfig
 }
 
 func (c *RestController) InitRestRoutes() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -171,7 +171,14 @@ func (s *DeviceService) LoadCustomConfig(customConfig UpdatableConfig, sectionNa
 	if s.configProcessor == nil {
 		s.configProcessor = bootstrapConfig.NewProcessorForCustomConfig(s.flags, s.ctx, s.wg, s.dic)
 	}
-	return s.configProcessor.LoadCustomConfigSection(customConfig, sectionName)
+
+	if err := s.configProcessor.LoadCustomConfigSection(customConfig, sectionName); err != nil {
+		return err
+	}
+
+	s.controller.SetCustomConfigInfo(customConfig)
+
+	return nil
 }
 
 // ListenForCustomConfigChanges uses the Config Processor from go-mod-bootstrap to attempt to listen for


### PR DESCRIPTION
Fixes #1136

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?) **Unit tested.** 
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Build example device service.
Run the example device service.
Send a request to the /config endpoint (Port: 59999).
Verify json response contains the following:
```
        "CustomConfiguration": {
            "SimpleCustom": {
                "OffImageLocation": "./res/off.jpg",
                "OnImageLocation": "./res/on.png",
                "Writable": {
                    "DiscoverSleepDurationSecs": 10
                }
            }
        }
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->