### PR TITLE
refactor!: Use bool types for command parameters to be more consistent

### DIFF
--- a/internal/controller/http/command_test.go
+++ b/internal/controller/http/command_test.go
@@ -305,7 +305,7 @@ func TestRestController_GetCommand_ReturnEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	query := req.URL.Query()
-	query.Add("ds-returnevent", "no")
+	query.Add("ds-returnevent", common.ValueFalse)
 	req.URL.RawQuery = query.Encode()
 	// Act
 	recorder := httptest.NewRecorder()

--- a/openapi/v2/device-sdk.yaml
+++ b/openapi/v2/device-sdk.yaml
@@ -1095,21 +1095,21 @@ paths:
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: no
-          example: yes
-          description: "If set to yes, a successful GET will result in an event being pushed to the EdgeX system"
+              - true
+              - false
+            default: false
+          example: true
+          description: "If set to true, a successful GET will result in an event being pushed to the EdgeX system"
         - in: query
           name: ds-returnevent
           schema:
             type: string
             enum:
-              - yes
-              - no
-            default: yes
-          example: no
-          description: "If set to no, there will be no Event returned in the http response"
+              - true
+              - false
+            default: true
+          example: false
+          description: "If set to false, there will be no Event returned in the http response"
       responses:
         '200':
           description: String as returned by the device/sensor through the device service.


### PR DESCRIPTION
BREAKING CHANGE: ds-pushevent and ds-returnevent to use bool true/false instead of yes/no

related: https://github.com/edgexfoundry/go-mod-core-contracts/pull/782

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/917 and the Swagger file in this repo

## Testing Instructions
<!-- How can the reviewers test your change? -->
build core-command and device-virtual docker images based on the changes and run docker-compose.yml
The following commands work as expected:

```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=false
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=true
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=false
```

and the following commands return errors as expected:
```
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-pushevent\=no
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=yes
curl http://localhost:59882/api/v2/device/name/Random-Boolean-Device/Bool\?ds-return\=no
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->