### PR TITLE
feat: Add metrics for count of Events and Readings sent

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -16,7 +16,11 @@ LogLevel = "INFO"
   Interval = "30s"
   PublishTopicPrefix  = "edgex/telemetry" # /<service-name>/<metric-name> will be added to this Publish Topic prefix
     [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
+    EventsSent = true
+    ReadingsSent = true
     ReadCommandsExecuted = true
+    SecuritySecretsRequested = true
+    SecuritySecretsStored = true
     [Writable.Telemetry.Tags] # Contains the service level tags to be attached to all the service's metrics
 #    Gateway="my-iot-gateway" # Tag must be added here or via Consul Env Override can only chnage existing value, not added new ones.
 

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/v2/internal/container"
+	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
+	gometrics "github.com/rcrowley/go-metrics"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -23,6 +25,15 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 )
+
+const (
+	eventsSentName   = "EventsSent"
+	readingsSentName = "ReadingsSent"
+)
+
+// TODO: Refactor code in 3.0 to encapsulate this in a struct, factory func and
+var eventsSent gometrics.Counter
+var readingsSent gometrics.Counter
 
 func UpdateLastConnected(name string, lc logger.LoggingClient, dc interfaces.DeviceClient) {
 	t := time.Now().UnixNano() / int64(time.Millisecond)
@@ -68,6 +79,8 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 		return
 	}
 
+	sent := false
+
 	if configuration.Device.UseMessageBus {
 		mc := bootstrapContainer.MessagingClientFrom(dic.Get)
 		ctx = context.WithValue(ctx, common.ContentType, encoding) // nolint: staticcheck
@@ -78,6 +91,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 			lc.Errorf("Failed to publish event to MessageBus: %s", err)
 		}
 		lc.Debugf("Event(profileName: %s, deviceName: %s, sourceName: %s, id: %s) published to MessageBus", event.ProfileName, event.DeviceName, event.SourceName, event.Id)
+		sent = true
 	} else {
 		ec := bootstrapContainer.EventClientFrom(dic.Get)
 		_, err := ec.Add(ctx, req)
@@ -86,5 +100,38 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 		} else {
 			lc.Debugf("Event(profileName: %s, deviceName: %s, sourceName: %s, id: %s) pushed to Coredata", event.ProfileName, event.DeviceName, event.SourceName, event.Id)
 		}
+		sent = true
+	}
+
+	if sent {
+		handleEventReadingMetrics(event, lc, dic)
+	}
+}
+
+func handleEventReadingMetrics(event *dtos.Event, lc logger.LoggingClient, dic *di.Container) {
+	// Just need to check one of the metrics
+	if eventsSent == nil {
+		eventsSent = gometrics.NewCounter()
+		readingsSent = gometrics.NewCounter()
+
+		metricsManager := bootstrapContainer.MetricsManagerFrom(dic.Get)
+		if metricsManager != nil {
+			registerMetric(metricsManager, lc, eventsSentName, eventsSent)
+			registerMetric(metricsManager, lc, readingsSentName, readingsSent)
+		} else {
+			lc.Warn("MetricsManager not available to register Event/Reading metrics")
+		}
+	}
+
+	eventsSent.Inc(1)
+	readingsSent.Inc(int64(len(event.Readings)))
+}
+
+func registerMetric(metricsManager bootstrapInterfaces.MetricsManager, lc logger.LoggingClient, name string, metric interface{}) {
+	err := metricsManager.Register(name, metric, nil)
+	if err != nil {
+		lc.Errorf("unable to register %s metric. Metric will not be reported: %v", name, err)
+	} else {
+		lc.Debugf("%s metric has been registered and will be reported (if enabled)", name)
 	}
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -104,27 +104,22 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	}
 
 	if sent {
-		handleEventReadingMetrics(event, lc, dic)
+		eventsSent.Inc(1)
+		readingsSent.Inc(int64(len(event.Readings)))
 	}
 }
 
