### PR TITLE
fix: Retrieve the event tags before mapping cmd value

### DIFF
--- a/internal/transformer/transform.go
+++ b/internal/transformer/transform.go
@@ -89,6 +89,10 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 			return nil, errors.NewCommonEdgeXWrapper(err)
 		}
 
+		for key, value := range cv.Tags {
+			tags[key] = value
+		}
+
 		// ResourceOperation mapping
 		ro, err := cache.Profiles().ResourceOperation(device.ProfileName, cv.DeviceResourceName)
 		if err != nil {
@@ -99,10 +103,6 @@ func CommandValuesToEventDTO(cvs []*models.CommandValue, deviceName string, sour
 			if ok {
 				cv = newCV
 			}
-		}
-
-		for key, value := range cv.Tags {
-			tags[key] = value
 		}
 
 		reading, err := commandValueToReading(cv, device.Name, device.ProfileName, dr.Properties.MediaType, origin)


### PR DESCRIPTION
Retrieve the event tags before mapping cmd value to prevent tags lost.

Close #1397

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run unit test and test the command API.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->