### PR TITLE
fix: Remove redundant logic of chaching profile

### DIFF
--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -29,19 +29,6 @@ func (s *DeviceService) AddDevice(device models.Device) (string, error) {
 		return d.Id, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, Device %s exists", device.Name), nil)
 	}
 
-	_, cacheExist := cache.Profiles().ForName(device.ProfileName)
-	if !cacheExist {
-		res, err := s.edgexClients.DeviceProfileClient.DeviceProfileByName(context.Background(), device.ProfileName)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to find Profile %s for Device %s", device.ProfileName, device.Name)
-			s.LoggingClient.Error(errMsg)
-			return "", err
-		}
-		err = cache.Profiles().Add(dtos.ToDeviceProfileModel(res.Profile))
-		if err != nil {
-			return "", errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
-		}
-	}
 	device.ServiceName = s.ServiceName
 
 	s.LoggingClient.Debugf("Adding managed Device %s", device.Name)

--- a/pkg/service/managedwatchers.go
+++ b/pkg/service/managedwatchers.go
@@ -28,19 +28,6 @@ func (s *DeviceService) AddProvisionWatcher(watcher models.ProvisionWatcher) (st
 			errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, ProvisionWatcher %s exists", watcher.Name), nil)
 	}
 
-	_, ok := cache.Profiles().ForName(watcher.ProfileName)
-	if !ok {
-		res, err := s.edgexClients.DeviceProfileClient.DeviceProfileByName(context.Background(), watcher.ProfileName)
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to find Profile %s for provision watcher %s", watcher.ProfileName, watcher.Name)
-			s.LoggingClient.Error(errMsg)
-			return "", err
-		}
-		err = cache.Profiles().Add(dtos.ToDeviceProfileModel(res.Profile))
-		if err != nil {
-			return "", errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
-		}
-	}
 	watcher.ServiceName = s.ServiceName
 
 	s.LoggingClient.Debugf("Adding managed ProvisionWatcher %s", watcher.Name)


### PR DESCRIPTION
Remove the duplicated logic of caching profile in the managed device and
provision watcher API, because this is handled by the callback

Fix https://github.com/edgexfoundry/device-sdk-go/issues/1195

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A, this is just removing redundant code
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) N/A, this is just removing redundant code


## Testing Instructions
<!-- How can the reviewers test your change? -->

1. Write a new Device Service and invoke the AddProvisionWatcher and AddDevice API from the Device Service SDK
2. Invoke PorfileForName API to make sure the profile is in the cache
