### PR TITLE
fix: Put cmd return 400 when updating empty string to NonString type

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -247,7 +247,7 @@ func (c *CommandProcessor) WriteDeviceResource() (e errors.EdgeX) {
 	// create CommandValue
 	cv, e := createCommandValueFromDeviceResource(dr, v)
 	if e != nil {
-		return errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", e)
+		return errors.NewCommonEdgeX(errors.Kind(e), "failed to create CommandValue", e)
 	}
 
 	// prepare CommandRequest
@@ -343,7 +343,7 @@ func (c *CommandProcessor) WriteDeviceCommand() errors.EdgeX {
 		if err == nil {
 			cvs = append(cvs, cv)
 		} else {
-			return errors.NewCommonEdgeX(errors.KindServerError, "failed to create CommandValue", err)
+			return errors.NewCommonEdgeX(errors.Kind(err), "failed to create CommandValue", err)
 		}
 	}
 
@@ -387,6 +387,10 @@ func createCommandValueFromDeviceResource(dr models.DeviceResource, value interf
 	var result *sdkModels.CommandValue
 
 	v := fmt.Sprint(value)
+
+	if dr.Properties.ValueType != common.ValueTypeString && strings.TrimSpace(v) == "" {
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("empty string is invalid for %v value type", dr.Properties.ValueType), nil)
+	}
 
 	switch dr.Properties.ValueType {
 	case common.ValueTypeString:

--- a/internal/application/command_test.go
+++ b/internal/application/command_test.go
@@ -248,6 +248,7 @@ func TestCommandProcessor_WriteDeviceResource(t *testing.T) {
 	readOnlyDeviceResource := NewCommandProcessor(testDevice, "ro-resource", uuid.NewString(), nil, "", dic)
 	noRequestBody := NewCommandProcessor(testDevice, "test-resource", uuid.NewString(), nil, "", dic)
 	invalidRequestBody := NewCommandProcessor(testDevice, "test-resource", uuid.NewString(), map[string]interface{}{"wrong-resource": "wrong-value"}, "", dic)
+	invalidEmpty := NewCommandProcessor(testDevice, "rw-object", uuid.NewString(), map[string]interface{}{"rw-object": ""}, "", dic)
 
 	tests := []struct {
 		name             string
@@ -260,6 +261,7 @@ func TestCommandProcessor_WriteDeviceResource(t *testing.T) {
 		{"invalid - writing read-only DeviceResource", readOnlyDeviceResource, true},
 		{"valid - no set parameter specified but default value exists", noRequestBody, false},
 		{"valid - set parameter doesn't match requested command, using DefaultValue in DeviceResource.Properties", invalidRequestBody, false},
+		{"invalid - writing empty string to non string deviceResource", invalidEmpty, true},
 	}
 
 	for _, tt := range tests {
@@ -285,6 +287,7 @@ func TestCommandProcessor_WriteDeviceCommand(t *testing.T) {
 	outOfRangeResourceOperation := NewCommandProcessor(testDevice, "exceed-command", uuid.NewString(), nil, "", dic)
 	noRequestBody := NewCommandProcessor(testDevice, "test-command", uuid.NewString(), nil, "", dic)
 	invalidRequestBody := NewCommandProcessor(testDevice, "test-command", uuid.NewString(), map[string]interface{}{"wrong-resource": "wrong-value"}, "", dic)
+	invalidEmpty := NewCommandProcessor(testDevice, "rw-object", uuid.NewString(), map[string]interface{}{"rw-object": ""}, "", dic)
 
 	tests := []struct {
 		name             string
@@ -297,6 +300,7 @@ func TestCommandProcessor_WriteDeviceCommand(t *testing.T) {
 		{"invalid - RO exceed MaxCmdOps count", outOfRangeResourceOperation, true},
 		{"valid - no set parameter specified but default value exist", noRequestBody, false},
 		{"valid - parameter doesn't match requested command, using DefaultValue in DeviceResource.Properties", invalidRequestBody, false},
+		{"invalid - writing empty string to non string deviceResource", invalidEmpty, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add checking if the value is an empty string and the valueType is not String, the proper error should be returned

Close #1179

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact the doc**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Deploy device-virtual
2. Inspect the result should look like below:
```
curl curl --location --request PUT 'http://localhost:59882/api/v2/device/name/Random-Float-Device/WriteFloat64Value' \
> --header 'Content-Type: application/json' \
> --data-raw '{"Float64":""}' | json_pp
...
{
   "apiVersion" : "v2",
   "message" : "request failed, status code: 400, err: {\"apiVersion\":\"v2\",\"message\":\"failed to create CommandValue -\\u003e empty string is invalid for Float64 value type\",\"statusCode\":400}",
   "statusCode" : 400
}
```

```
curl curl --location --request PUT 'http://localhost:59882/api/v2/device/name/Random-UnsignedInteger-Device/Uint64' \
> --header 'Content-Type: application/json' \
> --data-raw '{"Uint64":""}' | json_pp
...
{
   "apiVersion" : "v2",
   "message" : "request failed, status code: 400, err: {\"apiVersion\":\"v2\",\"message\":\"failed to create CommandValue -\\u003e empty string is invalid for Uint64 value type\",\"statusCode\":400}",
   "statusCode" : 400
}
```


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->