### PR TITLE
feat!: remove UseMessageBus config in 3.0

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -53,11 +53,6 @@ Port = 8500
 Type = "consul"
 
 [Clients]
-  [Clients.core-data]
-  Protocol = "http"
-  Host = "localhost"
-  Port = 59880
-
   [Clients.core-metadata]
   Protocol = "http"
   Host = "localhost"
@@ -98,7 +93,6 @@ SecretName = "redisdb"
   AsyncBufferSize = 1
   EnableAsyncReadings = true
   Labels = []
-  UseMessageBus = true
   [Device.Discovery]
     Enabled = false
     Interval = "30s"

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -57,8 +57,6 @@ type DeviceInfo struct {
 	EnableAsyncReadings bool
 	// Labels are properties applied to the device service to help with searching
 	Labels []string
-	// UseMessageBus indicates whether or not the Event are published directly to the MessageBus
-	UseMessageBus bool
 }
 
 // DiscoveryInfo is a struct which contains configuration of device auto discovery.


### PR DESCRIPTION
BREAKING CHANGE: Removed the 'Device.UseMessageBus' config, the code for sending event via core-data REST client and the 'Clients.core-data' dependency

MessageBus is always enabled in 3.0 for sending events and receiving system events for callbacks.

closes #1296

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run device-simple from this branch
2. Run `PSUBSCRIBE edgex.events.device.*` in redis container to subscribe to the auto event messages
3. Check the autoevent messages are received by `redis` container:
```shell
127.0.0.1:6379> PSUBSCRIBE edgex.events.device.*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) "edgex.events.device.*"
3) (integer) 1
1) "pmessage"
2) "edgex.events.device.*"
3) "edgex.events.device.Simple-Device.Simple-Device01.Switch"
4) "{\"ReceivedTopic\":\"\",\"CorrelationID\":\"8421be6f-b4cb-4a3f-9d28-bce7f7701ff4\",\"ApiVersion\":\"v2\",\"RequestID\":\"\",\"ErrorCode\":0,\"Payload\":\"eyJhcGlWZXJzaW9uIjoidjIiLCJyZXF1ZXN0SWQiOiJiODhmOTQ3My0wMzZkLTRhODgtYmIyMi04MmU4ZjU0Y2RhNDQiLCJldmVudCI6eyJhcGlWZXJzaW9uIjoidjIiLCJpZCI6IjdiYWQxM2MzLWZiMmEtNDM2ZS1hYjQ3LTQxOTY5NWM1YmFiZSIsImRldmljZU5hbWUiOiJTaW1wbGUtRGV2aWNlMDEiLCJwcm9maWxlTmFtZSI6IlNpbXBsZS1EZXZpY2UiLCJzb3VyY2VOYW1lIjoiU3dpdGNoIiwib3JpZ2luIjoxNjc1MzE4MDcxOTQyOTE3MDAwLCJyZWFkaW5ncyI6W3siaWQiOiJjOGQ0OWE5NC1iOTQ1LTQ5NjQtYmVhYi0zMDY3MWNlMzExYTgiLCJvcmlnaW4iOjE2NzUzMTgwNzE5NDI5MTcwMDAsImRldmljZU5hbWUiOiJTaW1wbGUtRGV2aWNlMDEiLCJyZXNvdXJjZU5hbWUiOiJTd2l0Y2hCdXR0b24iLCJwcm9maWxlTmFtZSI6IlNpbXBsZS1EZXZpY2UiLCJ2YWx1ZVR5cGUiOiJCb29sIiwidmFsdWUiOiJmYWxzZSJ9XX19\",\"ContentType\":\"application/json\",\"QueryParams\":{}}"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->