### PR TITLE
feat: subscribe command request via internal messaging

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -66,6 +66,9 @@ PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name
   AutoReconnect = "true"
   ConnectTimeout = "5" # Seconds
   SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified
+  [MessageQueue.Topics]
+  CommandRequestTopic = "edgex/command/request/#"         # subscribing for inbound command requests
+  CommandResponseTopicPrefix = "edgex/command/response"   # publishing outbound command responses; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
 
 # Example SecretStore configuration.
 # Only used when EDGEX_SECURITY_SECRET_STORE=true

--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -1,0 +1,223 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/errors"
+	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
+
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/application"
+	sdkCommon "github.com/edgexfoundry/device-sdk-go/v2/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
+)
+
+type key string
+
+const (
+	correlationHeaderKey       key = common.CorrelationHeader
+	CommandRequestTopic            = "CommandRequestTopic"
+	CommandResponseTopicPrefix     = "CommandResponseTopicPrefix"
+)
+
+func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageQueue
+	requestTopic := messageBusInfo.Topics[CommandRequestTopic]
+	responseTopicPrefix := messageBusInfo.Topics[CommandResponseTopicPrefix]
+
+	messages := make(chan types.MessageEnvelope)
+	messageErrors := make(chan error)
+	topics := []types.TopicChannel{
+		{
+			Topic:    requestTopic,
+			Messages: messages,
+		},
+	}
+
+	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
+	err := messageBus.Subscribe(topics, messageErrors)
+	if err != nil {
+		return errors.NewCommonEdgeXWrapper(err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				lc.Infof("Exiting waiting for MessageBus '%s' topic messages", requestTopic)
+				return
+			case err = <-messageErrors:
+				lc.Error(err.Error())
+			case msgEnvelope := <-messages:
+				lc.Debugf("Command request received on message queue. Topic: %s, Correlation-id: %s ", requestTopic, msgEnvelope.CorrelationID)
+
+				// expected command request topic scheme: #/<service-name>/<device-name>/<command-name>/<method>
+				topicLevels := strings.Split(msgEnvelope.ReceivedTopic, "/")
+				length := len(topicLevels)
+				if length < 4 {
+					lc.Error("Failed to parse and construct command response topic scheme, expected request topic scheme: '#/<service-name>/<device-name>/<command-name>/<method>'")
+					continue
+				}
+
+				// expected command response topic scheme: #/<service-name>/<device-name>/<command-name>/<method>
+				serviceName := topicLevels[length-4]
+				deviceName := topicLevels[length-3]
+				commandName := topicLevels[length-2]
+				method := topicLevels[length-1]
+				responseTopic := strings.Join([]string{responseTopicPrefix, serviceName, deviceName, commandName, method}, "/")
+
+				switch strings.ToUpper(method) {
+				case "GET":
+					getCommand(ctx, msgEnvelope, responseTopic, deviceName, commandName, dic)
+				case "SET":
+					setCommand(ctx, msgEnvelope, responseTopic, deviceName, commandName, dic)
+				default:
+					lc.Errorf("unknown command method '%s', only 'get' or 'set' is allowed", method)
+					continue
+				}
+
+				lc.Debugf("Command response published on message queue. Topic: %s, Correlation-id: %s ", responseTopic, msgEnvelope.CorrelationID)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func getCommand(ctx context.Context, msgEnvelope types.MessageEnvelope, responseTopic string, deviceName string, commandName string, dic *di.Container) {
+	var responseEnvelope types.MessageEnvelope
+
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
+	rawQuery, pushEvent, returnEvent := filterQueryParams(msgEnvelope.QueryParams)
+
+	ctx = context.WithValue(ctx, correlationHeaderKey, msgEnvelope.CorrelationID)
+	event, edgexErr := application.GetCommand(ctx, deviceName, commandName, rawQuery, dic)
+	if edgexErr != nil {
+		lc.Errorf("Failed to process get device command %s for device %s: %s", commandName, deviceName, edgexErr.Error())
+		responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, edgexErr.Error())
+		err := messageBus.Publish(responseEnvelope, responseTopic)
+		if err != nil {
+			lc.Errorf("Failed to publish command response: %s", err.Error())
+		}
+		return
+	}
+
+	if returnEvent {
+		eventResponse := responses.NewEventResponse("", "", http.StatusOK, *event)
+		eventResponseBytes, encoding, err := eventResponse.Encode()
+		if err != nil {
+			lc.Errorf("Failed to encode event response: %s", err.Error())
+			responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, err.Error())
+			err = messageBus.Publish(responseEnvelope, responseTopic)
+			if err != nil {
+				lc.Errorf("Failed to publish command response: %s", err.Error())
+			}
+			return
+		}
+
+		responseEnvelope, err = types.NewMessageEnvelopeForResponse(eventResponseBytes, msgEnvelope.RequestID, msgEnvelope.CorrelationID, encoding)
+		if err != nil {
+			lc.Errorf("Failed to create response message envelope: %s", err.Error())
+			responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, err.Error())
+			err = messageBus.Publish(responseEnvelope, responseTopic)
+			if err != nil {
+				lc.Errorf("Failed to publish command response: %s", err.Error())
+			}
+			return
+		}
+
+		err = messageBus.Publish(responseEnvelope, responseTopic)
+		if err != nil {
+			lc.Errorf("Failed to publish command response: %s", err.Error())
+			return
+		}
+	}
+	if pushEvent {
+		go sdkCommon.SendEvent(event, msgEnvelope.CorrelationID, dic)
+	}
+
+}
+
+func setCommand(ctx context.Context, msgEnvelope types.MessageEnvelope, responseTopic string, deviceName string, commandName string, dic *di.Container) {
+	var responseEnvelope types.MessageEnvelope
+
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
+	rawQuery, _, _ := filterQueryParams(msgEnvelope.QueryParams)
+
+	requestPayload := make(map[string]any)
+	err := json.Unmarshal(msgEnvelope.Payload, &requestPayload)
+	if err != nil {
+		lc.Errorf("Failed to decode set command request payload: %s", err.Error())
+		responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, err.Error())
+		err = messageBus.Publish(responseEnvelope, responseTopic)
+		if err != nil {
+			lc.Errorf("Failed to publish command response: %s", err.Error())
+		}
+		return
+	}
+
+	ctx = context.WithValue(ctx, correlationHeaderKey, msgEnvelope.CorrelationID)
+	edgexErr := application.SetCommand(ctx, deviceName, commandName, rawQuery, requestPayload, dic)
+	if edgexErr != nil {
+		lc.Errorf("Failed to process set device command %s for device %s: %s", commandName, deviceName, edgexErr.Error())
+		responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, edgexErr.Error())
+		err = messageBus.Publish(responseEnvelope, responseTopic)
+		if err != nil {
+			lc.Errorf("Failed to publish command response: %s", err.Error())
+		}
+		return
+	}
+
+	responseEnvelope, err = types.NewMessageEnvelopeForResponse(nil, msgEnvelope.RequestID, msgEnvelope.CorrelationID, common.ContentTypeJSON)
+	if err != nil {
+		lc.Errorf("Failed to create response message envelope: %s", err.Error())
+		responseEnvelope = types.NewMessageEnvelopeWithError(msgEnvelope.RequestID, err.Error())
+		err = messageBus.Publish(responseEnvelope, responseTopic)
+		if err != nil {
+			lc.Errorf("Failed to publish command response: %s", err.Error())
+		}
+		return
+	}
+
+	err = messageBus.Publish(responseEnvelope, responseTopic)
+	if err != nil {
+		lc.Errorf("Failed to publish command response: %s", err.Error())
+		return
+	}
+}
+
+func filterQueryParams(queries map[string]string) (string, bool, bool) {
+	var rawQuery []string
+	pushEvent, returnEvent := false, true
+	for k, v := range queries {
+		if k == common.PushEvent && v == common.ValueYes {
+			pushEvent = true
+			continue
+		}
+		if k == common.ReturnEvent && v == common.ValueNo {
+			returnEvent = false
+			continue
+		}
+		if strings.HasPrefix(k, sdkCommon.SDKReservedPrefix) {
+			continue
+		}
+		rawQuery = append(rawQuery, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(rawQuery, "&"), pushEvent, returnEvent
+}

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2022 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/controller/messaging"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/provision"
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 )
@@ -78,6 +79,12 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	}
 
 	ds.manager.StartAutoEvents()
