### PR TITLE
fix: Skip Subscription to Empty Command Request Topic

### DIFF
--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -38,6 +38,11 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 	requestTopic := messageBusInfo.Topics[CommandRequestTopic]
 	responseTopicPrefix := messageBusInfo.Topics[CommandResponseTopicPrefix]
 
+	if strings.TrimSpace(requestTopic) == "" {
+		lc.Info("skipping subscription to empty command request topic")
+		return nil
+	}
+
 	messages := make(chan types.MessageEnvelope)
 	messageErrors := make(chan error)
 	topics := []types.TopicChannel{


### PR DESCRIPTION
Log informational message and return nil error if empty topic found in MessageQueue topics.  Fixes #1215

Signed-off-by: Alex Ullrich <alex.ullrich@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Start a device service with no CommandRequestTopic configured.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->