### PR TITLE
feat!: replace REST provision watcher callbacks with System Events

### DIFF
--- a/internal/controller/http/callback.go
+++ b/internal/controller/http/callback.go
@@ -10,69 +10,12 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/application"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	commonDTO "github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
-	"github.com/gorilla/mux"
-
-	"github.com/edgexfoundry/device-sdk-go/v3/internal/application"
 )
-
-func (c *RestController) DeleteProvisionWatcher(writer http.ResponseWriter, request *http.Request) {
-	vars := mux.Vars(request)
-	name := vars[common.Name]
-
-	err := application.DeleteProvisionWatcher(name, c.lc)
-	if err == nil {
-		res := commonDTO.NewBaseResponse("", "", http.StatusOK)
-		c.sendResponse(writer, request, common.ApiWatcherCallbackNameRoute, res, http.StatusOK)
-	} else {
-		c.sendEdgexError(writer, request, err, common.ApiWatcherCallbackNameRoute)
-	}
-}
-
-func (c *RestController) AddProvisionWatcher(writer http.ResponseWriter, request *http.Request) {
-	defer request.Body.Close()
-
-	var addProvisionWatcherRequest requests.AddProvisionWatcherRequest
-
-	err := json.NewDecoder(request.Body).Decode(&addProvisionWatcherRequest)
-	if err != nil {
-		edgexErr := errors.NewCommonEdgeX(errors.KindServerError, "failed to decode JSON", err)
-		c.sendEdgexError(writer, request, edgexErr, common.ApiWatcherCallbackRoute)
-		return
-	}
-
-	edgexErr := application.AddProvisionWatcher(addProvisionWatcherRequest, c.lc, c.dic)
-	if edgexErr == nil {
-		res := commonDTO.NewBaseResponse(addProvisionWatcherRequest.RequestId, "", http.StatusOK)
-		c.sendResponse(writer, request, common.ApiWatcherCallbackRoute, res, http.StatusOK)
-	} else {
-		c.sendEdgexError(writer, request, edgexErr, common.ApiWatcherCallbackRoute)
-	}
-}
-
-func (c *RestController) UpdateProvisionWatcher(writer http.ResponseWriter, request *http.Request) {
-	defer request.Body.Close()
-
-	var updateProvisionWatcherRequest requests.UpdateProvisionWatcherRequest
-
-	err := json.NewDecoder(request.Body).Decode(&updateProvisionWatcherRequest)
-	if err != nil {
-		edgexErr := errors.NewCommonEdgeX(errors.KindServerError, "failed to decode JSON", err)
-		c.sendEdgexError(writer, request, edgexErr, common.ApiWatcherCallbackRoute)
-		return
-	}
-
-	edgexErr := application.UpdateProvisionWatcher(updateProvisionWatcherRequest, c.dic)
-	if edgexErr == nil {
-		res := commonDTO.NewBaseResponse(updateProvisionWatcherRequest.RequestId, "", http.StatusOK)
-		c.sendResponse(writer, request, common.ApiWatcherCallbackRoute, res, http.StatusOK)
-	} else {
-		c.sendEdgexError(writer, request, edgexErr, common.ApiWatcherCallbackRoute)
-	}
-}
 
 func (c *RestController) UpdateDeviceService(writer http.ResponseWriter, request *http.Request) {
 	defer request.Body.Close()

--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -67,9 +67,6 @@ func (c *RestController) InitRestRoutes() {
 	c.addReservedRoute(common.ApiDeviceNameCommandNameRoute, c.GetCommand).Methods(http.MethodGet)
 	c.addReservedRoute(common.ApiDeviceNameCommandNameRoute, c.SetCommand).Methods(http.MethodPut)
 	// callback
-	c.addReservedRoute(common.ApiWatcherCallbackRoute, c.AddProvisionWatcher).Methods(http.MethodPost)
-	c.addReservedRoute(common.ApiWatcherCallbackRoute, c.UpdateProvisionWatcher).Methods(http.MethodPut)
-	c.addReservedRoute(common.ApiWatcherCallbackNameRoute, c.DeleteProvisionWatcher).Methods(http.MethodDelete)
 	c.addReservedRoute(common.ApiServiceCallbackRoute, c.UpdateDeviceService).Methods(http.MethodPut)
 
 	c.router.Use(correlation.ManageHeader)

--- a/openapi/v3/changes.txt
+++ b/openapi/v3/changes.txt
@@ -3,3 +3,4 @@ API changes from v2
 * Remove /callback/device, /callback/device/name/{name} endpoints
 * Change /device/name/{name}/{command} ds-pushevent and ds-returnevent parameter values to true/false
 * Remove /callback/profile endpoints
+* Remove /callback/watcher endpoints

--- a/openapi/v3/device-sdk.yaml
+++ b/openapi/v3/device-sdk.yaml
@@ -286,16 +286,6 @@ components:
           $ref: '#/components/schemas/Device'
       required:
         - device
-    NewProvisionWatcherRequest:
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      description: "Notification that a new provision watcher associated with this device service has been created."
-      type: object
-      properties:
-        provisionWatcher:
-          $ref: '#/components/schemas/ProvisionWatcher'
-      required:
-        - provisionWatcher
     PingResponse:
       description: "A response from the /ping endpoint indicating that the service is functioning."
       allOf:
@@ -315,55 +305,6 @@ components:
       type: object
       additionalProperties:
         type: string
-    ProvisionWatcher:
-      description: "A Provision Watcher assigns a subset of discoverable devices to a specified device service, and specifies the device profile which should be used with them, and their initial adminState. The subset is defined by the Identifiers and BlockingIdentifiers, which are matched against a discovered device's protocol properties - the subset contains only devices which match all of the Identifiers and none of the BlockingIdentifiers."
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: "The unique identifier for the provision watcher"
-        name:
-          type: string
-          description: "The name of the provision watcher"
-        created:
-          type: integer
-          description: "A Unix timestamp indicating when the object was initially persisted to a database"
-        modified:
-          type: integer
-          description: "A Unix timestamp indicating when the object was last modified"
-        labels:
-          type: array
-          description: "Labels applied to the provision watcher to help with searching"
-          items:
-            type: string
-        identifiers:
-          type: object
-          additionalProperties:
-            type: string
-          description: "Properties of a new device which must match in order for this provision watcher to match the new device"
-        blockingIdentifiers:
-          type: object
-          additionalProperties:
-            type: array
-            items:
-              type: string
-          description: "Properties of a new device which must not match in order for this provision watcher to match the new device"
-        serviceName:
-          type: string
-          description: "The device service to which to associate devices which match this watcher"
-        profileName:
-          type: string
-          description: "The device profile to which to associate devices which match this watcher"
-        adminState:
-          type: string
-          enum: [LOCKED, UNLOCKED]
-          description: "The initial administrative state to apply to devices which match this watcher"
-        autoEvents:
-          type: array
-          description: "Autoevents that allow device service to automatically start generating data from new devices"
-          items:
-            $ref: '#/components/schemas/AutoEvent'
     SecretRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
@@ -404,16 +345,6 @@ components:
       title: Setting
       type: object
       example: {"AHU-TargetTemperature": "28.5", "AHU-TargetBand": "4.0"}
-    UpdateProvisionWatcherRequest:
-      allOf:
-        - $ref: '#/components/schemas/BaseRequest'
-      description: "Notification that an existing provision watcher associated with this device service has been updated."
-      type: object
-      properties:
-        provisionWatcher:
-          $ref: '#/components/schemas/ProvisionWatcher'
-      required:
-        - provisionWatcher
     UpdateDeviceServiceRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
@@ -462,91 +393,6 @@ components:
 
 
 paths:
-  /callback/watcher:
-    parameters:
-      - $ref: '#/components/parameters/correlatedRequestHeader'
-    post:
-      description: "This call is used by core-metadata to inform the device service of the creation of a new Provision Watcher"
-      responses:
-        '200':
-          description: "Callback successful"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponse'
-        '400':
-          description: Invalid callback request.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NewProvisionWatcherRequest'
-        required: true
-    put:
-      description: "This call is used by core-metadata to inform the device service that a Provision Watcher's characteristics have been updated"
-      responses:
-        '200':
-          description: "Callback successful"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponse'
-        '400':
-          description: Invalid callback request.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '404':
-          description: The provision watcher doesn't exist.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateProvisionWatcherRequest'
-        required: true
-
   /callback/service:
     parameters:
       - $ref: '#/components/parameters/correlatedRequestHeader'
@@ -579,46 +425,6 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: The device doesn't exist.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '500':
-          description: Internal server error.
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
-  /callback/watcher/name/{name}:
-    parameters:
-      - $ref: '#/components/parameters/correlatedRequestHeader'
-      - name: name
-        in: path
-        required: true
-        schema:
-          type: string
-        description: "The unique name of a provision watcher"
-    delete:
-      description: "This call is used by core-metadata to inform the device service that a Provision Watcher has been deleted"
-      responses:
-        '200':
-          description: "Callback successful"
-          headers:
-            X-Correlation-ID:
-              $ref: '#/components/headers/correlatedResponseHeader'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseResponse'
-        '404':
-          description: No provision watcher exists for the ID provided.
           headers:
             X-Correlation-ID:
               $ref: '#/components/headers/correlatedResponseHeader'


### PR DESCRIPTION
BREAKING CHANGE: remove /callback/watcher and /callback/watcher/name/{name} REST endpoints

Signed-off-by: Ginny Guan <ginny@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)update the swagger file in this repo
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. build and run device-simple from this branch and core-metadata from https://github.com/edgexfoundry/edgex-go/pull/4346
2. add/update/delete a provision watcher
3. verified the callbacks are successfully triggered by system event:
- add a provision watcher
```
level=DEBUG ts=2023-02-13T09:48:21.488495286Z app=device-simple source=callback.go:56 msg="System event received on message queue. Topic: edgex/system-events/core-metadata/+/+/device-simple/#, Correlation-id: 71129ebb-344b-4799-96ec-150cd7028705 "
level=DEBUG ts=2023-02-13T09:48:21.492598991Z app=device-simple source=callback.go:189 msg="provision watcher provisionwatcher-1 added"
```
- update a provision watcher
```
level=DEBUG ts=2023-02-13T09:50:54.284329864Z app=device-simple source=callback.go:56 msg="System event received on message queue. Topic: edgex/system-events/core-metadata/+/+/device-simple/#, Correlation-id: 08da17e3-2bf8-4fc2-8800-952ea5d9c9e4 "
level=DEBUG ts=2023-02-13T09:50:54.288920668Z app=device-simple source=callback.go:225 msg="provision watcher provisionwatcher-1 updated"
```
- delete a provision watcher
```
l=DEBUG ts=2023-02-13T09:54:02.068925719Z app=device-simple source=callback.go:56 msg="System event received on message queue. Topic: edgex/system-events/core-metadata/+/+/device-simple/#, Correlation-id: 61e08d1e-16b6-4c3c-9241-c9e723125992 "
level=DEBUG ts=2023-02-13T09:54:02.069298889Z app=device-simple source=callback.go:237 msg="removed provision watcher provisionwatcher-1"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->