### PR TITLE
refactor: Update to use deepCopy of messageBusInfo to avoid external adds

### DIFF
--- a/internal/messaging/messaging.go
+++ b/internal/messaging/messaging.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +24,10 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
-
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	bootstrapMessaging "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
@@ -40,7 +41,8 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 		return true
 	}
 
-	messageBusInfo := config.MessageQueue
+	// Make sure the MessageBus password is not leaked into the Service Config that can be retrieved via the /config endpoint
+	messageBusInfo := deepCopy(config.MessageQueue)
 
 	messageBusInfo.AuthMode = strings.ToLower(strings.TrimSpace(messageBusInfo.AuthMode))
 	if len(messageBusInfo.AuthMode) > 0 && messageBusInfo.AuthMode != bootstrapMessaging.AuthModeNone {
@@ -103,13 +105,30 @@ func BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer star
 				messageBusInfo.PublishTopicPrefix,
 				messageBusInfo.AuthMode))
 
-			// Make sure the MessageBus password is not leaked into the Service Config that can be retrieved via the /config endpoint
-			delete(messageBusInfo.Optional, bootstrapMessaging.OptionsPasswordKey)
-
 			return true
 		}
 	}
 
 	lc.Error("Connecting to MessageBus time out")
 	return false
+}
+
+func deepCopy(target bootstrapConfig.MessageBusInfo) bootstrapConfig.MessageBusInfo {
+	result := bootstrapConfig.MessageBusInfo{
+		Type:               target.Type,
+		Protocol:           target.Protocol,
+		Host:               target.Host,
+		Port:               target.Port,
+		PublishTopicPrefix: target.PublishTopicPrefix,
+		SubscribeTopic:     target.SubscribeTopic,
+		AuthMode:           target.AuthMode,
+		SecretName:         target.SecretName,
+		SubscribeEnabled:   target.SubscribeEnabled,
+	}
+	result.Optional = make(map[string]string)
+	for key, value := range target.Optional {
+		result.Optional[key] = value
+	}
+
+	return result
 }

--- a/internal/messaging/messaging_test.go
+++ b/internal/messaging/messaging_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2022 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,10 +68,10 @@ func TestBootstrapHandler(t *testing.T) {
 			UseMessageBus: true,
 		},
 		MessageQueue: bootstrapConfig.MessageBusInfo{
-			Type:               messaging.ZeroMQ, // Use ZMQ so no issue connecting.
-			Protocol:           "http",
-			Host:               "*",
-			Port:               8765,
+			Type:               messaging.Redis,
+			Protocol:           "redis",
+			Host:               "localhost",
+			Port:               6379,
 			PublishTopicPrefix: "edgex/events/#",
 			AuthMode:           bootstrapMessaging.AuthModeUsernamePassword,
 			SecretName:         "redisdb",
@@ -131,6 +132,7 @@ func TestBootstrapHandler(t *testing.T) {
 
 			actual := BootstrapHandler(context.Background(), &sync.WaitGroup{}, startup.NewTimer(1, 1), dic)
 			assert.Equal(t, test.ExpectedResult, actual)
+			assert.Empty(t, test.Config.MessageQueue.Optional)
 			if test.ExpectClient {
 				assert.NotNil(t, container.MessagingClientFrom(dic.Get))
 			} else {


### PR DESCRIPTION

fix #1162

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) update the existing unit test
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build device-virtual docker image from this branch and run the security-enabled docker compose
2. GET `/api/v2/config` and verify the response
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->