### PR TITLE
fix: subscribe to internal message bus if UseMessageBus = true

### DIFF
--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/cache"
-	"github.com/edgexfoundry/device-sdk-go/v2/internal/controller/messaging"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/provision"
 	"github.com/edgexfoundry/device-sdk-go/v2/pkg/models"
 )
@@ -79,12 +78,6 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	}
 
 	ds.manager.StartAutoEvents()
-
-	err = messaging.SubscribeCommands(ctx, dic)
-	if err != nil {
-		ds.LoggingClient.Errorf("Failed to subscribe internal command request: %v", err)
-		return false
-	}
 
 	return true
 }

--- a/pkg/service/main.go
+++ b/pkg/service/main.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/handlers"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
@@ -24,6 +25,7 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/autodiscovery"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/autoevent"
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/controller/messaging"
 )
 
 const EnvInstanceName = "EDGEX_INSTANCE_NAME"
@@ -107,6 +109,12 @@ func messageBusBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startup
 	configuration := container.ConfigurationFrom(dic.Get)
 	if configuration.Device.UseMessageBus {
 		if !handlers.MessagingBootstrapHandler(ctx, wg, startupTimer, dic) {
+			return false
+		}
+		err := messaging.SubscribeCommands(ctx, dic)
+		if err != nil {
+			lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+			lc.Errorf("Failed to subscribe internal command request: %v", err)
 			return false
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `device-simple` from this branch with `DEVICE_USEMESSAGEBUS=false` environment variable
2. verify device-simple is running correctly, instead of getting error described in https://github.com/edgexfoundry/device-virtual-go/issues/307#issuecomment-1259120080

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->