### PR TITLE
fix: revert using custom-typed key for Context value

### DIFF
--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -24,12 +24,9 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
 )
 
-type key string
-
 const (
-	correlationHeaderKey       key = common.CorrelationHeader
-	CommandRequestTopic            = "CommandRequestTopic"
-	CommandResponseTopicPrefix     = "CommandResponseTopicPrefix"
+	CommandRequestTopic        = "CommandRequestTopic"
+	CommandResponseTopicPrefix = "CommandResponseTopicPrefix"
 )
 
 func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
@@ -109,7 +106,8 @@ func getCommand(ctx context.Context, msgEnvelope types.MessageEnvelope, response
 	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
 	rawQuery, pushEvent, returnEvent := filterQueryParams(msgEnvelope.QueryParams)
 
-	ctx = context.WithValue(ctx, correlationHeaderKey, msgEnvelope.CorrelationID)
+	// TODO: fix properly in EdgeX 3.0
+	ctx = context.WithValue(ctx, common.CorrelationHeader, msgEnvelope.CorrelationID) // nolint: staticcheck
 	event, edgexErr := application.GetCommand(ctx, deviceName, commandName, rawQuery, dic)
 	if edgexErr != nil {
 		lc.Errorf("Failed to process get device command %s for device %s: %s", commandName, deviceName, edgexErr.Error())
@@ -176,7 +174,8 @@ func setCommand(ctx context.Context, msgEnvelope types.MessageEnvelope, response
 		return
 	}
 
-	ctx = context.WithValue(ctx, correlationHeaderKey, msgEnvelope.CorrelationID)
+	// TODO: fix properly in EdgeX 3.0
+	ctx = context.WithValue(ctx, common.CorrelationHeader, msgEnvelope.CorrelationID) // nolint: staticcheck
 	edgexErr := application.SetCommand(ctx, deviceName, commandName, rawQuery, requestPayload, dic)
 	if edgexErr != nil {
 		lc.Errorf("Failed to process set device command %s for device %s: %s", commandName, deviceName, edgexErr.Error())


### PR DESCRIPTION
fix #1221 

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run device-simple from this branch with `WRITABLE_LOGLEVEL=DEBUG` environment variable
2. Send command request to command service via external MQTT
3. Verify the X-Correlation-ID is retrieved correctly:
```
level=DEBUG ts=2022-09-30T02:27:21.546901Z app=device-simple source=command.go:67 msg="Command request received on message queue. Topic: edgex/command/request/device-simple/#, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
level=DEBUG ts=2022-09-30T02:27:21.546998Z app=device-simple source=simpledriver.go:147 msg="SimpleDriver.HandleReadCommands: protocols: map[other:map[Address:simple01 Port:300]] resource: Xrotation attributes: map[]"
level=DEBUG ts=2022-09-30T02:27:21.547055Z app=device-simple source=transform.go:121 msg="device: Simple-Device01 DeviceResource: Xrotation reading: {Id:252633a9-d31f-41a5-8bac-35e8b29a4b9c Origin:1664504841547013000 DeviceName:Simple-Device01 ResourceName:Xrotation ProfileName:Simple-Device ValueType:Int32 Units:rpm BinaryReading:{BinaryValue:[] MediaType:} SimpleReading:{Value:0} ObjectReading:{ObjectValue:<nil>}}"
level=DEBUG ts=2022-09-30T02:27:21.547081Z app=device-simple source=command.go:69 msg="GET Device Command successfully. Device: Simple-Device01, Source: Xrotation, X-Correlation-ID: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835"
level=DEBUG ts=2022-09-30T02:27:21.549897Z app=device-simple source=command.go:94 msg="Command response published on message queue. Topic: edgex/command/response/device-simple/Simple-Device01/Xrotation/get, Correlation-id: 14a42ea6-c394-41c3-8bcd-a29b9f5e6835 "
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->