### PR TITLE
fix: Update swagger to match latest changes in go-mod-core-contracts Device DTO

### DIFF
--- a/openapi/v3/changes.txt
+++ b/openapi/v3/changes.txt
@@ -6,3 +6,4 @@ API changes from v2
 * Remove /callback/watcher endpoints
 * Remove /callback/service endpoints
 * Rename path on SecretRequest to secretName
+* Rename the NewDeviceRequest to DeviceValidationRequest, and add "tags" and "properties" fields into the schema of DeviceValidationRequest

--- a/openapi/v3/device-sdk.yaml
+++ b/openapi/v3/device-sdk.yaml
@@ -67,12 +67,6 @@ components:
           type: string
           format: uuid
           description: "The unique identifier of the device"
-        created:
-          type: integer
-          description: "A Unix timestamp indicating when the object was initially persisted to a database"
-        modified:
-          type: integer
-          description: "A Unix timestamp indicating when the object was last modified"
         name:
           type: string
           description: "The name of the device"
@@ -95,15 +89,9 @@ components:
         location:
           type: object
           description: "Device service specific location information"
-        serviceId:
-          type: string
-          description: "Associated device service referenced by id"
         serviceName:
           type: string
           description: "Associated device service referenced by name"
-        profileId:
-          type: string
-          description: "Associated device profile referenced by id"
         profileName:
           type: string
           description: "Associated device profile referenced by name"
@@ -116,6 +104,12 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ProtocolProperties'
+        tags:
+          type: object
+          description: "A map of tags used to tag the given device."
+        properties:
+          type: object
+          description: "A map of properties required to address the given device."
     BaseReading:
       description: "A base reading type containing common properties from which more specific reading types inherit. This definition should not be implemented but is used elsewhere to indicate support for a mixed list of simple/binary readings in a single event."
       type: object
@@ -247,7 +241,7 @@ components:
         config:
           description: "An object containing the service''s configuration. Please refer to Core Data''s configuration documentation for more details at [EdgeX Foundry Documentation](https://docs.edgexfoundry.org)."
           type: object
-    NewDeviceRequest:
+    DeviceValidationRequest:
       allOf:
         - $ref: '#/components/schemas/BaseRequest'
       description: "Notification that a new device associated with this device service has been created."
@@ -556,7 +550,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewDeviceRequest'
+              $ref: '#/components/schemas/DeviceValidationRequest'
         required: true
       responses:
         '200':


### PR DESCRIPTION
Per https://github.com/edgexfoundry/go-mod-core-contracts/pull/800, the Device DTO is added with a new field `properties`, so the swagger file needs to be updated correspondingly.

Moreover, this commit also updates the swagger file to remove those fields that had been taken out of Device DTO before:
- created
- modified
- serviceId
- profileId

This commit also adds back a newly created field `tags` into the Device DTO.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->