### PR TITLE
fix: typo in calls to GetDeviceByName

### DIFF
--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -69,7 +69,7 @@ func (s *deviceService) DeviceExistsForName(name string) bool {
 // RemoveDeviceByName removes the specified Device by name from the cache and ensures that the
 // instance in Core Metadata is also removed.
 func (s *deviceService) RemoveDeviceByName(name string) error {
-	if _, err := s.GetDeviceByName(s.Name()); err != nil {
+	if _, err := s.GetDeviceByName(name); err != nil {
 		return err
 	}
 
@@ -109,7 +109,7 @@ func (s *deviceService) PatchDevice(updateDevice dtos.UpdateDevice) error {
 		return errors.NewCommonEdgeX(errors.KindContractInvalid, msg, nil)
 	}
 
-	if _, err := s.GetDeviceByName(s.Name()); err != nil {
+	if _, err := s.GetDeviceByName(*updateDevice.Name); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Build device-onvif-camera using the lastet sdk
- Run the service and see that cameras are added to the system
- Observe that there are errors updating the device during the checkstatus calls:
  ```
  failed to find Device device-onvif-camera in cache
  ```
- Clone this branch to the same top-level directory as device-onvif-camera
- Build device-onvif-camera using this code (use replace in go.mod file)
```
replace (
	github.com/edgexfoundry/device-sdk-go/v3 => ../device-sdk-go
)
```
- Run the service and see that cameras are added to the system
- Observe that there are no more errors updating the device during the checkstatus calls:
```
Patching managed Device unknown_unknown_3fa1fe68-b915-4053-a3e1-1027f5ea88f4
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

Fixes #1456