### PR TITLE
feat!: Remove ZeroMQ MessageBus capability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,6 @@
 .PHONY: build test clean docker unittest lint
 
 ARCH=$(shell uname -m)
-GO=CGO_ENABLED=0 GO111MODULE=on go
-GOCGO=CGO_ENABLED=1 GO111MODULE=on go
-
-
-# see https://shibumi.dev/posts/hardening-executables
-CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-CGO_CFLAGS="-O2 -pipe -fno-plt"
-CGO_CXXFLAGS="-O2 -pipe -fno-plt"
-CGO_LDFLAGS="-Wl,-O1,–sort-common,–as-needed,-z,relro,-z,now"
 
 MICROSERVICES=example/cmd/device-simple/device-simple
 .PHONY: $(MICROSERVICES)
@@ -18,20 +9,19 @@ VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 DOCKER_TAG=$(VERSION)-dev
 
 GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-sdk-go/v3.Version=$(VERSION)" -trimpath -mod=readonly
-CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-sdk-go/v3.Version=$(VERSION)" -trimpath -mod=readonly -buildmode=pie
 GOTESTFLAGS?=-race
 
 GIT_SHA=$(shell git rev-parse HEAD)
 
-
 build: $(MICROSERVICES)
-	$(GOCGO) install -tags=safe
 
 tidy:
 	go mod tidy
 
+# CGO is enabled by default and cause docker builds to fail due to no gcc,
+# but is required for test with -race, so must disable it for the builds only
 example/cmd/device-simple/device-simple:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./example/cmd/device-simple
+	CGO_ENABLED=0  go build $(GOFLAGS) -o $@ ./example/cmd/device-simple
 
 docker:
 	docker build \
@@ -42,7 +32,7 @@ docker:
 		.
 
 unittest:
-	GO111MODULE=on go test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
+	go test $(GOTESTFLAGS) -coverprofile=coverage.out ./...
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.46.2"
@@ -58,4 +48,4 @@ clean:
 	rm -f $(MICROSERVICES)
 
 vendor:
-	$(GO) mod vendor
+	go mod vendor

--- a/example/cmd/device-simple/Attribution.txt
+++ b/example/cmd/device-simple/Attribution.txt
@@ -46,10 +46,22 @@ davecgh/go-spew (ISC) https://github.com/davecgh/go-spew
 https://github.com/davecgh/go-spew/blob/master/LICENSE
 
 edgexfoundry/go-mod-core-contracts (Apache 2.0) https://github.com/edgexfoundry/go-mod-core-contracts/v3
-https://github.com/edgexfoundry/go-mod-core-contracts/v3/blob/master/LICENSE
+https://github.com/edgexfoundry/go-mod-core-contracts/blob/master/LICENSE
 
 edgexfoundry/go-mod-registry (Apache 2.0) https://github.com/edgexfoundry/go-mod-registry/v3
-https://github.com/edgexfoundry/go-mod-registry/v3/blob/master/LICENSE
+https://github.com/edgexfoundry/go-mod-registry/blob/master/LICENSE
+
+edgexfoundry/go-mod-messaging (Apache 2.0) https://github.com/edgexfoundry/go-mod-messaging/v3
+https://github.com/edgexfoundry/go-mod-messaging/blob/master/LICENSE
+
+edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-secrets/v3
+https://github.com/edgexfoundry/go-mod-secrets/blob/master/LICENSE
+
+edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-bootstrap/v3
+https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/LICENSE
+
+edgexfoundry/go-mod-secrets (Apache 2.0) https://github.com/edgexfoundry/go-mod-configuration/v3
+https://github.com/edgexfoundry/go-mod-configuration/blob/master/LICENSE
 
 go-logfmt/logfmt (MIT) https://github.com/go-logfmt/logfmt
 https://github.com/go-logfmt/logfmt/blob/master/LICENSE
@@ -138,9 +150,6 @@ https://github.com/go-redis/redis/blob/master/LICENSE
 gorilla/websocket (BSD-2) https://github.com/gorilla/websocket
 https://github.com/gorilla/websocket/blob/master/LICENSE
 
-pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
-https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
-
 golang.org/x/net (Unspecified) https://github.com/golang/net
 https://github.com/golang/net/blob/master/LICENSE
 
@@ -185,3 +194,15 @@ https://github.com/rcrowley/go-metrics/blob/master/LICENSE
 
 golang.org/x/sync (Unspecified) https://cs.opensource.google/go/x/sync
 https://cs.opensource.google/go/x/sync/+/master:LICENSE
+
+github.com/Microsoft/go-winio (MIT) https://github.com/Microsoft/go-winio
+https://github.com/microsoft/go-winio/blob/master/LICENSE
+
+github.com/nats-io/nats.go (Apache-2.0) https://github.com/nats-io/nats.go
+https://github.com/nats-io/nats.go/blob/main/LICENSE
+
+github.com/nats-io/nkeys (Apache-2.0) https://github.com/nats-io/nkeys
+https://github.com/nats-io/nkeys/blob/master/LICENSE
+
+github.com/nats-io/nuid (Apache-2.0) https://github.com/nats-io/nuid
+https://github.com/nats-io/nuid/blob/master/LICENSE

--- a/example/cmd/device-simple/Dockerfile
+++ b/example/cmd/device-simple/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Intel
+# Copyright (c) 2023 Intel
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ ARG MAKE=make build
 WORKDIR /device-sdk-go
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-  copyright='Copyright (c) 2022: Intel'
+  copyright='Copyright (c) 2023: Intel'
 
-RUN apk add --update --no-cache make git gcc libc-dev zeromq-dev libsodium-dev
+RUN apk add --update --no-cache make git
 
 COPY go.mod vendor* ./
 RUN [ ! -d "vendor" ] && go mod download all || echo "skipping..."
@@ -37,7 +37,7 @@ FROM alpine:3.16
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2022: Intel'
 
-RUN apk add --update --no-cache zeromq
+RUN apk add --update --no-cache
 
 WORKDIR /
 COPY --from=builder /device-sdk-go/example/cmd/device-simple/Attribution.txt /Attribution.txt


### PR DESCRIPTION
BREAKING CHANGE: ZeroMQ MessageBus capability no longer available

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Build branch locally without gcc and zmq libs available.
Verify sample builds and run as expected.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->