### PR TITLE
fix: typo "DeviceResourece" -> "DeviceResource" in error message

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2022 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -130,7 +130,7 @@ func readDeviceResource(device models.Device, resourceName string, attributes st
 	driver := container.ProtocolDriverFrom(dic.Get)
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
-		errMsg := fmt.Sprintf("error reading DeviceResourece %s for %s", dr.Name, device.Name)
+		errMsg := fmt.Sprintf("error reading DeviceResource %s for %s", dr.Name, device.Name)
 		return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
@@ -254,7 +254,7 @@ func writeDeviceResource(device models.Device, resourceName string, attributes s
 	driver := container.ProtocolDriverFrom(dic.Get)
 	err := driver.HandleWriteCommands(device.Name, device.Protocols, reqs, []*sdkModels.CommandValue{cv})
 	if err != nil {
-		errMsg := fmt.Sprintf("error writing DeviceResourece %s for %s", dr.Name, device.Name)
+		errMsg := fmt.Sprintf("error writing DeviceResource %s for %s", dr.Name, device.Name)
 		return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) N/A
- [ ] I have opened a PR for the related docs change (if not, why?) N/A
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->