### PR TITLE
refactor!: update data types in ResourceProperties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.28
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44 h1:bzROMV3XZzFB5uBFTeQ
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.44/go.mod h1:qiG4HABtB+mnFBOby/ZUpIWcQD0TZa8jIG7p/jeVuzc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7 h1:pOH2GLDg1KB4EmAzo6IEvl4NEVFAw3ywxPUMa5Wi1Vw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.7/go.mod h1:ZZbOu7K0/P8B1VKhZygVujLQyhvWuPe0E2vC/k2yscw=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26 h1:vTTaaM3NErQRoNQKkbQ9f9x/FMJqzZX6OAQuXvU6HN8=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.26/go.mod h1:QBzXOAoyLzBm5k9CshgH9CR9nWMNXxZjknBFMnGJN/A=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.28 h1:aNHlmF2uPcwUr7VKvNVJXdxMDaI41j2laoGxZy5H95g=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.28/go.mod h1:SYoD+tmUP/zwWuuIySmsQSjPx6MHP+2w9FsLgm0IR7A=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16 h1:JdZiqZ6CAboZ3+GuWZLyXc42y8HfsH1CmsIKNPY+0PY=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.16/go.mod h1:3q+Ys51HwpR9/kOv6sT7+EwAANgOfFWi509sEP5iPEo=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.5 h1:FUUfsQUKHJqSwOXEj0j/qAn+uoWzM8nV7IOapGf7D80=

--- a/internal/transformer/transformparam.go
+++ b/internal/transformer/transformparam.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2018-2021 IOTech Ltd
+// Copyright (C) 2018-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,19 +39,19 @@ func TransformWriteParameter(cv *dsModels.CommandValue, pv models.ResourceProper
 			return errors.NewCommonEdgeXWrapper(err)
 		}
 	}
-	if pv.Offset != "" && pv.Offset != defaultOffset {
+	if pv.Offset != 0 && pv.Offset != defaultOffset {
 		newValue, err = transformOffset(newValue, pv.Offset, false)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
 		}
 	}
-	if pv.Scale != "" && pv.Scale != defaultScale {
+	if pv.Scale != 0 && pv.Scale != defaultScale {
 		newValue, err = transformScale(newValue, pv.Scale, false)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)
 		}
 	}
