### PR TITLE
feat: Accept URL escape for device command name and resource name

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
+	"net/url"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
@@ -70,7 +71,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	ctx = context.WithValue(ctx, common.ContentType, encoding) // nolint: staticcheck
 	envelope := types.NewMessageEnvelope(bytes, ctx)
 	serviceName := container.DeviceServiceFrom(dic.Get).Name
-	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, serviceName, event.ProfileName, event.DeviceName, event.SourceName)
+	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, serviceName, event.ProfileName, event.DeviceName, url.QueryEscape(event.SourceName))
 	err = mc.Publish(envelope, publishTopic)
 	if err != nil {
 		lc.Errorf("Failed to publish event to MessageBus: %s", err)

--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2021 IOTech Ltd
+// Copyright (C) 2019-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,9 @@ package correlation
 
 import (
 	"context"
+	"github.com/gorilla/mux"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
@@ -41,6 +43,25 @@ func LoggingMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler 
 			} else {
 				next.ServeHTTP(w, r)
 			}
+		})
+	}
+}
+
+// UrlDecodeMiddleware decode the path variables
+// After invoking the router.UseEncodedPath() func, the path variables needs to decode before passing to the controller
+func UrlDecodeMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			vars := mux.Vars(r)
+			for k, v := range vars {
+				unescape, err := url.QueryUnescape(v)
+				if err != nil {
+					lc.Debugf("failed to decode the %s from the value %s", k, v)
+					return
+				}
+				vars[k] = unescape
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -53,6 +53,8 @@ func (c *RestController) SetCustomConfigInfo(customConfig interfaces.UpdatableCo
 
 func (c *RestController) InitRestRoutes() {
 	c.lc.Info("Registering v2 routes...")
+	// router.UseEncodedPath() tells the router to match the encoded original path to the routes
+	c.router.UseEncodedPath()
 	// common
 	c.addReservedRoute(common.ApiPingRoute, c.Ping).Methods(http.MethodGet)
 	c.addReservedRoute(common.ApiVersionRoute, c.Version).Methods(http.MethodGet)
@@ -69,6 +71,7 @@ func (c *RestController) InitRestRoutes() {
 
 	c.router.Use(correlation.ManageHeader)
 	c.router.Use(correlation.LoggingMiddleware(c.lc))
+	c.router.Use(correlation.UrlDecodeMiddleware(c.lc))
 }
 
 func (c *RestController) addReservedRoute(route string, handler func(http.ResponseWriter, *http.Request)) *mux.Route {

--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
@@ -71,7 +72,11 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 
 				// expected command response topic scheme: #/<service-name>/<device-name>/<command-name>/<method>
 				deviceName := topicLevels[length-3]
-				commandName := topicLevels[length-2]
+				commandName, err := url.QueryUnescape(topicLevels[length-2])
+				if err != nil {
+					lc.Errorf("Failed to unescape command name '%s'", commandName)
+					continue
+				}
 				method := topicLevels[length-1]
 
 				responsePublishTopic := common.BuildTopic(responsePublishTopicPrefix, msgEnvelope.RequestID)


### PR DESCRIPTION
- Use escaped resource name for message bus topic
- Unescape the URL path

Close #1334

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->