### PR TITLE
feat: enable regex for executing GET command

### DIFF
--- a/example/driver/simpledriver.go
+++ b/example/driver/simpledriver.go
@@ -165,21 +165,19 @@ func (s *SimpleDriver) ProcessCustomConfigChanges(rawWritableConfig interface{})
 func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[string]models.ProtocolProperties, reqs []sdkModels.CommandRequest) (res []*sdkModels.CommandValue, err error) {
 	s.lc.Debugf("SimpleDriver.HandleReadCommands: protocols: %v resource: %v attributes: %v", protocols, reqs[0].DeviceResourceName, reqs[0].Attributes)
 
-	if len(reqs) == 1 {
-		res = make([]*sdkModels.CommandValue, 1)
-		if reqs[0].DeviceResourceName == "SwitchButton" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeBool, s.switchButton)
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Xrotation" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeInt32, s.xRotation)
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Yrotation" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeInt32, s.yRotation)
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Zrotation" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeInt32, s.zRotation)
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Image" {
+	res = make([]*sdkModels.CommandValue, 0)
+	for _, req := range reqs {
+		var cv *sdkModels.CommandValue
+		switch req.DeviceResourceName {
+		case "SwitchButton":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeBool, s.switchButton)
+		case "Xrotation":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeInt32, s.xRotation)
+		case "Yrotation":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeInt32, s.yRotation)
+		case "Zrotation":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeInt32, s.zRotation)
+		case "Image":
 			// Show a binary/image representation of the switch's on/off value
 			buf := new(bytes.Buffer)
 			if s.switchButton {
@@ -187,32 +185,16 @@ func (s *SimpleDriver) HandleReadCommands(deviceName string, protocols map[strin
 			} else {
 				err = getImageBytes(s.serviceConfig.SimpleCustom.OffImageLocation, buf)
 			}
-			cvb, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeBinary, buf.Bytes())
-			res[0] = cvb
-		} else if reqs[0].DeviceResourceName == "StringArray" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeStringArray, s.stringArray)
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Uint8Array" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeUint8Array, []uint8{0, 1, 2})
-			res[0] = cv
-		} else if reqs[0].DeviceResourceName == "Counter" {
-			cv, _ := sdkModels.NewCommandValue(reqs[0].DeviceResourceName, common.ValueTypeObject, s.counter)
-			res[0] = cv
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeBinary, buf.Bytes())
+		case "StringArray":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeStringArray, s.stringArray)
+		case "Uint8Array":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeUint8Array, []uint8{0, 1, 2})
+		case "Counter":
+			cv, _ = sdkModels.NewCommandValue(req.DeviceResourceName, common.ValueTypeObject, s.counter)
 		}
-	} else if len(reqs) == 3 {
-		res = make([]*sdkModels.CommandValue, 3)
-		for i, r := range reqs {
-			var cv *sdkModels.CommandValue
-			switch r.DeviceResourceName {
-			case "Xrotation":
-				cv, _ = sdkModels.NewCommandValue(r.DeviceResourceName, common.ValueTypeInt32, s.xRotation)
-			case "Yrotation":
-				cv, _ = sdkModels.NewCommandValue(r.DeviceResourceName, common.ValueTypeInt32, s.yRotation)
-			case "Zrotation":
-				cv, _ = sdkModels.NewCommandValue(r.DeviceResourceName, common.ValueTypeInt32, s.zRotation)
-			}
-			res[i] = cv
-		}
+
+		res = append(res, cv)
 	}
 
 	s.readCommandsExecuted.Inc(1)

