### PR TITLE
fix: ProvisionWatcher callbacks return BaseResponse, not 204 No Content.

### DIFF
--- a/openapi/v2/device-sdk.yaml
+++ b/openapi/v2/device-sdk.yaml
@@ -903,11 +903,15 @@ paths:
     post:
       description: "This call is used by core-metadata to inform the device service of the creation of a new Provision Watcher"
       responses:
-        '204':
-          description: Indicating success of the operation and no content returned.
+        '200':
+          description: "Callback successful"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
         '400':
           description: Invalid callback request.
           headers:
@@ -935,11 +939,15 @@ paths:
     put:
       description: "This call is used by core-metadata to inform the device service that a Provision Watcher's characteristics have been updated"
       responses:
-        '204':
-          description: Indicating success of the operation and no content returned.
+        '200':
+          description: "Callback successful"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
         '400':
           description: Invalid callback request.
           headers:
@@ -1035,11 +1043,15 @@ paths:
     delete:
       description: "This call is used by core-metadata to inform the device service that a Provision Watcher has been deleted"
       responses:
-        '204':
-          description: Indicating success of the operation and no content returned.
+        '200':
+          description: "Callback successful"
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaseResponse'
         '404':
           description: No provision watcher exists for the ID provided.
           headers:


### PR DESCRIPTION
Signed-off-by: Corey Mutter <CoreyMutter@eaton.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

Noticed this working on issues 419 and 420 in C SDK. Assuming the Go SDK code is the correct behavior (core-metadata thinks so), updating this doc to match.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
This IS that docs PR, companion to device-sdk-c PR 421.

## Testing Instructions
<!-- How can the reviewers test your change? -->
VS Code's OpenAPI extensions and viewer didn't flag any problems.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->