### PR TITLE
feat: Add resource, command, and device tags to reading/event

### DIFF
--- a/internal/transformer/transform.go
+++ b/internal/transformer/transform.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
+	sdkCommon "github.com/edgexfoundry/device-sdk-go/v3/internal/common"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
 	"github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
 
@@ -113,6 +114,7 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 		if config.Writable.Reading.ReadingUnits {
 			reading.Units = dr.Properties.Units
 		}
+		sdkCommon.AddReadingTags(&reading)
 		readings = append(readings, reading)
 
 		if cv.Type == common.ValueTypeBinary {
@@ -131,6 +133,7 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 		eventDTO.Readings = readings
 		eventDTO.Origin = origin
 		eventDTO.Tags = tags
+		sdkCommon.AddEventTags(&eventDTO)
 
 		return &eventDTO, nil
 	} else {


### PR DESCRIPTION
fix #1294 

1. Add device resource tags to reading
2. Add device command tags to event
3. Add device tags to event
Note: Device tags take precedence over Device Command tags.

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run non-secure EdgeX Stack
2. Based on this branch, modify the device configuration of Device Simple to add device tags

simple-device.toml
```
[[DeviceList]]
  Name = "Simple-Device01"
  ProfileName = "Simple-Device"
  Description = "Example of Simple Device"
  Labels = [ "industrial" ]
  [DeviceList.Tags]
    deviceTag = "deviceTag"
  [DeviceList.Protocols]
  [DeviceList.Protocols.other]
    Address = "simple01"
    Port = "300"
  [[DeviceList.AutoEvents]]
    Interval = "10s"
    OnChange = false
    SourceName = "Switch"
  [[DeviceList.AutoEvents]]
    Interval = "30s"
    OnChange = false
    SourceName = "Image"
```

3. Modify the device profile configuration of Device Simple to add resource and command tags

Simple-Driver.yaml
```
apiVersion: "v2"
name: "Simple-Device"
manufacturer: "Simple Corp."
model: "SP-01"
labels:
  - "modbus"
description: "Example of Simple Device"

deviceResources:
  -
    name: "SwitchButton"
    isHidden: false
    description: "Switch On/Off."
    tags:
      resourceTag: "resourceTag"
    properties:
        valueType: "Bool"
        readWrite: "RW"
        defaultValue: "true"
  -
    name: "Image"
    isHidden: false
    description: "Visual representation of Switch state."
    properties:
        valueType: "Binary"
        readWrite: "R"
        mediaType: "image/jpeg"
  -
    name: "Xrotation"
    isHidden: true
    description: "X axis rotation rate"
    properties:
        valueType: "Int32"
        readWrite: "RW"
        units: "rpm"
  -
    name: "Yrotation"
    isHidden: true
    description: "Y axis rotation rate"
    properties:
        valueType: "Int32"
        readWrite: "RW"
        "units": "rpm"
  -
    name: "Zrotation"
    isHidden: true
    description: "Z axis rotation rate"
    properties:
        valueType: "Int32"
        readWrite: "RW"
        "units": "rpm"
  -
    name: "StringArray"
    isHidden: false
    description: "String array"
    properties:
      valueType: "StringArray"
      readWrite: "RW"
  -
    name: "Uint8Array"
    isHidden: false
    description: "Unsigned 8bit array"
    properties:
        valueType: "Uint8Array"
        readWrite: "RW"
  -
    name: "Counter"
    isHidden: false
    description: "Counter data"
    properties:
      valueType: "Object"
      readWrite: "RW"

deviceCommands:
  -
    name: "Switch"
    isHidden: false
    readWrite: "RW"
    tags:
      commandTag: "commandTag"
    resourceOperations:
      - { deviceResource: "SwitchButton", defaultValue: "false" }
  -
    name: "Image"
    isHidden: false
    readWrite: "R"
    resourceOperations:
      - { deviceResource: "Image" }
  -
    name: "Rotation"
    isHidden: false
    readWrite: "RW"
    resourceOperations:
      - { deviceResource: "Xrotation", defaultValue: "0" }
      - { deviceResource: "Yrotation", defaultValue: "0" }
      - { deviceResource: "Zrotation", defaultValue: "0" }

```

4. Run Device Simple
5. `curl http://localhost:59882/api/v2/device/name/Simple-Device01/Switch`
Verify the returned event contains resource, command, and device tags.
```
{
    "apiVersion": "v2",
    "statusCode": 200,
    "event": {
        "apiVersion": "v2",
        "id": "de6e7c7c-5cb3-4af6-b3ac-3d0c460fe211",
        "deviceName": "Simple-Device01",
        "profileName": "Simple-Device",
        "sourceName": "Switch",
        "origin": 1675147339613147000,
        "readings": [
            {
                "id": "98bf94c7-6a9b-45a6-a2a9-f7c976728c8c",
                "origin": 1675147339613147000,
                "deviceName": "Simple-Device01",
                "resourceName": "SwitchButton",
                "profileName": "Simple-Device",
                "valueType": "Bool",
                "tags": {
                    "resourceTag": "resourceTag"
                },
                "value": "false"
            }
        ],
        "tags": {
            "commandTag": "commandTag",
            "deviceTag": "deviceTag"
        }
    }
}
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->