### PR TITLE
feat!: Using url.PathUnescape for decoding API path

### DIFF
--- a/internal/controller/http/correlation/middleware.go
+++ b/internal/controller/http/correlation/middleware.go
@@ -54,7 +54,7 @@ func UrlDecodeMiddleware(lc logger.LoggingClient) func(http.Handler) http.Handle
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			vars := mux.Vars(r)
 			for k, v := range vars {
-				unescape, err := url.QueryUnescape(v)
+				unescape, err := url.PathUnescape(v)
 				if err != nil {
 					lc.Debugf("failed to decode the %s from the value %s", k, v)
 					return

--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -72,7 +72,7 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 
 				// expected command response topic scheme: #/<service-name>/<device-name>/<command-name>/<method>
 				deviceName := topicLevels[length-3]
-				commandName, err := url.QueryUnescape(topicLevels[length-2])
+				commandName, err := url.PathUnescape(topicLevels[length-2])
 				if err != nil {
 					lc.Errorf("Failed to unescape command name '%s'", commandName)
 					continue


### PR DESCRIPTION
BREAKING CHANGE: Use PathUnescape for decoding API path to consist with the change from MQTT topic, the MQTT topic path will encode with url.PathEscape.

Close #1443

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core services and device service to check whether the event can publish to the message bus.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->