### PR TITLE
feat: Consume new -d/--dev Dev Mode command-line flag

### DIFF
--- a/example/cmd/device-simple/res/configuration.yaml
+++ b/example/cmd/device-simple/res/configuration.yaml
@@ -11,15 +11,7 @@ Service:
   Port: 59999 # Device service are assigned the 599xx range
   StartupMsg: device simple started
 
-# uncomment when running from command-line in hybrid mode with -cp -o flags
-#Registry:
-#  Host: "localhost"
-#Clients:
-# core-metadata:
-#   Host: localhost # uncomment when running from command-line in hybrid mode
-
 MessageBus:
-#  Host: localhost # uncomment when running from command-line in hybrid mode
   Optional:
     ClientId: device-simple
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.38
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.25
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71 h1:+lMhxjPuvRJ6syy1mzI1wbjfqzJPmkNMBruaiCUcEQQ=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.71/go.mod h1:GAoMAkiij8VjRAb9jRw3+skSE/VPDXBqhi5jsGSwIVM=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73 h1:zoUJgeH2fdwWQ3qV0kiwNvYI2LMDpd6tjAjhNZyX3T8=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.73/go.mod h1:VHs/2Ri69ftKnuVw7dwNmNKOpODml90Db9e2Wcg8DPk=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10 h1:iDuAO3vpBQnlQuFhai/NATbJkiYXxo3bPCtSnFl07Yw=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10/go.mod h1:8RlYm5CPzZgUsfXDWVP1TIeUMhsDNIdRdj1HXdomtOI=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.38 h1:FSu4b6DqviexPsS/ECBR9YgkVB76VSgyMCMDUvyGgNM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,8 @@ import (
 type ConfigurationStruct struct {
 	// WritableInfo contains configuration settings that can be changed in the Registry .
 	Writable WritableInfo
-	// Clients is a map of services used by a DS.
-	Clients map[string]bootstrapConfig.ClientInfo
+	// Clients is a collection of services used by a DS.
+	Clients bootstrapConfig.ClientsCollection
 	// Registry contains registry-specific settings.
 	Registry bootstrapConfig.RegistryInfo
 	// Service contains DeviceService-specific settings.
@@ -68,10 +68,10 @@ func (c *ConfigurationStruct) UpdateWritableFromRaw(rawWritable interface{}) boo
 // into an bootstrapConfig.BootstrapConfiguration struct contained within ConfigurationStruct).
 func (c *ConfigurationStruct) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
 	return bootstrapConfig.BootstrapConfiguration{
-		Clients:    c.Clients,
-		Service:    c.Service,
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Clients:    &c.Clients,
+		Service:    &c.Service,
+		Registry:   &c.Registry,
+		MessageBus: &c.MessageBus,
 	}
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -134,7 +134,7 @@ func (s *deviceService) Run() error {
 			httpServer.BootstrapHandler,
 			messageBusBootstrapHandler,
 			handlers.NewServiceMetrics(s.serviceKey).BootstrapHandler, // Must be after Messaging
-			handlers.NewClientsBootstrap().BootstrapHandler,
+			handlers.NewClientsBootstrap(s.flags.InDevMode()).BootstrapHandler,
 			autoevent.BootstrapHandler,
 			NewBootstrap(s, router).BootstrapHandler,
 			autodiscovery.BootstrapHandler,


### PR DESCRIPTION
Dev Mode is used when running service locally with the other services running in Docker (aka hybrid mode). This causes all the Host settings pulled from common configuration to be overridden with the value localhost.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
https://github.com/edgexfoundry/edgex-docs/pull/1040

## Testing Instructions
build device-simple with this branch
run `device-simple -cp`
Verify it hangs do to Subscribe error issue
run `device-simple -cp -d`
Verify service successfully bootstraps
Enable DEBUG logging from Consul
Verify service is publishing events

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->