+
+	err = messaging.SubscribeCommands(ctx, dic)
+	if err != nil {
+		ds.LoggingClient.Errorf("Failed to subscribe internal command request: %v", err)
+		return false
+	}
 
 	return true
 }


### PR DESCRIPTION
fix #1189 

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) most of the application call is tested in http controller
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run core services from edgex-compose with external MQTT broker and `MESSAGEQUEUE_REQUIRED=true` environment variable
2. Run device-simple from this branch
3. Run `PSUBSCRIBE edgex.command.response.*` in redis container to subscribe to the device command response
4. Send command request to` edgex/command/request/<device>/<command>/<method>` topic. For example send following message to `edgex/command/request/Simple-Device-1/Xrotation/get`:
```json
{
  "CorrelationID": "14a42ea6-c394-41c3-8bcd-a29b9f5e6835",
  "ApiVersion": "v2",
  "RequestId": "e6e8a2f4-eb14-4649-9e2b-175247911369",
  "ContentType": "application/json",
  "QueryParams": {
    "foo": "bar",
    "key": "value"
  }  
}
```
5. check the device command response is received by `redis` container:
```shell
/data # redis-cli
127.0.0.1:6379> PSUBSCRIBE edgex.command.response.*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) "edgex.command.response.*"
3) (integer) 1
1) "pmessage"
2) "edgex.command.response.*"
3) "edgex.command.response.device-simple.Simple-Device01.Xrotation.GeT"
4) "{\"ReceivedTopic\":\"\",\"CorrelationID\":\"14a42ea6-c394-41c3-8bcd-a29b9f5e6835\",\"ApiVersion\":\"v2\",\"RequestID\":\"e6e8a2f4-eb14-4649-9e2b-175247911369\",\"ErrorCode\":0,\"Payload\":\"eyJhcGlWZXJzaW9uIjoidjIiLCJzdGF0dXNDb2RlIjoyMDAsImV2ZW50Ijp7ImFwaVZlcnNpb24iOiJ2MiIsImlkIjoiYjE0N2NiMzgtMTFhMS00ZmRmLThhYjUtNzU2YzYxNThmOTQ2IiwiZGV2aWNlTmFtZSI6IlNpbXBsZS1EZXZpY2UwMSIsInByb2ZpbGVOYW1lIjoiU2ltcGxlLURldmljZSIsInNvdXJjZU5hbWUiOiJYcm90YXRpb24iLCJvcmlnaW4iOjE2NjM3NDYzMzYwNDI1NDUwMDAsInJlYWRpbmdzIjpbeyJpZCI6IjBkNDVhY2Y4LTdiN2ItNDZmYi1hZGI1LTM4M2NhM2QyMzEzOCIsIm9yaWdpbiI6MTY2Mzc0NjMzNjA0MjU0NTAwMCwiZGV2aWNlTmFtZSI6IlNpbXBsZS1EZXZpY2UwMSIsInJlc291cmNlTmFtZSI6Ilhyb3RhdGlvbiIsInByb2ZpbGVOYW1lIjoiU2ltcGxlLURldmljZSIsInZhbHVlVHlwZSI6IkludDMyIiwidW5pdHMiOiJycG0iLCJ2YWx1ZSI6IjAifV19fQ==\",\"ContentType\":\"application/json\",\"QueryParams\":{}}"
```

or check the device service log:
```
level=DEBUG ts=2022-09-21T07:46:27.654824Z app=device-simple source=subscriber.go:61 msg="Command request received on message queue. Topic: edgex/command/request/#, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-09-21T07:46:27.65487Z app=device-simple source=simpledriver.go:147 msg="SimpleDriver.HandleReadCommands: protocols: map[other:map[Address:simple01 Port:300]] resource: Xrotation attributes: map[urlRawQuery:key=value&foo=bar]"
level=DEBUG ts=2022-09-21T07:46:27.654921Z app=device-simple source=transform.go:121 msg="device: Simple-Device01 DeviceResource: Xrotation reading: {Id:aad66248-237a-4e0d-8444-186676c9ead4 Origin:1663746387654883000 DeviceName:Simple-Device01 ResourceName:Xrotation ProfileName:Simple-Device ValueType:Int32 Units:rpm BinaryReading:{BinaryValue:[] MediaType:} SimpleReading:{Value:0} ObjectReading:{ObjectValue:<nil>}}"
level=DEBUG ts=2022-09-21T07:46:27.654941Z app=device-simple source=command.go:69 msg="GET Device Command successfully. Device: Simple-Device01, Source: Xrotation, X-Correlation-ID: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->