### PR TITLE
refactor!: Update config for message bus topic wild cards

### DIFF
--- a/example/cmd/device-simple/res/configuration.toml
+++ b/example/cmd/device-simple/res/configuration.toml
@@ -69,7 +69,7 @@ SecretName = "redisdb"
   PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   CommandRequestTopic = "edgex/device/command/request/device-simple/#"   # subscribing for inbound command requests
   CommandResponseTopicPrefix = "edgex/device/command/response"   # publishing outbound command responses; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix
-  SystemEventTopic = "edgex/system-events/core-metadata/device/#/device-simple/#"
+  SystemEventTopic = "edgex/system-events/core-metadata/device/+/device-simple/#"
   [MessageBus.Optional]
   # Default MQTT Specific options that need to be here to enable environment variable overrides of them
   # Client Identifiers


### PR DESCRIPTION
BREAKING CHANGE: use MQTT wild cards + for single level and # for multiple levels

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) update config
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/953

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build and run device-simple
2. create a device and receive the system event correctly
```
level=DEBUG ts=2023-02-06T03:54:48.837716Z app=device-simple source=callback.go:55 msg="System event received on message queue. Topic: edgex/system-events/core-metadata/device/+/device-simple/#, Correlation-id: aff63bcd-93b2-43ce-afb6-b7d38535ce13 "
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->