### PR TITLE
feat: Device ProtocolProperties have typed values

### DIFF
--- a/example/cmd/device-simple/res/devices/simple-device.json.example
+++ b/example/cmd/device-simple/res/devices/simple-device.json.example
@@ -7,7 +7,7 @@
     "protocols": {
       "other": {
         "address": "simple01",
-        "port": "300"
+        "port": 300
       }
     },
     "autoEvents": [

--- a/example/cmd/device-simple/res/devices/simple-device.toml
+++ b/example/cmd/device-simple/res/devices/simple-device.toml
@@ -6,7 +6,7 @@
   [DeviceList.Protocols]
   [DeviceList.Protocols.other]
     Address = "simple01"
-    Port = "300"
+    Port = 300
   [[DeviceList.AutoEvents]]
     Interval = "10s"
     OnChange = false

--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2022 IOTech Ltd
+// Copyright (C) 2018-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,13 +21,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/edgexfoundry/device-sdk-go/v3/pkg/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	gometrics "github.com/rcrowley/go-metrics"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/example/config"
+	"github.com/edgexfoundry/device-sdk-go/v3/pkg/interfaces"
 	sdkModels "github.com/edgexfoundry/device-sdk-go/v3/pkg/models"
 )
 
@@ -311,7 +311,7 @@ func (s *SimpleDriver) RemoveDevice(deviceName string, protocols map[string]mode
 // Devices found as part of this discovery operation are written to the channel devices.
 func (s *SimpleDriver) Discover() {
 	proto := make(map[string]models.ProtocolProperties)
-	proto["other"] = map[string]string{"Address": "simple02", "Port": "301"}
+	proto["other"] = map[string]any{"Address": "simple02", "Port": 301}
 
 	device2 := sdkModels.DiscoveredDevice{
 		Name:        "Simple-Device02",
@@ -321,7 +321,7 @@ func (s *SimpleDriver) Discover() {
 	}
 
 	proto = make(map[string]models.ProtocolProperties)
-	proto["other"] = map[string]string{"Address": "simple03", "Port": "399"}
+	proto["other"] = map[string]any{"Address": "simple03", "Port": 399}
 
 	device3 := sdkModels.DiscoveredDevice{
 		Name:        "Simple-Device03",
@@ -352,8 +352,12 @@ func (s *SimpleDriver) ValidateDevice(device models.Device) error {
 	port, ok := protocol["Port"]
 	if !ok {
 		return errors.New("missing 'Port' information")
-	} else if _, err := strconv.Atoi(port); err != nil {
-		return errors.New("port must be a number")
+	} else {
+		portString := fmt.Sprintf("%v", port)
+		_, err := strconv.ParseUint(portString, 10, 64)
+		if err != nil {
+			return errors.New("port must be a number")
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.39
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.24
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16
 	github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.39 h1:r1G6zshXslAwr6RCF1Y
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.39/go.mod h1:ExX0El4Gu1kpO0saAEyMzaGfkWaC7wRKzLox52imq6s=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.6 h1:x/QErFpfer2vbOGrQx46FWxPw4Ye51f72YOAnEKW5Fk=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.6/go.mod h1:ZZbOu7K0/P8B1VKhZygVujLQyhvWuPe0E2vC/k2yscw=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.24 h1:EdQ36s2hBwieNf2nEwpchfZnxEu4VQKyl3H7IVl/ZRE=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.24/go.mod h1:QBzXOAoyLzBm5k9CshgH9CR9nWMNXxZjknBFMnGJN/A=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26 h1:vTTaaM3NErQRoNQKkbQ9f9x/FMJqzZX6OAQuXvU6HN8=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26/go.mod h1:QBzXOAoyLzBm5k9CshgH9CR9nWMNXxZjknBFMnGJN/A=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16 h1:JdZiqZ6CAboZ3+GuWZLyXc42y8HfsH1CmsIKNPY+0PY=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16/go.mod h1:3q+Ys51HwpR9/kOv6sT7+EwAANgOfFWi509sEP5iPEo=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5 h1:FUUfsQUKHJqSwOXEj0j/qAn+uoWzM8nV7IOapGf7D80=


### PR DESCRIPTION
related to edgexfoundry/go-mod-core-contracts#592

consume ProtocolProperties type changes in go-mod-core-contracts. AutoDiscovery handler will still parse property as string type and compare with ProvisionWatcher regex identifier.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `device-simple` from this branch with `DEVICE_DISCOVERY_ENABLED: true` 
2. Verify autodiscovery is working correctly by seeing logs like:
```shell
level=INFO ts=2023-03-08T03:37:44.264246Z app=device-simple source=async.go:105 msg="Adding discovered device Simple-Device02 to Metadata"
level=DEBUG ts=2023-03-08T03:37:44.268304Z app=device-simple source=validation.go:58 msg="Device validation request received on message queue. Topic: edgex/device-simple/validate/device, Correlation-id: 9d070e7b-cf91-41a7-96eb-e489340aa754"
level=DEBUG ts=2023-03-08T03:37:44.269186Z app=device-simple source=validation.go:100 msg="Device validation response published on message queue. Topic: edgex/response/device-simple/8d3145ec-aa52-4d3b-8b43-e86e833a996e, Correlation-id: 9d070e7b-cf91-41a7-96eb-e489340aa754"
level=DEBUG ts=2023-03-08T03:37:44.270504Z app=device-simple source=async.go:173 msg="Discovered Device Simple-Device03 Port value cannot be 399"
level=DEBUG ts=2023-03-08T03:37:44.270522Z app=device-simple source=async.go:128 msg="Filtered device addition finished"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->