-	if pv.Base != "" && pv.Base != defaultBase {
+	if pv.Base != 0 && pv.Base != defaultBase {
 		newValue, err = transformBase(newValue, pv.Base, false)
 		if err != nil {
 			return errors.NewCommonEdgeXWrapper(err)

--- a/internal/transformer/transformresult_test.go
+++ b/internal/transformer/transformresult_test.go
@@ -1,13 +1,12 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2021 IOTech Ltd
+// Copyright (C) 2019-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package transformer
 
 import (
-	"fmt"
 	"math"
 	"testing"
 
@@ -23,30 +22,30 @@ func Test_transformReadBase(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       interface{}
-		base        string
+		base        float64
 		expected    interface{}
 		expectedErr bool
 	}{
-		{"valid - uint8 base transformation", uint8(2), "10", uint8(100), false},
-		{"invalid - uint8 base transformation overflow", uint8(10), "10", nil, true},
-		{"valid - uint16 base transformation", uint16(2), "100", uint16(10000), false},
-		{"invalid - uint16 base transformation overflow", uint16(100), "10", nil, true},
-		{"valid - uint32 base transformation", uint32(2), "10000", uint32(100000000), false},
-		{"invalid - uint32 base transformation overflow", uint32(10000), "10", nil, true},
-		{"valid - uint64 base transformation", uint64(2), "100000", uint64(10000000000), false},
-		{"invalid - uint64 base transformation overflow", uint64(100000000), "10", nil, true},
-		{"valid - int8 base transformation", int8(2), "10", int8(100), false},
-		{"invalid - int8 base transformation overflow", int8(10), "10", nil, true},
-		{"valid - int16 base transformation", int16(2), "100", int16(10000), false},
-		{"invalid - int16 base transformation overflow", int16(100), "10", nil, true},
-		{"valid - int32 base transformation", int32(2), "10000", int32(100000000), false},
-		{"invalid - int32 base transformation overflow", int32(10000), "10", nil, true},
-		{"valid - int64 base transformation", int64(2), "100000", int64(10000000000), false},
-		{"invalid - int64 base transformation overflow", int64(100000000), "10", nil, true},
-		{"valid - float32 base transformation", float32(1.1), "2", float32(2.143547), false},
-		{"invalid - float32 base transformation overflow", math.MaxFloat32, "2", nil, true},
-		{"valid - float64 base transformation", float64(1.1), "2", float64(2.1435469250725863), false},
-		{"invalid - float64 base transformation overflow", math.MaxFloat64, "2", nil, true},
+		{"valid - uint8 base transformation", uint8(2), 10, uint8(100), false},
+		{"invalid - uint8 base transformation overflow", uint8(10), 10, nil, true},
+		{"valid - uint16 base transformation", uint16(2), 100, uint16(10000), false},
+		{"invalid - uint16 base transformation overflow", uint16(100), 10, nil, true},
+		{"valid - uint32 base transformation", uint32(2), 10000, uint32(100000000), false},
+		{"invalid - uint32 base transformation overflow", uint32(10000), 10, nil, true},
+		{"valid - uint64 base transformation", uint64(2), 100000, uint64(10000000000), false},
+		{"invalid - uint64 base transformation overflow", uint64(100000000), 10, nil, true},
+		{"valid - int8 base transformation", int8(2), 10, int8(100), false},
+		{"invalid - int8 base transformation overflow", int8(10), 10, nil, true},
+		{"valid - int16 base transformation", int16(2), 100, int16(10000), false},
+		{"invalid - int16 base transformation overflow", int16(100), 10, nil, true},
+		{"valid - int32 base transformation", int32(2), 10000, int32(100000000), false},
+		{"invalid - int32 base transformation overflow", int32(10000), 10, nil, true},
+		{"valid - int64 base transformation", int64(2), 100000, int64(10000000000), false},
+		{"invalid - int64 base transformation overflow", int64(100000000), 10, nil, true},
+		{"valid - float32 base transformation", float32(1.1), 2, float32(2.143547), false},
+		{"invalid - float32 base transformation overflow", math.MaxFloat32, 2, nil, true},
+		{"valid - float64 base transformation", float64(1.1), 2, float64(2.1435469250725863), false},
+		{"invalid - float64 base transformation overflow", math.MaxFloat64, 2, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -66,28 +65,28 @@ func Test_transformReadScale(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       interface{}
-		scale       string
+		scale       float64
 		expected    interface{}
 		expectedErr bool
 	}{
-		{"valid - uint8 scale transformation", uint8(math.MaxUint8 / 5), "5", uint8(math.MaxUint8), false},
-		{"invalid - uint8 scale transformation overflow", uint8(math.MaxUint8 / 5), "6", nil, true},
-		{"valid - uint16 scale transformation", uint16(math.MaxUint16 / 5), "5", uint16(math.MaxUint16), false},
-		{"invalid - uint16 scale transformation overflow", uint16(math.MaxUint16 / 5), "6", nil, true},
-		{"valid - uint32 scale transformation", uint32(math.MaxUint32 / 5), "5", uint32(math.MaxUint32), false},
-		{"invalid - uint32 scale transformation overflow", uint32(math.MaxUint32 / 5), "6", nil, true},
-		{"valid - uint64 scale transformation", uint64(math.MaxUint64 / 5), "5", uint64(math.MaxUint64), false},
-		{"valid - int8 scale transformation", int8(10), "10", int8(100), false},
-		{"invalid - int8 scale transformation overflow", int8(10), "30", nil, true},
-		{"valid - int16 scale transformation", int16(10000), "3", int16(30000), false},
-		{"invalid - int16 scale transformation overflow", int16(10000), "4", nil, true},
-		{"valid - int32 scale transformation", int32(1000000000), "2", int32(2000000000), false},
-		{"invalid - int32 scale transformation overflow", int32(1000000000), "3", nil, true},
-		{"valid - int64 scale transformation", int64(1000000000), "1000000000", int64(1000000000000000000), false},
-		{"valid - float32 scale transformation", float32(12.1), "10", float32(121), false},
-		{"invalid - float32 scale transformation overflow", float32(math.MaxFloat32 / 2), "3", nil, true},
-		{"valid - float64 scale transformation", float64(111111111.1), "2", float64(222222222.2), false},
-		{"invalid - float64 scale transformation overflow", float64(math.MaxFloat64), "2", nil, true},
+		{"valid - uint8 scale transformation", uint8(math.MaxUint8 / 5), 5, uint8(math.MaxUint8), false},
+		{"invalid - uint8 scale transformation overflow", uint8(math.MaxUint8 / 5), 6, nil, true},
+		{"valid - uint16 scale transformation", uint16(math.MaxUint16 / 5), 5, uint16(math.MaxUint16), false},
+		{"invalid - uint16 scale transformation overflow", uint16(math.MaxUint16 / 5), 6, nil, true},
+		{"valid - uint32 scale transformation", uint32(math.MaxUint32 / 5), 5, uint32(math.MaxUint32), false},
+		{"invalid - uint32 scale transformation overflow", uint32(math.MaxUint32 / 5), 6, nil, true},
+		{"valid - uint64 scale transformation", uint64(math.MaxUint64 / 5), 5, uint64(math.MaxUint64), false},
+		{"valid - int8 scale transformation", int8(10), 10, int8(100), false},
+		{"invalid - int8 scale transformation overflow", int8(10), 30, nil, true},
+		{"valid - int16 scale transformation", int16(10000), 3, int16(30000), false},
+		{"invalid - int16 scale transformation overflow", int16(10000), 4, nil, true},
+		{"valid - int32 scale transformation", int32(1000000000), 2, int32(2000000000), false},
+		{"invalid - int32 scale transformation overflow", int32(1000000000), 3, nil, true},
+		{"valid - int64 scale transformation", int64(1000000000), 1000000000, int64(1000000000000000000), false},
+		{"valid - float32 scale transformation", float32(12.1), 10, float32(121), false},
+		{"invalid - float32 scale transformation overflow", float32(math.MaxFloat32 / 2), 3, nil, true},
+		{"valid - float64 scale transformation", float64(111111111.1), 2, float64(222222222.2), false},
+		{"invalid - float64 scale transformation overflow", float64(math.MaxFloat64), 2, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -107,27 +106,27 @@ func Test_transformReadOffset(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       interface{}
-		offset      string
+		offset      float64
 		expected    interface{}
 		expectedErr bool
 	}{
-		{"valid - uint8 offset transformation", uint8(math.MaxUint8 - 1), "1", uint8(math.MaxUint8), false},
-		{"invalid - uint8 offset transformation overflow", uint8(math.MaxUint8), "1", nil, true},
-		{"valid - uint16 offset transformation", uint16(math.MaxUint16 - 1), "1", uint16(math.MaxUint16), false},
-		{"invalid - uint16 offset transformation overflow", uint16(math.MaxUint16), "1", nil, true},
-		{"valid - uint32 offset transformation", uint32(math.MaxUint32 - 1), "1", uint32(math.MaxUint32), false},
-		{"invalid - uint32 offset transformation overflow", uint32(math.MaxUint32), "1", nil, true},
-		{"valid - uint64 offset transformation", uint64(math.MaxUint64) - uint64(1), "1", uint64(math.MaxUint64), false},
-		{"valid - int8 offset transformation", int8(math.MaxInt8 - 1), "1", int8(math.MaxInt8), false},
-		{"invalid - int8 offset transformation overflow", int8(math.MaxInt8), "1", nil, true},
-		{"valid - int16 offset transformation", int16(math.MaxInt16 - 1), "1", int16(math.MaxInt16), false},
-		{"invalid - int16 offset transformation overflow", int16(math.MaxInt16), "1", nil, true},
-		{"valid - int32 offset transformation", int32(math.MaxInt32 - 1), "1", int32(math.MaxInt32), false},
-		{"invalid - int32 offset transformation overflow", int32(math.MaxInt32), "1", nil, true},
-		{"valid - int64 offset transformation", int64(math.MaxInt64 - 1), "1", int64(math.MaxInt64), false},
-		{"valid - float32 offset transformation", float32(1.1), "1", float32(2.1), false},
-		{"invalid - float32 offset transformation overflow", float32(math.MaxFloat32), fmt.Sprintf("%v", math.MaxFloat32), nil, true},
-		{"valid - float64 offset transformation", float64(1.1), "1", float64(2.1), false},
+		{"valid - uint8 offset transformation", uint8(math.MaxUint8 - 1), 1, uint8(math.MaxUint8), false},
+		{"invalid - uint8 offset transformation overflow", uint8(math.MaxUint8), 1, nil, true},
+		{"valid - uint16 offset transformation", uint16(math.MaxUint16 - 1), 1, uint16(math.MaxUint16), false},
+		{"invalid - uint16 offset transformation overflow", uint16(math.MaxUint16), 1, nil, true},
+		{"valid - uint32 offset transformation", uint32(math.MaxUint32 - 1), 1, uint32(math.MaxUint32), false},
+		{"invalid - uint32 offset transformation overflow", uint32(math.MaxUint32), 1, nil, true},
+		{"valid - uint64 offset transformation", uint64(math.MaxUint64) - uint64(1), 1, uint64(math.MaxUint64), false},
+		{"valid - int8 offset transformation", int8(math.MaxInt8 - 1), 1, int8(math.MaxInt8), false},
+		{"invalid - int8 offset transformation overflow", int8(math.MaxInt8), 1, nil, true},
+		{"valid - int16 offset transformation", int16(math.MaxInt16 - 1), 1, int16(math.MaxInt16), false},
+		{"invalid - int16 offset transformation overflow", int16(math.MaxInt16), 1, nil, true},
+		{"valid - int32 offset transformation", int32(math.MaxInt32 - 1), 1, int32(math.MaxInt32), false},
+		{"invalid - int32 offset transformation overflow", int32(math.MaxInt32), 1, nil, true},
+		{"valid - int64 offset transformation", int64(math.MaxInt64 - 1), 1, int64(math.MaxInt64), false},
+		{"valid - float32 offset transformation", float32(1.1), 1, float32(2.1), false},
+		{"invalid - float32 offset transformation overflow", float32(math.MaxFloat32), math.MaxFloat32, nil, true},
+		{"valid - float64 offset transformation", float64(1.1), 1, float64(2.1), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -147,15 +146,14 @@ func Test_transformReadMask(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       interface{}
-		mask        string
+		mask        uint64
 		expected    interface{}
 		expectedErr bool
 	}{
-		{"valid - uint8 mask transformation", uint8(math.MaxUint8), "15", uint8(15), false},
-		{"valid - uint16 mask transformation", uint16(math.MaxUint16), "256", uint16(256), false},
-		{"valid - uint32 mask transformation", uint32(math.MaxUint32), "256", uint32(256), false},
-		{"valid - uint64 mask transformation", uint64(math.MaxUint64), "256", uint64(256), false},
-		{"invalid - mask value needs to be unsigned integer", uint8(math.MaxInt8), "-256", nil, true},
+		{"valid - uint8 mask transformation", uint8(math.MaxUint8), 15, uint8(15), false},
+		{"valid - uint16 mask transformation", uint16(math.MaxUint16), 256, uint16(256), false},
+		{"valid - uint32 mask transformation", uint32(math.MaxUint32), 256, uint32(256), false},
+		{"valid - uint64 mask transformation", uint64(math.MaxUint64), 256, uint64(256), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,20 +172,18 @@ func Test_transformReadShift(t *testing.T) {
 	tests := []struct {
 		name        string
 		value       interface{}
-		shift       string
+		shift       int64
 		expected    interface{}
 		expectedErr bool
 	}{
-		{"valid - uint8 shift transformation with positive shift value", uint8(0b1), "4", uint8(0b10000), false},
-		{"valid - uint8 shift transformation with negative shift value", uint8(0b11111111), "-4", uint8(0b00001111), false},
-		{"valid - uint16 shift transformation with positive shift value", uint16(0b1), "8", uint16(0b100000000), false},
-		{"valid - uint16 shift transformation with negative shift value", uint16(0b1111111100000000), "-8", uint16(0b0000000011111111), false},
-		{"valid - uint32 shift transformation with positive shift value", uint32(0b1), "16", uint32(0b10000000000000000), false},
-		{"valid - uint32 shift transformation with negative shift value", uint32(0b11111111111111110000000000000000), "-16", uint32(0b00000000000000001111111111111111), false},
-		{"valid - uint64 shift transformation with positive shift value", uint64(0b1), "32", uint64(0b100000000000000000000000000000000), false},
-		{"valid - uint64 shift transformation with negative shift value", uint64(0b1111111111111111111111111111111100000000000000000000000000000000), "-32", uint64(0b0000000000000000000000000000000011111111111111111111111111111111), false},
-		{"invalid - shift value needs to be integer value", uint8(8), "12.34", nil, true},
-		{"invalid - shift value needs to be integer value", uint8(8), "+-4", nil, true},
+		{"valid - uint8 shift transformation with positive shift value", uint8(0b1), 4, uint8(0b10000), false},
+		{"valid - uint8 shift transformation with negative shift value", uint8(0b11111111), -4, uint8(0b00001111), false},
+		{"valid - uint16 shift transformation with positive shift value", uint16(0b1), 8, uint16(0b100000000), false},
+		{"valid - uint16 shift transformation with negative shift value", uint16(0b1111111100000000), -8, uint16(0b0000000011111111), false},
+		{"valid - uint32 shift transformation with positive shift value", uint32(0b1), 16, uint32(0b10000000000000000), false},
+		{"valid - uint32 shift transformation with negative shift value", uint32(0b11111111111111110000000000000000), -16, uint32(0b00000000000000001111111111111111), false},
+		{"valid - uint64 shift transformation with positive shift value", uint64(0b1), 32, uint64(0b100000000000000000000000000000000), false},
+		{"valid - uint64 shift transformation with negative shift value", uint64(0b1111111111111111111111111111111100000000000000000000000000000000), -32, uint64(0b0000000000000000000000000000000011111111111111111111111111111111), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
BREAKING CHANGE: support mask,shift,base,scale,offset in numeric data type

related to edgexfoundry/go-mod-core-contracts#770

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/982

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->