-func handleEventReadingMetrics(event *dtos.Event, lc logger.LoggingClient, dic *di.Container) {
-	// Just need to check one of the metrics
-	if eventsSent == nil {
-		eventsSent = gometrics.NewCounter()
-		readingsSent = gometrics.NewCounter()
+func InitializeSentMetrics(lc logger.LoggingClient, dic *di.Container) {
+	eventsSent = gometrics.NewCounter()
+	readingsSent = gometrics.NewCounter()
 
-		metricsManager := bootstrapContainer.MetricsManagerFrom(dic.Get)
-		if metricsManager != nil {
-			registerMetric(metricsManager, lc, eventsSentName, eventsSent)
-			registerMetric(metricsManager, lc, readingsSentName, readingsSent)
-		} else {
-			lc.Warn("MetricsManager not available to register Event/Reading metrics")
-		}
+	metricsManager := bootstrapContainer.MetricsManagerFrom(dic.Get)
+	if metricsManager != nil {
+		registerMetric(metricsManager, lc, eventsSentName, eventsSent)
+		registerMetric(metricsManager, lc, readingsSentName, readingsSent)
+	} else {
+		lc.Warn("MetricsManager not available to register Event/Reading Sent metrics")
 	}
-
-	eventsSent.Inc(1)
-	readingsSent.Inc(int64(len(event.Readings)))
 }
 
 func registerMetric(metricsManager bootstrapInterfaces.MetricsManager, lc logger.LoggingClient, name string, metric interface{}) {

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -6,17 +6,21 @@
 package common
 
 import (
+	"errors"
 	"testing"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	mocks2 "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
 	msgMocks "github.com/edgexfoundry/go-mod-messaging/v2/messaging/mocks"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +119,100 @@ func TestSendEvent(t *testing.T) {
 				ecMock.AssertNumberOfCalls(t, "Add", 1)
 				mcMock.AssertNumberOfCalls(t, "Publish", 0)
 			}
+		})
+	}
+}
+
+func Test_HandleEventReadingMetrics(t *testing.T) {
+	event1Reading := dtos.NewEvent("Test", "Test", "Test")
+	err := event1Reading.AddSimpleReading("Test", common.ValueTypeInt32, int32(123))
+	require.NoError(t, err)
+	event3Readings := dtos.NewEvent("Test", "Test", "Test")
+	err = event3Readings.AddSimpleReading("Test1", common.ValueTypeInt32, int32(123))
+	require.NoError(t, err)
+	err = event3Readings.AddSimpleReading("Test2", common.ValueTypeInt32, int32(123))
+	require.NoError(t, err)
+	err = event3Readings.AddSimpleReading("Test3", common.ValueTypeInt32, int32(123))
+	require.NoError(t, err)
+
+	tests := []struct {
+		Name                    string
+		TimesToCall             int
+		Event                   dtos.Event
+		MetricsManagerAvailable bool
+		RegisterError           bool
+		ExpectedEventCount      int64
+		ExpectedReadingCount    int64
+	}{
+		{"First Pass", 1, event1Reading, true, false, 1, 1},
+		{"3 Passes with 1 reading", 3, event1Reading, true, false, 3, 3},
+		{"3 Passes with 3 readings", 3, event3Readings, true, false, 3, 9},
+		{"No MetricsManager", 1, event1Reading, false, false, 1, 1},
+		{"Error Registering", 1, event1Reading, true, true, 1, 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			eventsSent = nil
+			readingsSent = nil
+
+			mockManager := &mocks.MetricsManager{}
+			mockLogger := &mocks2.LoggingClient{}
+
+			if test.RegisterError {
+				mockManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("failed"))
+			} else {
+				mockManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			}
+
+			mockLogger.On("Warn", mock.Anything).Return()
+			mockLogger.On("Debugf", mock.Anything, mock.Anything).Return()
+			mockLogger.On("Errorf", mock.Anything, mock.Anything, mock.Anything).Return()
+
+			dic := di.NewContainer(di.ServiceConstructorMap{
+				bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+					return mockLogger
+				},
+				bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+					if test.MetricsManagerAvailable {
+						return mockManager
+					}
+
+					return nil
+				},
+			})
+
+			n := 0
+			for n < test.TimesToCall {
+				handleEventReadingMetrics(&test.Event, mockLogger, dic)
+				n++
+			}
+
+			if test.MetricsManagerAvailable {
+				mockManager.AssertNumberOfCalls(t, "Register", 2)
+				mockLogger.AssertNumberOfCalls(t, "Warn", 0)
+
+				if test.RegisterError {
+					mockLogger.AssertNumberOfCalls(t, "Errorf", 2)
+					mockLogger.AssertNumberOfCalls(t, "Debugf", 0)
+
+				} else {
+					mockLogger.AssertNumberOfCalls(t, "Errorf", 0)
+					mockLogger.AssertNumberOfCalls(t, "Debugf", 2)
+				}
+
+			} else {
+				mockManager.AssertNumberOfCalls(t, "Register", 0)
+				mockLogger.AssertNumberOfCalls(t, "Warn", 1)
+				mockLogger.AssertNumberOfCalls(t, "Debugf", 0)
+			}
+
+			require.NotNil(t, eventsSent)
+			require.NotNil(t, readingsSent)
+
+			assert.Equal(t, test.ExpectedEventCount, eventsSent.Count())
+			assert.Equal(t, test.ExpectedReadingCount, readingsSent.Count())
 		})
 	}
 }

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/edgexfoundry/device-sdk-go/v2/internal/common"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 	"github.com/gorilla/mux"
@@ -78,6 +79,10 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 	}
 
 	ds.manager.StartAutoEvents()
+
+	// Very important that this handler is called after the NewServiceMetrics handler so
+	// MetricsManager dependency has been created.
+	common.InitializeSentMetrics(ds.LoggingClient, dic)
 
 	return true
 }


### PR DESCRIPTION
closes #1238

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/881

## Testing Instructions
Run non-secure EdgeX Stack
Build Device Simple from this branch
Run Device Simple from command-line with logging set to DEBUG
Verify the following are in the log file once first autoevent fires
```
"EventsSent metric has been registered and will be reported (if enabled)"
"ReadingsSent metric has been registered and will be reported (if enabled)"
```
After 30secs or so verify the following in the log file
```
"Publish 5 metrics to the 'edgex/telemetry/device-simple' base topic"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->