### PR TITLE
fix: fix empty device name when updating device's serviceName

### DIFF
--- a/internal/application/callback.go
+++ b/internal/application/callback.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -75,10 +75,12 @@ func UpdateDevice(updateDeviceRequest requests.UpdateDeviceRequest, dic *di.Cont
 
 	device, exist := cache.Devices().ForName(*updateDeviceRequest.Device.Name)
 	if !exist {
-		// scenario that device migrate from another device service to here
+		// scenario that device migrates from another device service to here
 		if ds.Name == *updateDeviceRequest.Device.ServiceName {
 			var newDevice models.Device
 			requests.ReplaceDeviceModelFieldsWithDTO(&newDevice, updateDeviceRequest.Device)
+			newDevice.Name = *updateDeviceRequest.Device.Name
+			newDevice.Id = *updateDeviceRequest.Device.Id
 			req := requests.NewAddDeviceRequest(dtos.FromDeviceModelToDTO(newDevice))
 			return AddDevice(req, dic)
 		} else {


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run two device services from this branch with `WRITABLE_LOGLEVEL: DEBUG`
2. migrate a device from one to another by updating device's serviceName
3. Verified the device name is correctly received by device-service :
```
level=DEBUG ts=2022-07-28T07:27:46.780732Z app=device-virtual source=callback.go:56 msg="device sample-numeric added"
level=DEBUG ts=2022-07-28T07:27:46.780758Z app=device-virtual source=virtualdriver.go:127 msg="a new Device is added: sample-numeric"
level=DEBUG ts=2022-07-28T07:27:46.780772Z app=device-virtual source=callback.go:61 msg="Invoked driver.AddDevice callback for sample-numeric"
level=DEBUG ts=2022-07-28T07:27:46.78078Z app=device-virtual source=callback.go:67 msg="starting AutoEvents for device sample-numeric"
level=DEBUG ts=2022-07-28T07:28:46.787656Z app=device-virtual source=utils.go:80 msg="Event(profileName: Random-Integer-Device, deviceName: sample-numeric, sourceName: Int8, id: 00dded28-0ef5-4a4f-b9d0-8a57ec847681) published to MessageBus"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->