### PR TITLE
feat: publish event with updated value for PUT command

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -9,9 +9,10 @@ package common
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
-	"net/url"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"

--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2022 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -83,10 +83,15 @@ func (c *RestController) SetCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = application.SetCommand(ctx, deviceName, commandName, queryParams, requestParamsMap, c.dic)
+	event, err := application.SetCommand(ctx, deviceName, commandName, queryParams, requestParamsMap, c.dic)
 	if err != nil {
 		c.sendEdgexError(w, r, err, common.ApiDeviceNameCommandNameRoute)
 		return
+	}
+
+	if event != nil {
+		correlationId := utils.FromContext(ctx, common.CorrelationHeader)
+		go sdkCommon.SendEvent(event, correlationId, c.dic)
 	}
 
 	res := commonDTO.NewBaseResponse("", "", http.StatusOK)

--- a/internal/transformer/transform_test.go
+++ b/internal/transformer/transform_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -168,7 +168,7 @@ func TestCommandValuesToEventDTO_ReadingUnits(t *testing.T) {
 					return configuration
 				},
 			})
-			event, err := CommandValuesToEventDTO(testCase.CommandValues, TestDevice, TestDeviceCommand, dic)
+			event, err := CommandValuesToEventDTO(testCase.CommandValues, TestDevice, TestDeviceCommand, configuration.Device.DataTransform, dic)
 			require.NoError(t, err)
 
 			assert.Equal(t, TestDevice, event.DeviceName)


### PR DESCRIPTION
Similiar to GET command with 'ds-pushevent=true', publish an event with updated resource(s) value to messageBus as long as the resource/command is not write-only.

closes #1271

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/983

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `device-simple` from this branch
2. Subscribe to edgex internal event topics in `redis` container:
```shell
$ docker exec -it edgex-redis /bin/sh
/data # redis-cli
127.0.0.1:6379> PSUBSCRIBE edgex.events.device.*
Reading messages... (press Ctrl-C to quit)
1) "psubscribe"
2) "edgex.events.device.*"
3) (integer) 1
1) "pmessage"
2) "edgex.events.device.*"
3) "edgex.events.device.device-simple.Simple-Device.Simple-Device01.Xrotation"
4) "{\"ReceivedTopic\":\"\",\"CorrelationID\":\"24683755-b598-4dda-8f3e-29536ef2b3d6\",\"ApiVersion\":\"v2\",\"RequestID\":\"\",\"ErrorCode\":0,\"Payload\":\"eyJhcGlWZXJzaW9uIjoidjIiLCJyZXF1ZXN0SWQiOiJkODZjOTliOS1iMGE0LTQ2MzgtODgxOS03ODAxYTJjZTA4ZWUiLCJldmVudCI6eyJhcGlWZXJzaW9uIjoidjIiLCJpZCI6ImM1ZDllN2E4LWE3NzEtNGNkNS04NTBmLTU4OTJhMDIxNDE1NiIsImRldmljZU5hbWUiOiJTaW1wbGUtRGV2aWNlMDEiLCJwcm9maWxlTmFtZSI6IlNpbXBsZS1EZXZpY2UiLCJzb3VyY2VOYW1lIjoiWHJvdGF0aW9uIiwib3JpZ2luIjoxNjc3ODM1Nzc1NTcyNzMwMDAwLCJyZWFkaW5ncyI6W3siaWQiOiIxMTRlZGNmYS1hNTAwLTRmMGEtYTBkMC02MTNlZDU5ZWYyZGQiLCJvcmlnaW4iOjE2Nzc4MzU3NzU1NzI3MzAwMDAsImRldmljZU5hbWUiOiJTaW1wbGUtRGV2aWNlMDEiLCJyZXNvdXJjZU5hbWUiOiJYcm90YXRpb24iLCJwcm9maWxlTmFtZSI6IlNpbXBsZS1EZXZpY2UiLCJ2YWx1ZVR5cGUiOiJJbnQzMiIsInVuaXRzIjoicnBtIiwidmFsdWUiOiIxMCJ9XX19\",\"ContentType\":\"application/json\",\"QueryParams\":{}}"
```
3. Verify there's an event being published after a successfully PUT command:
```shell
$ curl -X PUT -H "Content-Type: application/json" -d '{"Xrotation": "10"}' http://localhost:59882/api/v2/device/name/Simple-Device01/Xrotation
{"apiVersion":"v2","statusCode":200}
```

base64 decode the payload:
```json
{
   "apiVersion":"v2",
   "requestId":"d86c99b9-b0a4-4638-8819-7801a2ce08ee",
   "event":{
      "apiVersion":"v2",
      "id":"c5d9e7a8-a771-4cd5-850f-5892a0214156",
      "deviceName":"Simple-Device01",
      "profileName":"Simple-Device",
      "sourceName":"Xrotation",
      "origin":1677835775572730000,
      "readings":[
         {
            "id":"114edcfa-a500-4f0a-a0d0-613ed59ef2dd",
            "origin":1677835775572730000,
            "deviceName":"Simple-Device01",
            "resourceName":"Xrotation",
            "profileName":"Simple-Device",
            "valueType":"Int32",
            "units":"rpm",
            "value":"10"
         }
      ]
   }
}
```

Note that this behavior also applies to commands via messaging.


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->