--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -51,7 +51,7 @@ func GetCommand(ctx context.Context, deviceName string, commandName string, quer
 	if cmdExist {
 		res, err = readDeviceCommand(device, commandName, queryParams, dic)
 	} else if regexCmd {
-		res, err = readDeviceResources(device, commandName, queryParams, dic)
+		res, err = readDeviceResourcesRegex(device, commandName, queryParams, dic)
 	} else {
 		res, err = readDeviceResource(device, commandName, queryParams, dic)
 	}
@@ -98,12 +98,12 @@ func SetCommand(ctx context.Context, deviceName string, commandName string, quer
 func readDeviceResource(device models.Device, resourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
 	dr, ok := cache.Profiles().DeviceResource(device.ProfileName, resourceName)
 	if !ok {
-		errMsg := fmt.Sprintf("deviceResource %s not found", resourceName)
+		errMsg := fmt.Sprintf("DeviceResource %s not found", resourceName)
 		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceResource is not write-only
 	if dr.Properties.ReadWrite == common.ReadWrite_W {
-		errMsg := fmt.Sprintf("deviceResource %s is marked as write-only", dr.Name)
+		errMsg := fmt.Sprintf("DeviceResource %s is marked as write-only", dr.Name)
 		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 
@@ -140,31 +140,40 @@ func readDeviceResource(device models.Device, resourceName string, attributes st
 	return res, nil
 }
 
-func readDeviceResources(device models.Device, regexResourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
+func readDeviceResourcesRegex(device models.Device, regexResourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
 	deviceResources, ok := cache.Profiles().DeviceResourcesByRegex(device.ProfileName, regexResourceName)
 	if !ok || len(deviceResources) == 0 {
-		errMsg := fmt.Sprintf("Regex deviceResource %s not found", regexResourceName)
+		errMsg := fmt.Sprintf("Regex DeviceResource %s not found", regexResourceName)
 		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 
-	reqs := make([]sdkModels.CommandRequest, len(deviceResources))
-	for i, dr := range deviceResources {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	reqs := make([]sdkModels.CommandRequest, 0)
+	for _, dr := range deviceResources {
 		// check deviceResource is not write-only
 		if dr.Properties.ReadWrite == common.ReadWrite_W {
-			errMsg := fmt.Sprintf("deviceResource %s is marked as write-only", dr.Name)
-			return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
+			lc.Debugf("DeviceResource %s is marked as write-only, skipping adding to RegEx Read list", dr.Name)
+			continue
 		}
 
 		// prepare CommandRequest
-		reqs[i].DeviceResourceName = dr.Name
-		reqs[i].Attributes = dr.Attributes
+		var req sdkModels.CommandRequest
+		req.DeviceResourceName = dr.Name
+		req.Attributes = dr.Attributes
 		if attributes != "" {
-			if len(reqs[i].Attributes) <= 0 {
-				reqs[i].Attributes = make(map[string]interface{})
+			if len(req.Attributes) <= 0 {
+				req.Attributes = make(map[string]any)
 			}
-			reqs[i].Attributes[sdkCommon.URLRawQuery] = attributes
+			req.Attributes[sdkCommon.URLRawQuery] = attributes
 		}
-		reqs[i].Type = dr.Properties.ValueType
+		req.Type = dr.Properties.ValueType
+
+		reqs = append(reqs, req)
+	}
+
+	if len(reqs) == 0 {
+		errMsg := fmt.Sprintf("no readable resources matched with %s", regexResourceName)
+		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 
 	// execute protocol-specific read operation
@@ -188,12 +197,12 @@ func readDeviceResources(device models.Device, regexResourceName string, attribu
 func readDeviceCommand(device models.Device, commandName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
 	dc, ok := cache.Profiles().DeviceCommand(device.ProfileName, commandName)
 	if !ok {
-		errMsg := fmt.Sprintf("deviceCommand %s not found", commandName)
+		errMsg := fmt.Sprintf("DeviceCommand %s not found", commandName)
 		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceCommand is not write-only
 	if dc.ReadWrite == common.ReadWrite_W {
-		errMsg := fmt.Sprintf("deviceCommand %s is marked as write-only", dc.Name)
+		errMsg := fmt.Sprintf("DeviceCommand %s is marked as write-only", dc.Name)
 		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 	// check ResourceOperation count does not exceed MaxCmdOps defined in configuration
@@ -210,7 +219,7 @@ func readDeviceCommand(device models.Device, commandName string, attributes stri
 		// check the deviceResource in ResourceOperation actually exist
 		dr, ok := cache.Profiles().DeviceResource(device.ProfileName, drName)
 		if !ok {
-			errMsg := fmt.Sprintf("deviceResource %s in GET commnd %s for %s not defined", drName, dc.Name, device.Name)
+			errMsg := fmt.Sprintf("DeviceResource %s in GET commnd %s for %s not defined", drName, dc.Name, device.Name)
 			return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 		}
 
@@ -245,12 +254,12 @@ func readDeviceCommand(device models.Device, commandName string, attributes stri
 func writeDeviceResource(device models.Device, resourceName string, attributes string, requests map[string]any, dic *di.Container) (*dtos.Event, errors.EdgeX) {
 	dr, ok := cache.Profiles().DeviceResource(device.ProfileName, resourceName)
 	if !ok {
-		errMsg := fmt.Sprintf("deviceResource %s not found", resourceName)
+		errMsg := fmt.Sprintf("DeviceResource %s not found", resourceName)
 		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceResource is not read-only
 	if dr.Properties.ReadWrite == common.ReadWrite_R {
-		errMsg := fmt.Sprintf("deviceResource %s is marked as read-only", dr.Name)
+		errMsg := fmt.Sprintf("DeviceResource %s is marked as read-only", dr.Name)
 		return nil, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 
@@ -260,7 +269,7 @@ func writeDeviceResource(device models.Device, resourceName string, attributes s
 		if dr.Properties.DefaultValue != "" {
 			v = dr.Properties.DefaultValue
 		} else {
-			errMsg := fmt.Sprintf("deviceResource %s not found in request body and no default value defined", dr.Name)
+			errMsg := fmt.Sprintf("DeviceResource %s not found in request body and no default value defined", dr.Name)
 			return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 		}
 	}
@@ -311,12 +320,12 @@ func writeDeviceResource(device models.Device, resourceName string, attributes s
 func writeDeviceCommand(device models.Device, commandName string, attributes string, requests map[string]any, dic *di.Container) (*dtos.Event, errors.EdgeX) {
 	dc, ok := cache.Profiles().DeviceCommand(device.ProfileName, commandName)
 	if !ok {
-		errMsg := fmt.Sprintf("deviceCommand %s not found", commandName)
+		errMsg := fmt.Sprintf("DeviceCommand %s not found", commandName)
 		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceCommand is not read-only
 	if dc.ReadWrite == common.ReadWrite_R {
-		errMsg := fmt.Sprintf("deviceCommand %s is marked as read-only", dc.Name)
+		errMsg := fmt.Sprintf("DeviceCommand %s is marked as read-only", dc.Name)
 		return nil, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 	// check ResourceOperation count does not exceed MaxCmdOps defined in configuration
@@ -333,7 +342,7 @@ func writeDeviceCommand(device models.Device, commandName string, attributes str
 		// check the deviceResource in ResourceOperation actually exist
 		dr, ok := cache.Profiles().DeviceResource(device.ProfileName, drName)
 		if !ok {
-			errMsg := fmt.Sprintf("deviceResource %s in SET commnd %s for %s not defined", drName, dc.Name, device.Name)
+			errMsg := fmt.Sprintf("DeviceResource %s in SET commnd %s for %s not defined", drName, dc.Name, device.Name)
 			return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 		}
 
@@ -345,7 +354,7 @@ func writeDeviceCommand(device models.Device, commandName string, attributes str
 			} else if dr.Properties.DefaultValue != "" {
 				value = dr.Properties.DefaultValue
 			} else {
-				errMsg := fmt.Sprintf("deviceResource %s not found in request body and no default value defined", dr.Name)
+				errMsg := fmt.Sprintf("DeviceResource %s not found in request body and no default value defined", dr.Name)
 				return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 			}
 		}

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2022 IOTech Ltd
+// Copyright (C) 2019-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -86,7 +86,7 @@ func readResource(e *Executor, dic *di.Container) (event *dtos.Event, err errors
 	vars[common.Name] = e.deviceName
 	vars[common.Command] = e.sourceName
 
-	res, err := application.GetCommand(context.Background(), e.deviceName, e.sourceName, "", dic)
+	res, err := application.GetCommand(context.Background(), e.deviceName, e.sourceName, "", true, dic)
 	if err != nil {
 		return event, err
 	}

--- a/internal/cache/profiles_test.go
+++ b/internal/cache/profiles_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2021 IOTech Ltd
+// Copyright (C) 2021-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -188,6 +188,29 @@ func Test_profileCache_ResourceOperation(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, ro, tt.res)
 			}
+		})
+	}
+}
+
+func Test_profileCache_DeviceResourcesByRegex(t *testing.T) {
+	newProfileCache([]models.DeviceProfile{testProfile})
+
+	tests := []struct {
+		name              string
+		profileName       string
+		regexResourceName string
+		deviceResources   []models.DeviceResource
+		expected          bool
+	}{
+		{"valid - resources found by regex pattern", TestProfile, ".+Resource", testProfile.DeviceResources, true},
+		{"Valid -  resources not found by regex pattern", TestProfile, "nil", nil, true},
+		{"invalid - profile not found", "nil", "%2E%2B-resource", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, ok := pc.DeviceResourcesByRegex(tt.profileName, tt.regexResourceName)
+			assert.Equal(t, res, tt.deviceResources, "DeviceResource returns wrong deviceResource")
+			assert.Equal(t, ok, tt.expected, "DeviceResource returns opposite result")
 		})
 	}
 }

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -9,7 +9,6 @@ package common
 
 import (
 	"context"
-	"net/url"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
@@ -72,7 +71,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	ctx = context.WithValue(ctx, common.ContentType, encoding) // nolint: staticcheck
 	envelope := types.NewMessageEnvelope(bytes, ctx)
 	serviceName := container.DeviceServiceFrom(dic.Get).Name
-	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, serviceName, event.ProfileName, event.DeviceName, url.QueryEscape(event.SourceName))
+	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, serviceName, event.ProfileName, event.DeviceName, common.URLEncode(event.SourceName))
 	err = mc.Publish(envelope, publishTopic)
 	if err != nil {
 		lc.Errorf("Failed to publish event to MessageBus: %s", err)

--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -40,7 +40,7 @@ func (c *RestController) GetCommand(w http.ResponseWriter, r *http.Request) {
 	}
 
 	regexCmd := true
-	if useRegex, ok := reserved[common.RegexCommand]; ok && useRegex[0] == common.ValueFalse {
+	if useRegex := reserved.Get(common.RegexCommand); useRegex == common.ValueFalse {
 		regexCmd = false
 	}
 
@@ -50,13 +50,13 @@ func (c *RestController) GetCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// push event to CoreData if specified (default no)
-	if ok, exist := reserved[common.PushEvent]; exist && ok[0] == common.ValueTrue {
+	// push event to CoreData if specified (default false)
+	if pushEvent := reserved.Get(common.PushEvent); pushEvent == common.ValueTrue {
 		go sdkCommon.SendEvent(event, correlationId, c.dic)
 	}
 
-	// return event in http response if specified (default yes)
-	if ok, exist := reserved[common.ReturnEvent]; !exist || ok[0] == common.ValueTrue {
+	// return event in http response if specified (default true)
+	if returnEvent := reserved.Get(common.ReturnEvent); returnEvent == "" || returnEvent == common.ValueTrue {
 		res := responses.NewEventResponse("", "", http.StatusOK, *event)
 		c.sendEventResponse(w, r, res, http.StatusOK)
 		return

--- a/internal/controller/http/command.go
+++ b/internal/controller/http/command.go
@@ -39,7 +39,12 @@ func (c *RestController) GetCommand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event, err := application.GetCommand(ctx, deviceName, commandName, queryParams, c.dic)
+	regexCmd := true
+	if useRegex, ok := reserved[common.RegexCommand]; ok && useRegex[0] == common.ValueFalse {
+		regexCmd = false
+	}
+
+	event, err := application.GetCommand(ctx, deviceName, commandName, queryParams, regexCmd, c.dic)
 	if err != nil {
 		c.sendEdgexError(w, r, err, common.ApiDeviceNameCommandNameRoute)
 		return

--- a/internal/controller/http/command_test.go
+++ b/internal/controller/http/command_test.go
@@ -56,6 +56,8 @@ const (
 	readOnlyResource  = "ro-resource"
 	writeOnlyResource = "wo-resource"
 	objectResource    = "object-resource"
+
+	testRegexResource = "^t.+-resource"
 )
 
 func mockDic() *di.Container {
@@ -218,6 +220,7 @@ func TestRestController_GetCommand(t *testing.T) {
 	}{
 		{"valid - read device resource", testDevice, testResource, http.StatusOK},
 		{"valid - read device command", testDevice, testCommand, http.StatusOK},
+		{"valid - read regex device resource", testDevice, testRegexResource, http.StatusOK},
 		{"invalid - device name parameter is empty", "", testResource, http.StatusBadRequest},
 		{"invalid - command is empty", testDevice, "", http.StatusBadRequest},
 		{"invalid - device name not found", "notFound", testCommand, http.StatusNotFound},

--- a/openapi/v3/device-sdk.yaml
+++ b/openapi/v3/device-sdk.yaml
@@ -387,6 +387,16 @@ paths:
             default: true
           example: false
           description: "If set to false, there will be no Event returned in the http response"
+        - in: query
+          name: ds-regexcmd
+          schema:
+            type: string
+            enum:
+              - true
+              - false
+            default: true
+          example: false
+          description: "If set to false, the command name will be treated as normal string instead of regex syntax"
       responses:
         '200':
           description: String as returned by the device/sensor through the device service.


### PR DESCRIPTION
SDK now default treat resource name as regex pattern and will return
readings whose resource name matches against the regex pattern.

For protocol whose resource name contains special character, specify
'ds-regexcmd=false' in query parameter to make it as normal resource name.

closes edgexfoundry/edgex-go#4279

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/991

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Run `device-simple` from this branch
2. Run core-command with URL-escaped regex command name: `.rotation` or `[A-Z]+rotation` and query parameter `ds-regexcmd=true`
```shell
$ curl http://localhost:59882/api/v2/device/name/Simple-Device01/%2Erotation
{"apiVersion":"v2","statusCode":200,"event":{"apiVersion":"v2","id":"183d4439-fe9c-4706-9f79-829dce9e2d39","deviceName":"Simple-Device01","profileName":"Simple-Device","sourceName":"[A-Z]+rotation","origin":1678793090008476000,"readings":[{"id":"a527b677-069b-41d0-a4d5-231a7b69b423","origin":1678793090008476000,"deviceName":"Simple-Device01","resourceName":"Xrotation","profileName":"Simple-Device","valueType":"Int32","units":"rpm","value":"0"},{"id":"afb88931-82f0-422f-b5d6-45985db08566","origin":1678793090008476000,"deviceName":"Simple-Device01","resourceName":"Yrotation","profileName":"Simple-Device","valueType":"Int32","units":"rpm","value":"0"},{"id":"b0453fe5-9c1d-4019-8b7a-6555f5fcf361","origin":1678793090008476000,"deviceName":"Simple-Device01","resourceName":"Zrotation","profileName":"Simple-Device","valueType":"Int32","units":"rpm","value":"0"}]}}%
```
3. Check `device-simple` logs has something similiar:
```shell
level=DEBUG ts=2023-03-22T04:29:03.044589908Z app=device-simple source=command.go:64 msg="GET Device Command successfully. Device: Simple-Device01, Source: .rotation, X-Correlation-ID: 15b4c7ed-53f9-4aa4-bb10-6a2b6bf70493"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->