### PR TITLE
fix: update regex resourceName match logic

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -141,7 +142,12 @@ func readDeviceResource(device models.Device, resourceName string, attributes st
 }
 
 func readDeviceResourcesRegex(device models.Device, regexResourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
-	deviceResources, ok := cache.Profiles().DeviceResourcesByRegex(device.ProfileName, regexResourceName)
+	regex, err := regexp.CompilePOSIX(regexResourceName)
+	if err != nil {
+		return res, errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to CompilePOSIX resource name", err)
+	}
+
+	deviceResources, ok := cache.Profiles().DeviceResourcesByRegex(device.ProfileName, regex)
 	if !ok || len(deviceResources) == 0 {
 		errMsg := fmt.Sprintf("Regex DeviceResource %s not found", regexResourceName)
 		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)

--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -96,16 +96,16 @@ func SetCommand(ctx context.Context, deviceName string, commandName string, quer
 	return event, nil
 }
 
-func readDeviceResource(device models.Device, resourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
+func readDeviceResource(device models.Device, resourceName string, attributes string, dic *di.Container) (*dtos.Event, errors.EdgeX) {
 	dr, ok := cache.Profiles().DeviceResource(device.ProfileName, resourceName)
 	if !ok {
 		errMsg := fmt.Sprintf("DeviceResource %s not found", resourceName)
-		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceResource is not write-only
 	if dr.Properties.ReadWrite == common.ReadWrite_W {
 		errMsg := fmt.Sprintf("DeviceResource %s is marked as write-only", dr.Name)
-		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 
 	var req sdkModels.CommandRequest
@@ -128,29 +128,29 @@ func readDeviceResource(device models.Device, resourceName string, attributes st
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
 		errMsg := fmt.Sprintf("error reading DeviceResource %s for %s", dr.Name, device.Name)
-		return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
 	// convert CommandValue to Event
 	configuration := container.ConfigurationFrom(dic.Get)
-	res, edgexErr = transformer.CommandValuesToEventDTO(results, device.Name, dr.Name, configuration.Device.DataTransform, dic)
-	if edgexErr != nil {
-		return res, errors.NewCommonEdgeX(errors.KindServerError, "failed to convert CommandValue to Event", err)
+	event, err := transformer.CommandValuesToEventDTO(results, device.Name, dr.Name, configuration.Device.DataTransform, dic)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to convert CommandValue to Event", err)
 	}
 
-	return res, nil
+	return event, nil
 }
 
-func readDeviceResourcesRegex(device models.Device, regexResourceName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
+func readDeviceResourcesRegex(device models.Device, regexResourceName string, attributes string, dic *di.Container) (*dtos.Event, errors.EdgeX) {
 	regex, err := regexp.CompilePOSIX(regexResourceName)
 	if err != nil {
-		return res, errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to CompilePOSIX resource name", err)
+		return nil, errors.NewCommonEdgeX(errors.KindContractInvalid, "failed to CompilePOSIX resource name", err)
 	}
 
 	deviceResources, ok := cache.Profiles().DeviceResourcesByRegex(device.ProfileName, regex)
 	if !ok || len(deviceResources) == 0 {
 		errMsg := fmt.Sprintf("Regex DeviceResource %s not found", regexResourceName)
-		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
@@ -179,7 +179,7 @@ func readDeviceResourcesRegex(device models.Device, regexResourceName string, at
 
 	if len(reqs) == 0 {
 		errMsg := fmt.Sprintf("no readable resources matched with %s", regexResourceName)
-		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 
 	// execute protocol-specific read operation
@@ -187,35 +187,35 @@ func readDeviceResourcesRegex(device models.Device, regexResourceName string, at
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
 		errMsg := fmt.Sprintf("error reading Regex DeviceResource(s) %s for %s", regexResourceName, device.Name)
-		return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
 	// convert CommandValue to Event
 	configuration := container.ConfigurationFrom(dic.Get)
-	res, edgexErr = transformer.CommandValuesToEventDTO(results, device.Name, regexResourceName, configuration.Device.DataTransform, dic)
-	if edgexErr != nil {
-		return res, errors.NewCommonEdgeX(errors.KindServerError, "failed to convert CommandValue to Event", err)
+	event, err := transformer.CommandValuesToEventDTO(results, device.Name, regexResourceName, configuration.Device.DataTransform, dic)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to convert CommandValue to Event", err)
 	}
 
-	return res, nil
+	return event, nil
 }
 
-func readDeviceCommand(device models.Device, commandName string, attributes string, dic *di.Container) (res *dtos.Event, edgexErr errors.EdgeX) {
+func readDeviceCommand(device models.Device, commandName string, attributes string, dic *di.Container) (*dtos.Event, errors.EdgeX) {
 	dc, ok := cache.Profiles().DeviceCommand(device.ProfileName, commandName)
 	if !ok {
 		errMsg := fmt.Sprintf("DeviceCommand %s not found", commandName)
-		return res, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindEntityDoesNotExist, errMsg, nil)
 	}
 	// check deviceCommand is not write-only
 	if dc.ReadWrite == common.ReadWrite_W {
 		errMsg := fmt.Sprintf("DeviceCommand %s is marked as write-only", dc.Name)
-		return res, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindNotAllowed, errMsg, nil)
 	}
 	// check ResourceOperation count does not exceed MaxCmdOps defined in configuration
 	configuration := container.ConfigurationFrom(dic.Get)
 	if len(dc.ResourceOperations) > configuration.Device.MaxCmdOps {
 		errMsg := fmt.Sprintf("GET command %s exceed device %s MaxCmdOps (%d)", dc.Name, device.Name, configuration.Device.MaxCmdOps)
-		return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 	}
 
 	// prepare CommandRequests
@@ -226,7 +226,7 @@ func readDeviceCommand(device models.Device, commandName string, attributes stri
 		dr, ok := cache.Profiles().DeviceResource(device.ProfileName, drName)
 		if !ok {
 			errMsg := fmt.Sprintf("DeviceResource %s in GET commnd %s for %s not defined", drName, dc.Name, device.Name)
-			return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
+			return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, nil)
 		}
 
 		reqs[i].DeviceResourceName = dr.Name
@@ -245,16 +245,16 @@ func readDeviceCommand(device models.Device, commandName string, attributes stri
 	results, err := driver.HandleReadCommands(device.Name, device.Protocols, reqs)
 	if err != nil {
 		errMsg := fmt.Sprintf("error reading DeviceCommand %s for %s", dc.Name, device.Name)
-		return res, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
 	// convert CommandValue to Event
-	res, edgexErr = transformer.CommandValuesToEventDTO(results, device.Name, dc.Name, configuration.Device.DataTransform, dic)
-	if edgexErr != nil {
-		return res, errors.NewCommonEdgeX(errors.KindServerError, "failed to transform CommandValue to Event", edgexErr)
+	event, err := transformer.CommandValuesToEventDTO(results, device.Name, dc.Name, configuration.Device.DataTransform, dic)
+	if err != nil {
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to transform CommandValue to Event", err)
 	}
 
-	return res, nil
+	return event, nil
 }
 
 func writeDeviceResource(device models.Device, resourceName string, attributes string, requests map[string]any, dic *di.Container) (*dtos.Event, errors.EdgeX) {

--- a/internal/cache/profiles.go
+++ b/internal/cache/profiles.go
@@ -26,7 +26,7 @@ type ProfileCache interface {
 	Update(profile models.DeviceProfile) errors.EdgeX
 	RemoveByName(name string) errors.EdgeX
 	DeviceResource(profileName string, resourceName string) (models.DeviceResource, bool)
-	DeviceResourcesByRegex(profileName string, regex string) ([]models.DeviceResource, bool)
+	DeviceResourcesByRegex(profileName string, regex *regexp.Regexp) ([]models.DeviceResource, bool)
 	DeviceCommand(profileName string, commandName string) (models.DeviceCommand, bool)
 	ResourceOperation(profileName string, deviceResource string) (models.ResourceOperation, errors.EdgeX)
 }
@@ -170,7 +170,7 @@ func (p *profileCache) DeviceResource(profileName string, resourceName string) (
 }
 
 // DeviceResourcesByRegex returns matched DeviceResource list with given profileName and regex pattern
-func (p *profileCache) DeviceResourcesByRegex(profileName string, regex string) ([]models.DeviceResource, bool) {
+func (p *profileCache) DeviceResourcesByRegex(profileName string, regex *regexp.Regexp) ([]models.DeviceResource, bool) {
 	p.mutex.RLock()
 	defer p.mutex.RUnlock()
 
@@ -181,8 +181,13 @@ func (p *profileCache) DeviceResourcesByRegex(profileName string, regex string) 
 
 	var res []models.DeviceResource
 	for _, dr := range drs {
-		match, _ := regexp.MatchString(regex, dr.Name)
-		if match {
+		if dr.Name == regex.String() {
+			res = append(res, dr)
+			continue
+		}
+
+		matchString := regex.FindString(dr.Name)
+		if matchString == dr.Name {
 			res = append(res, dr)
 		}
 	}


### PR DESCRIPTION
Use `CompilePOSIX` and `FindString` and check that the string found is the entire resource name

closes #1418

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Build and Run `device-virtual` from this branch
2. Verify autoevent `Uint16` returns only 1 reading `Uint16`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->