### PR TITLE
feat: Implement URI for Profile, Device, & Provision Watcher

### DIFF
--- a/example/cmd/device-simple/res/configuration.yaml
+++ b/example/cmd/device-simple/res/configuration.yaml
@@ -19,8 +19,8 @@ MessageBus:
 Device:
   AsyncBufferSize: 1
   # These have common values (currently), but must be here for service local env overrides to apply when customized
-  ProfilesDir: "./res/profiles"
-  DevicesDir: "./res/devices"
+  ProfilesDir: ./res/profiles
+  DevicesDir: ./res/devices
   # Only needed if device service implements auto provisioning
   ProvisionWatchersDir: ./res/provisionwatchers
 # Example structured custom configuration

--- a/internal/provision/common.go
+++ b/internal/provision/common.go
@@ -6,6 +6,8 @@
 package provision
 
 import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"net/url"
 	"strings"
 )
 
@@ -25,4 +27,18 @@ func GetFileType(fullPath string) FileType {
 	} else {
 		return OTHER
 	}
+}
+
+func GetFullAndParsedURI(baseUrl, file, description string, lc logger.LoggingClient) (string, *url.URL) {
+	fullPath, err := url.JoinPath(baseUrl, file)
+	if err != nil {
+		lc.Error("could not join URI path for %s %s: %v", description, file, err)
+		return "", nil
+	}
+	parsedFullPath, err := url.Parse(fullPath)
+	if err != nil {
+		lc.Error("could not parse URI path for %s %s: %v", description, file, err)
+		return "", nil
+	}
+	return fullPath, parsedFullPath
 }

--- a/internal/provision/common.go
+++ b/internal/provision/common.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"strings"
+)
+
+type FileType int
+
+const (
+	YAML FileType = iota
+	JSON
+	OTHER
+)
+
+func GetFileType(fullPath string) FileType {
+	if strings.HasSuffix(fullPath, yamlExt) || strings.HasSuffix(fullPath, ymlExt) {
+		return YAML
+	} else if strings.HasSuffix(fullPath, ".json") {
+		return JSON
+	} else {
+		return OTHER
+	}
+}

--- a/internal/provision/common_test.go
+++ b/internal/provision/common_test.go
@@ -1,0 +1,57 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/url"
+	"path"
+	"testing"
+)
+
+func Test_GetFileType(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		expectedFileType FileType
+	}{
+		{"valid get Yaml file type", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), YAML},
+		{"valid get Json file type", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.json"), JSON},
+		{"valid get other file type", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.bogus"), OTHER},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualType := GetFileType(tt.path)
+			assert.Equal(t, tt.expectedFileType, actualType)
+		})
+	}
+}
+
+func Test_GetFullAndRedactedURI(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseURI          string
+		file             string
+		expectedURI      string
+		expectedRedacted string
+	}{
+		{"valid no secret uri", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/devices.yaml", "device-simple.yaml", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/device-simple.yaml", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/device-simple.yaml"},
+		{"valid query secret uri", "https://raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/index.json?edgexSecretName=githubCredentials", "device-simple.yaml", "https://raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/device-simple.yaml?edgexSecretName=githubCredentials", "https://raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/device-simple.yaml?edgexSecretName=githubCredentials"},
+		{"valid query secret uri", "https://myuser:mypassword@raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/index.json", "device-simple.yaml", "https://myuser:mypassword@raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/device-simple.yaml", "https://myuser:xxxxx@raw.githubusercontent.com/edgexfoundry/device-simple/main/devices/device-simple.yaml"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testURI, err := url.Parse(tt.baseURI)
+			require.NoError(t, err)
+			lc := logger.MockLogger{}
+			actualURI, actualRedacted := GetFullAndRedactedURI(testURI, tt.file, "test", lc)
+			assert.Equal(t, tt.expectedURI, actualURI)
+			assert.Equal(t, tt.expectedRedacted, actualRedacted)
+		})
+	}
+}

--- a/internal/provision/devices.go
+++ b/internal/provision/devices.go
@@ -117,6 +117,7 @@ func loadDevicesFromFile(path, serviceName string, lc logger.LoggingClient) ([]r
 }
 
 func loadDevicesFromURI(inputURI string, parsedURI *url.URL, serviceName string, secretProvider interfaces.SecretProvider, lc logger.LoggingClient) ([]requests.AddDeviceRequest, errors.EdgeX) {
+	// the input URI contains the index file containing the Device list to be loaded
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Devices list from URI %s", parsedURI.Redacted()), err)

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
 )
@@ -31,7 +32,8 @@ func Test_processDevices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
-			cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			err := cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			require.NoError(t, err)
 			addDeviceRequests := processDevices(tt.path, tt.path, TestDeviceService, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumDevices, len(addDeviceRequests))
 		})

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+)
+
+func Test_processDevices(t *testing.T) {
+	tests := []struct {
+		name                string
+		path                string
+		secretProvider      interfaces.SecretProvider
+		expectedNumProfiles int
+	}{
+		{"valid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), nil, 1},
+		{"valid load device from uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/simple-device.yml", nil, 1},
+		{"invalid load device empty path", "", nil, 0},
+		{"invalid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "bogus.yml"), nil, 0},
+		{"invalid load device invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/bogus.yml", nil, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var addDeviceRequests []requests.AddDeviceRequest
+			lc := logger.MockLogger{}
+			dic, _ := NewMockDIC()
+			cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			addDeviceRequests = processDevices(tt.path, TestDeviceService, tt.secretProvider, lc, addDeviceRequests)
+			assert.Equal(t, tt.expectedNumProfiles, len(addDeviceRequests))
+		})
+	}
+}

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/stretchr/testify/assert"
 	"path"
 	"testing"
@@ -17,25 +16,24 @@ import (
 
 func Test_processDevices(t *testing.T) {
 	tests := []struct {
-		name                string
-		path                string
-		secretProvider      interfaces.SecretProvider
-		expectedNumProfiles int
+		name               string
+		path               string
+		secretProvider     interfaces.SecretProvider
+		expectedNumDevices int
 	}{
 		{"valid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), nil, 1},
-		{"valid load device from uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/simple-device.yml", nil, 1},
+		{"valid load devices from uri", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/devices.yaml", nil, 5},
 		{"invalid load device empty path", "", nil, 0},
 		{"invalid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "bogus.yml"), nil, 0},
 		{"invalid load device invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/bogus.yml", nil, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var addDeviceRequests []requests.AddDeviceRequest
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
 			cache.InitCache(TestDeviceService, TestDeviceService, dic)
-			addDeviceRequests = processDevices(tt.path, TestDeviceService, tt.secretProvider, lc, addDeviceRequests)
-			assert.Equal(t, tt.expectedNumProfiles, len(addDeviceRequests))
+			addDeviceRequests := processDevices(tt.path, tt.path, TestDeviceService, tt.secretProvider, lc)
+			assert.Equal(t, tt.expectedNumDevices, len(addDeviceRequests))
 		})
 	}
 }

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"net/url"
 	"path"
 	"testing"
 )
@@ -36,6 +38,44 @@ func Test_processDevices(t *testing.T) {
 			require.NoError(t, err)
 			addDeviceRequests := processDevices(tt.path, tt.path, TestDeviceService, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumDevices, len(addDeviceRequests))
+		})
+	}
+}
+
+func Test_loadDevicesFromURI(t *testing.T) {
+	tests := []struct {
+		name                string
+		path                string
+		serviceName         string
+		secretProvider      interfaces.SecretProvider
+		expectedNumDevices  int
+		expectedEdgexErrMsg string
+	}{
+		{"valid load from uri",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/devices/index.json",
+			"TestDevice",
+			nil,
+			2, ""},
+		{"invalid load from uri",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/devices/bogus.json",
+			"TestDevice",
+			nil,
+			0, "failed to load Devices list from URI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var addDeviceReq []requests.AddDeviceRequest
+			lc := logger.MockLogger{}
+			dic, _ := NewMockDIC()
+			edgexErr := cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			require.NoError(t, edgexErr)
+			parsedURI, err := url.Parse(tt.path)
+			require.NoError(t, err)
+			addDeviceReq, edgexErr = loadDevicesFromURI(tt.path, parsedURI, tt.serviceName, tt.secretProvider, lc)
+			assert.Equal(t, tt.expectedNumDevices, len(addDeviceReq))
+			if edgexErr != nil {
+				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)
+			}
 		})
 	}
 }

--- a/internal/provision/mockdic_test.go
+++ b/internal/provision/mockdic_test.go
@@ -1,0 +1,119 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"context"
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/config"
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+)
+
+const (
+	TestDeviceService             = "testDeviceService"
+	TestDeviceWithTags            = "testDeviceWithTags"
+	TestDeviceWithoutTags         = "testDeviceWithoutTags"
+	TestProfile                   = "testProfile"
+	TestDeviceResourceWithTags    = "testResourceWithTags"
+	TestDeviceResourceWithoutTags = "testResourceWithoutTags"
+	TestDeviceCommandWithTags     = "testCommandWithTags"
+	TestDeviceCommandWithoutTags  = "testCommandWithoutTags"
+	TestResourceTagName           = "testResourceTagName"
+	TestResourceTagValue          = "testResourceTagValue"
+	TestCommandTagName            = "testCommandTagName"
+	TestCommandTagValue           = "testCommandTagValue"
+	TestDeviceTagName             = "testDeviceTagName"
+	TestDeviceTagValue            = "testDeviceTagValue"
+	TestDuplicateTagName          = "testDuplicateTagName"
+)
+
+var profile = responses.DeviceProfileResponse{
+	Profile: dtos.DeviceProfile{
+		DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{Name: TestProfile},
+		DeviceResources: []dtos.DeviceResource{
+			{
+				Name: TestDeviceResourceWithTags,
+				Tags: dtos.Tags{
+					TestResourceTagName: TestResourceTagValue,
+				},
+			},
+			{
+				Name: TestDeviceResourceWithoutTags,
+			},
+		},
+		DeviceCommands: []dtos.DeviceCommand{
+			{
+				Name: TestDeviceCommandWithTags,
+				Tags: dtos.Tags{
+					TestCommandTagName:   TestCommandTagValue,
+					TestDuplicateTagName: TestCommandTagValue,
+				},
+			},
+			{
+				Name: TestDeviceCommandWithoutTags,
+			},
+		},
+	},
+}
+
+func NewMockDIC() (*di.Container, *clientMocks.DeviceProfileClient) {
+	configuration := &config.ConfigurationStruct{
+		Device: config.DeviceInfo{MaxCmdOps: 1},
+	}
+	deviceService := &models.DeviceService{Name: TestDeviceService}
+
+	devices := responses.MultiDevicesResponse{
+		Devices: []dtos.Device{
+			{
+				Name:        TestDeviceWithTags,
+				ProfileName: TestProfile,
+				Tags: dtos.Tags{
+					TestDeviceTagName:    TestDeviceTagValue,
+					TestDuplicateTagName: TestDeviceTagValue,
+				},
+			},
+			{
+				Name:        TestDeviceWithoutTags,
+				ProfileName: TestProfile,
+			},
+		},
+	}
+	dcMock := &clientMocks.DeviceClient{}
+	dcMock.On("DevicesByServiceName", context.Background(), TestDeviceService, 0, -1).Return(devices, nil)
+
+	dpcMock := &clientMocks.DeviceProfileClient{}
+	dpcMock.On("DeviceProfileByName", context.Background(), TestProfile).Return(profile, nil)
+
+	pwcMock := &clientMocks.ProvisionWatcherClient{}
+	pwcMock.On("ProvisionWatchersByServiceName", context.Background(), TestDeviceService, 0, -1).Return(responses.MultiProvisionWatchersResponse{}, nil)
+
+	return di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return configuration
+		},
+		container.DeviceServiceName: func(get di.Get) any {
+			return deviceService
+		},
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
+			return dcMock
+		},
+		bootstrapContainer.DeviceProfileClientName: func(get di.Get) interface{} {
+			return dpcMock
+		},
+		bootstrapContainer.ProvisionWatcherClientName: func(get di.Get) interface{} {
+			return pwcMock
+		},
+	}), dpcMock
+}

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -104,13 +104,9 @@ func loadProfilesFromFile(path string, dpc interfaces.DeviceProfileClient, lc lo
 
 func loadProfilesFromURI(inputURI string, parsedURI *url.URL, dpc interfaces.DeviceProfileClient, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, errors.EdgeX) {
 	var edgexErr errors.EdgeX
-	redactedURI, err := url.JoinPath(parsedURI.Host, parsedURI.Path)
-	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create a query-free URI for the profile list", err)
-	}
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Profile list from URI %s", redactedURI), err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Profile list from URI %s", parsedURI.Redacted()), err)
 	}
 
 	if len(bytes) == 0 {
@@ -126,7 +122,7 @@ func loadProfilesFromURI(inputURI string, parsedURI *url.URL, dpc interfaces.Dev
 		return nil, nil
 	}
 
-	lc.Infof("Loading pre-defined profiles from %s(%d files found)", redactedURI, len(files))
+	lc.Infof("Loading pre-defined profiles from %s(%d files found)", parsedURI.Redacted(), len(files))
 	var addProfilesReq, processedProfilesReq []requests.DeviceProfileRequest
 	for _, file := range files {
 		fullPath, redactedPath := GetFullAndRedactedURI(parsedURI, file, "profile", lc)

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -103,6 +103,7 @@ func loadProfilesFromFile(path string, dpc interfaces.DeviceProfileClient, lc lo
 
 func loadProfilesFromURI(inputURI string, parsedURI *url.URL, dpc interfaces.DeviceProfileClient, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, errors.EdgeX) {
 	var edgexErr errors.EdgeX
+	// the input URI contains the index file containing the Profile list to be loaded
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Device Profile list from URI %s", parsedURI.Redacted()), err)

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -2,6 +2,7 @@
 //
 // Copyright (C) 2017-2018 Canonical Ltd
 // Copyright (C) 2018-2023 IOTech Ltd
+// Copyright (C) 2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,9 +12,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/file"
+	bootstrapInterfaces "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
@@ -34,10 +42,40 @@ const (
 )
 
 func LoadProfiles(path string, dic *di.Container) errors.EdgeX {
+	var addProfilesReq []requests.DeviceProfileRequest
 	if path == "" {
 		return nil
 	}
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	dpc := bootstrapContainer.DeviceProfileClientFrom(dic.Get)
+	parsedUrl, err := url.Parse(path)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to parse url", err)
+	}
 
+	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
+		secretProvider := bootstrapContainer.SecretProviderFrom(dic.Get)
+		edgexErr := loadProfilesFromUri(lc, path, dpc, secretProvider, addProfilesReq)
+		if edgexErr != nil {
+			return edgexErr
+		}
+	} else {
+		edgexErr := loadProfilesFromFile(lc, path, dpc, addProfilesReq)
+		if edgexErr != nil {
+			return edgexErr
+		}
+	}
+
+	if len(addProfilesReq) == 0 {
+		return nil
+	}
+	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck
+	_, edgexErr := dpc.Add(ctx, addProfilesReq)
+	return edgexErr
+}
+
+func loadProfilesFromFile(lc logger.LoggingClient, path string, dpc interfaces.DeviceProfileClient, addProfilesReq []requests.DeviceProfileRequest) errors.EdgeX {
+	var edgexErr errors.EdgeX
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path", err)
@@ -52,63 +90,96 @@ func LoadProfiles(path string, dic *di.Container) errors.EdgeX {
 		return nil
 	}
 
-	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	lc.Infof("Loading pre-defined profiles from %s(%d files found)", absPath, len(files))
 
-	var addProfilesReq []requests.DeviceProfileRequest
-	dpc := bootstrapContainer.DeviceProfileClientFrom(dic.Get)
 	for _, file := range files {
-		var profile dtos.DeviceProfile
 		fullPath := filepath.Join(absPath, file.Name())
-		if strings.HasSuffix(fullPath, yamlExt) || strings.HasSuffix(fullPath, ymlExt) {
-			content, err := os.ReadFile(fullPath)
-			if err != nil {
-				lc.Errorf("Failed to read %s: %v", fullPath, err)
-				continue
-			}
-
-			err = yaml.Unmarshal(content, &profile)
-			if err != nil {
-				lc.Errorf("Failed to YAML decode profile %s: %v", file.Name(), err)
-				continue
-			}
-		} else if strings.HasSuffix(fullPath, jsonExt) {
-			content, err := os.ReadFile(fullPath)
-			if err != nil {
-				lc.Errorf("Failed to read %s: %v", fullPath, err)
-				continue
-			}
-
-			err = json.Unmarshal(content, &profile)
-			if err != nil {
-				lc.Errorf("Failed to JSON decode profile %s: %v", file.Name(), err)
-				continue
-			}
-		} else {
-			continue
-		}
-
-		res, err := dpc.DeviceProfileByName(context.Background(), profile.Name)
-		if err == nil {
-			lc.Infof("Profile %s exists, using the existing one", profile.Name)
-			_, exist := cache.Profiles().ForName(profile.Name)
-			if !exist {
-				err = cache.Profiles().Add(dtos.ToDeviceProfileModel(res.Profile))
-				if err != nil {
-					return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
-				}
-			}
-		} else {
-			lc.Infof("Profile %s not found in Metadata, adding it ...", profile.Name)
-			req := requests.NewDeviceProfileRequest(profile)
-			addProfilesReq = append(addProfilesReq, req)
+		addProfilesReq, edgexErr = processProfiles(lc, fullPath, nil, dpc, addProfilesReq)
+		if edgexErr != nil {
+			return nil
 		}
 	}
+	return nil
+}
 
-	if len(addProfilesReq) == 0 {
+func loadProfilesFromUri(lc logger.LoggingClient, inputUri string, dpc interfaces.DeviceProfileClient, secretProvider bootstrapInterfaces.SecretProvider, addProfilesReq []requests.DeviceProfileRequest) errors.EdgeX {
+	var edgexErr errors.EdgeX
+	bytes, err := file.Load(inputUri, timeout, secretProvider)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory", err)
+	}
+
+	if len(bytes) == 0 {
 		return nil
 	}
-	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck
-	_, edgexErr := dpc.Add(ctx, addProfilesReq)
-	return edgexErr
+
+	var files []string
+	err = json.Unmarshal(bytes, &files)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "could not unmarshal Provision Watcher contents", err)
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	baseUrl, _ := path.Split(inputUri)
+	parsedUrl, err := url.Parse(inputUri)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "could not parse uri for Provision Watcher", err)
+	}
+	lc.Infof("Loading pre-defined profiles from %s(%d files found)", parsedUrl.Redacted(), len(files))
+
+	for _, file := range files {
+		fullPath, err := url.JoinPath(baseUrl, file)
+		if err != nil {
+			lc.Error("could not join uri path for profile %s: %v", file, err)
+			continue
+		}
+		addProfilesReq, edgexErr = processProfiles(lc, fullPath, secretProvider, dpc, addProfilesReq)
+		if edgexErr != nil {
+			return edgexErr
+		}
+	}
+	return nil
+}
+
+func processProfiles(lc logger.LoggingClient, path string, secretProvider bootstrapInterfaces.SecretProvider, dpc interfaces.DeviceProfileClient, addProfilesReq []requests.DeviceProfileRequest) ([]requests.DeviceProfileRequest, errors.EdgeX) {
+	var profile dtos.DeviceProfile
+	bytes, err := file.Load(path, 10*time.Second, secretProvider)
+	if err != nil {
+		lc.Errorf("Failed to read %s: %v", path, err)
+		return addProfilesReq, nil
+	}
+	if strings.HasSuffix(path, yamlExt) || strings.HasSuffix(path, ymlExt) {
+		err = yaml.Unmarshal(bytes, &profile)
+		if err != nil {
+			lc.Errorf("Failed to YAML decode device profile: %v", err)
+			return addProfilesReq, nil
+		}
+	} else if strings.HasSuffix(path, jsonExt) {
+		err = json.Unmarshal(bytes, &profile)
+		if err != nil {
+			lc.Errorf("Failed to JSON decode device profile: %v", err)
+			return addProfilesReq, nil
+		}
+	} else {
+		return addProfilesReq, nil
+	}
+
+	res, err := dpc.DeviceProfileByName(context.Background(), profile.Name)
+	if err == nil {
+		lc.Infof("Profile %s exists, using the existing one", profile.Name)
+		_, exist := cache.Profiles().ForName(profile.Name)
+		if !exist {
+			err = cache.Profiles().Add(dtos.ToDeviceProfileModel(res.Profile))
+			if err != nil {
+				return addProfilesReq, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
+			}
+		}
+	} else {
+		lc.Infof("Profile %s not found in Metadata, adding it ...", profile.Name)
+		req := requests.NewDeviceProfileRequest(profile)
+		addProfilesReq = append(addProfilesReq, req)
+	}
+	return addProfilesReq, nil
 }

--- a/internal/provision/profiles_test.go
+++ b/internal/provision/profiles_test.go
@@ -181,7 +181,7 @@ func Test_processProfiles(t *testing.T) {
 			dic, dpcMock := NewMockDIC()
 			dpcMock.On("DeviceProfileByName", context.Background(), tt.profileName).Return(tt.dpcMockRes, tt.dpcMockErr)
 			cache.InitCache(TestDeviceService, TestDeviceService, dic)
-			addProfilesReq, edgexErr = processProfiles(tt.path, tt.secretProvider, lc, dpcMock, addProfilesReq)
+			addProfilesReq, edgexErr = processProfiles(tt.path, tt.path, tt.secretProvider, lc, dpcMock)
 			assert.Equal(t, len(addProfilesReq), tt.expectedNumProfiles)
 			if edgexErr != nil {
 				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)

--- a/internal/provision/profiles_test.go
+++ b/internal/provision/profiles_test.go
@@ -232,7 +232,7 @@ func Test_loadProfilesFromURI(t *testing.T) {
 			[]string{},
 			[]responses.DeviceProfileResponse{},
 			[]errors.EdgeX{},
-			0, "failed to load Profile list from URI"},
+			0, "failed to load Device Profile list from URI"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -240,7 +240,7 @@ func Test_loadProfilesFromURI(t *testing.T) {
 			var edgexErr errors.EdgeX
 			lc := logger.MockLogger{}
 			dic, dpcMock := NewMockDIC()
-			for index, _ := range tt.profileNames {
+			for index := range tt.profileNames {
 				dpcMock.On("DeviceProfileByName", context.Background(), tt.profileNames[index]).Return(tt.dpcMockRes[index], tt.dpcMockErr[index])
 			}
 			edgexErr = cache.InitCache(TestDeviceService, TestDeviceService, dic)

--- a/internal/provision/profiles_test.go
+++ b/internal/provision/profiles_test.go
@@ -1,0 +1,191 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"context"
+	goErrors "errors"
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+)
+
+func Test_processProfiles(t *testing.T) {
+	simpleProfile := responses.DeviceProfileResponse{
+		Profile: dtos.DeviceProfile{
+			DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{
+				Name:         "Simple-Device",
+				Manufacturer: "Simple Corp.",
+				Description:  "Example of Simple Device",
+				Model:        "SP-01",
+				Labels:       []string{"modbus"},
+			},
+			DeviceResources: []dtos.DeviceResource{
+				{
+					Description: "Switch On/Off.",
+					Name:        "SwitchButton",
+					IsHidden:    false,
+					Properties: dtos.ResourceProperties{
+						ValueType:    "Bool",
+						ReadWrite:    "RW",
+						DefaultValue: "true",
+					},
+				},
+				{
+					Description: "Visual representation of Switch state.",
+					Name:        "Image",
+					IsHidden:    false,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Binary",
+						ReadWrite: "R",
+						MediaType: "image/jpeg",
+					},
+				},
+				{
+					Description: "X axis rotation rate",
+					Name:        "Xrotation",
+					IsHidden:    true,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Int32",
+						ReadWrite: "RW",
+						Units:     "rpm",
+					},
+				},
+				{
+					Description: "y axis rotation rate",
+					Name:        "yrotation",
+					IsHidden:    true,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Int32",
+						ReadWrite: "RW",
+						Units:     "rpm",
+					},
+				},
+				{
+					Description: "z axis rotation rate",
+					Name:        "zrotation",
+					IsHidden:    true,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Int32",
+						ReadWrite: "RW",
+						Units:     "rpm",
+					},
+				},
+				{
+					Description: "String array",
+					Name:        "StringArray",
+					IsHidden:    false,
+					Properties: dtos.ResourceProperties{
+						ValueType: "StringArray",
+						ReadWrite: "RW",
+					},
+				},
+				{
+					Description: "Unsigned 8bit array",
+					Name:        "Uint8Array",
+					IsHidden:    false,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Uint8Array",
+						ReadWrite: "RW",
+					},
+				},
+				{
+					Description: "Counter data",
+					Name:        "Counter",
+					IsHidden:    false,
+					Properties: dtos.ResourceProperties{
+						ValueType: "Object",
+						ReadWrite: "RW",
+					},
+				},
+			},
+			DeviceCommands: []dtos.DeviceCommand{
+				{
+					Name:      "Switch",
+					IsHidden:  false,
+					ReadWrite: "RW",
+					ResourceOperations: []dtos.ResourceOperation{
+						{
+							DeviceResource: "SwitchButton",
+							DefaultValue:   "false",
+						},
+					},
+				},
+				{
+					Name:      "Image",
+					IsHidden:  false,
+					ReadWrite: "R",
+					ResourceOperations: []dtos.ResourceOperation{
+						{
+							DeviceResource: "Image",
+						},
+					},
+				},
+				{
+					Name:      "Rotation",
+					IsHidden:  false,
+					ReadWrite: "RW",
+					ResourceOperations: []dtos.ResourceOperation{
+						{
+							DeviceResource: "XRotation",
+							DefaultValue:   "0",
+						},
+						{
+							DeviceResource: "YRotation",
+							DefaultValue:   "0",
+						},
+						{
+							DeviceResource: "ZRotation",
+							DefaultValue:   "0",
+						},
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name                string
+		path                string
+		secretProvider      interfaces.SecretProvider
+		profileName         string
+		dpcMockRes          responses.DeviceProfileResponse
+		dpcMockErr          errors.EdgeX
+		expectedNumProfiles int
+		expectedEdgexErrMsg string
+	}{
+		{"valid load profile from file, profile exists", path.Join("..", "..", "example", "cmd", "device-simple", "res", "profiles", "Simple-Driver.yaml"), nil, "Simple-Device", simpleProfile, nil, 0, ""},
+		{"valid load profile from file, profile does not exist", path.Join("..", "..", "example", "cmd", "device-simple", "res", "profiles", "Simple-Driver.yaml"), nil, "Simple-Device", responses.DeviceProfileResponse{}, errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile")), 1, ""},
+		{"valid load profile from uri, profile exists", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/profiles/Simple-Driver.yaml", nil, "Simple-Device", simpleProfile, nil, 0, ""},
+		{"valid load profile from uri, profile does not exist", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/profiles/Simple-Driver.yaml", nil, "Simple-Device", responses.DeviceProfileResponse{}, errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile")), 1, ""},
+		{"invalid load empty profile from file", "", nil, "Simple-Device", responses.DeviceProfileResponse{}, errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile")), 0, ""},
+		{"invalid load provision watcher from bogus file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "profiles", "bogus.yaml"), nil, "Simple-Device", responses.DeviceProfileResponse{}, nil, 0, ""},
+		{"invalid load profile from bogus uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/profiles/bogus.yaml", nil, "Simple-Device", responses.DeviceProfileResponse{}, nil, 0, ""},
+		{"invalid load profile from file, duplicate profile", path.Join("..", "..", "example", "cmd", "device-simple", "res", "profiles", "Simple-Driver.yaml"), nil, "Simple-Device", profile, nil, 0, "Profile testProfile has already existed in cache"},
+		{"invalid load profile from uri, duplicate profile", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/profiles/Simple-Driver.yaml", nil, "Simple-Device", profile, nil, 0, "Profile testProfile has already existed in cache"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var addProfilesReq []requests.DeviceProfileRequest
+			var edgexErr errors.EdgeX
+			lc := logger.MockLogger{}
+			dic, dpcMock := NewMockDIC()
+			dpcMock.On("DeviceProfileByName", context.Background(), tt.profileName).Return(tt.dpcMockRes, tt.dpcMockErr)
+			cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			addProfilesReq, edgexErr = processProfiles(tt.path, tt.secretProvider, lc, dpcMock, addProfilesReq)
+			assert.Equal(t, len(addProfilesReq), tt.expectedNumProfiles)
+			if edgexErr != nil {
+				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)
+			}
+		})
+	}
+}

--- a/internal/provision/profiles_test.go
+++ b/internal/provision/profiles_test.go
@@ -17,143 +17,145 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"net/url"
 	"path"
 	"testing"
 )
 
-func Test_processProfiles(t *testing.T) {
-	simpleProfile := responses.DeviceProfileResponse{
-		Profile: dtos.DeviceProfile{
-			DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{
-				Name:         "Simple-Device",
-				Manufacturer: "Simple Corp.",
-				Description:  "Example of Simple Device",
-				Model:        "SP-01",
-				Labels:       []string{"modbus"},
-			},
-			DeviceResources: []dtos.DeviceResource{
-				{
-					Description: "Switch On/Off.",
-					Name:        "SwitchButton",
-					IsHidden:    false,
-					Properties: dtos.ResourceProperties{
-						ValueType:    "Bool",
-						ReadWrite:    "RW",
-						DefaultValue: "true",
-					},
-				},
-				{
-					Description: "Visual representation of Switch state.",
-					Name:        "Image",
-					IsHidden:    false,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Binary",
-						ReadWrite: "R",
-						MediaType: "image/jpeg",
-					},
-				},
-				{
-					Description: "X axis rotation rate",
-					Name:        "Xrotation",
-					IsHidden:    true,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Int32",
-						ReadWrite: "RW",
-						Units:     "rpm",
-					},
-				},
-				{
-					Description: "y axis rotation rate",
-					Name:        "yrotation",
-					IsHidden:    true,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Int32",
-						ReadWrite: "RW",
-						Units:     "rpm",
-					},
-				},
-				{
-					Description: "z axis rotation rate",
-					Name:        "zrotation",
-					IsHidden:    true,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Int32",
-						ReadWrite: "RW",
-						Units:     "rpm",
-					},
-				},
-				{
-					Description: "String array",
-					Name:        "StringArray",
-					IsHidden:    false,
-					Properties: dtos.ResourceProperties{
-						ValueType: "StringArray",
-						ReadWrite: "RW",
-					},
-				},
-				{
-					Description: "Unsigned 8bit array",
-					Name:        "Uint8Array",
-					IsHidden:    false,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Uint8Array",
-						ReadWrite: "RW",
-					},
-				},
-				{
-					Description: "Counter data",
-					Name:        "Counter",
-					IsHidden:    false,
-					Properties: dtos.ResourceProperties{
-						ValueType: "Object",
-						ReadWrite: "RW",
-					},
+var simpleProfile = responses.DeviceProfileResponse{
+	Profile: dtos.DeviceProfile{
+		DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{
+			Name:         "Simple-Device",
+			Manufacturer: "Simple Corp.",
+			Description:  "Example of Simple Device",
+			Model:        "SP-01",
+			Labels:       []string{"modbus"},
+		},
+		DeviceResources: []dtos.DeviceResource{
+			{
+				Description: "Switch On/Off.",
+				Name:        "SwitchButton",
+				IsHidden:    false,
+				Properties: dtos.ResourceProperties{
+					ValueType:    "Bool",
+					ReadWrite:    "RW",
+					DefaultValue: "true",
 				},
 			},
-			DeviceCommands: []dtos.DeviceCommand{
-				{
-					Name:      "Switch",
-					IsHidden:  false,
-					ReadWrite: "RW",
-					ResourceOperations: []dtos.ResourceOperation{
-						{
-							DeviceResource: "SwitchButton",
-							DefaultValue:   "false",
-						},
-					},
-				},
-				{
-					Name:      "Image",
-					IsHidden:  false,
+			{
+				Description: "Visual representation of Switch state.",
+				Name:        "Image",
+				IsHidden:    false,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Binary",
 					ReadWrite: "R",
-					ResourceOperations: []dtos.ResourceOperation{
-						{
-							DeviceResource: "Image",
-						},
+					MediaType: "image/jpeg",
+				},
+			},
+			{
+				Description: "X axis rotation rate",
+				Name:        "Xrotation",
+				IsHidden:    true,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Int32",
+					ReadWrite: "RW",
+					Units:     "rpm",
+				},
+			},
+			{
+				Description: "y axis rotation rate",
+				Name:        "yrotation",
+				IsHidden:    true,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Int32",
+					ReadWrite: "RW",
+					Units:     "rpm",
+				},
+			},
+			{
+				Description: "z axis rotation rate",
+				Name:        "zrotation",
+				IsHidden:    true,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Int32",
+					ReadWrite: "RW",
+					Units:     "rpm",
+				},
+			},
+			{
+				Description: "String array",
+				Name:        "StringArray",
+				IsHidden:    false,
+				Properties: dtos.ResourceProperties{
+					ValueType: "StringArray",
+					ReadWrite: "RW",
+				},
+			},
+			{
+				Description: "Unsigned 8bit array",
+				Name:        "Uint8Array",
+				IsHidden:    false,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Uint8Array",
+					ReadWrite: "RW",
+				},
+			},
+			{
+				Description: "Counter data",
+				Name:        "Counter",
+				IsHidden:    false,
+				Properties: dtos.ResourceProperties{
+					ValueType: "Object",
+					ReadWrite: "RW",
+				},
+			},
+		},
+		DeviceCommands: []dtos.DeviceCommand{
+			{
+				Name:      "Switch",
+				IsHidden:  false,
+				ReadWrite: "RW",
+				ResourceOperations: []dtos.ResourceOperation{
+					{
+						DeviceResource: "SwitchButton",
+						DefaultValue:   "false",
 					},
 				},
-				{
-					Name:      "Rotation",
-					IsHidden:  false,
-					ReadWrite: "RW",
-					ResourceOperations: []dtos.ResourceOperation{
-						{
-							DeviceResource: "XRotation",
-							DefaultValue:   "0",
-						},
-						{
-							DeviceResource: "YRotation",
-							DefaultValue:   "0",
-						},
-						{
-							DeviceResource: "ZRotation",
-							DefaultValue:   "0",
-						},
+			},
+			{
+				Name:      "Image",
+				IsHidden:  false,
+				ReadWrite: "R",
+				ResourceOperations: []dtos.ResourceOperation{
+					{
+						DeviceResource: "Image",
+					},
+				},
+			},
+			{
+				Name:      "Rotation",
+				IsHidden:  false,
+				ReadWrite: "RW",
+				ResourceOperations: []dtos.ResourceOperation{
+					{
+						DeviceResource: "XRotation",
+						DefaultValue:   "0",
+					},
+					{
+						DeviceResource: "YRotation",
+						DefaultValue:   "0",
+					},
+					{
+						DeviceResource: "ZRotation",
+						DefaultValue:   "0",
 					},
 				},
 			},
 		},
-	}
+	},
+}
+
+func Test_processProfiles(t *testing.T) {
 	tests := []struct {
 		name                string
 		path                string
@@ -184,6 +186,68 @@ func Test_processProfiles(t *testing.T) {
 			err := cache.InitCache(TestDeviceService, TestDeviceService, dic)
 			require.NoError(t, err)
 			addProfilesReq, edgexErr = processProfiles(tt.path, tt.path, tt.secretProvider, lc, dpcMock)
+			assert.Equal(t, len(addProfilesReq), tt.expectedNumProfiles)
+			if edgexErr != nil {
+				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)
+			}
+		})
+	}
+}
+
+func Test_loadProfilesFromURI(t *testing.T) {
+	tests := []struct {
+		name                string
+		path                string
+		secretProvider      interfaces.SecretProvider
+		profileNames        []string
+		dpcMockRes          []responses.DeviceProfileResponse
+		dpcMockErr          []errors.EdgeX
+		expectedNumProfiles int
+		expectedEdgexErrMsg string
+	}{
+		{"valid load from uri, profile exists",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/profiles/index.json",
+			nil,
+			[]string{"Simple-Device", "Simple-Device2"},
+			[]responses.DeviceProfileResponse{simpleProfile, simpleProfile},
+			[]errors.EdgeX{nil, nil},
+			0, ""},
+		{"valid load from uri, profile does not exist in metadata",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/profiles/index.json",
+			nil,
+			[]string{"Simple-Device", "Simple-Device2"},
+			[]responses.DeviceProfileResponse{responses.DeviceProfileResponse{}, responses.DeviceProfileResponse{}},
+			[]errors.EdgeX{errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile")), errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile"))},
+			2, ""},
+		{"valid load where one profile exists and one profile does not exist in metadata",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/profiles/index.json",
+			nil,
+			[]string{"Simple-Device", "Simple-Device2"},
+			[]responses.DeviceProfileResponse{simpleProfile, responses.DeviceProfileResponse{}},
+			[]errors.EdgeX{nil, errors.NewCommonEdgeXWrapper(goErrors.New("could not find profile"))},
+			1, ""},
+		{"invalid load profile path join breaks",
+			"https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/internal/provision/uri-test-files/profiles/bogus.json",
+			nil,
+			[]string{},
+			[]responses.DeviceProfileResponse{},
+			[]errors.EdgeX{},
+			0, "failed to load Profile list from URI"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var addProfilesReq []requests.DeviceProfileRequest
+			var edgexErr errors.EdgeX
+			lc := logger.MockLogger{}
+			dic, dpcMock := NewMockDIC()
+			for index, _ := range tt.profileNames {
+				dpcMock.On("DeviceProfileByName", context.Background(), tt.profileNames[index]).Return(tt.dpcMockRes[index], tt.dpcMockErr[index])
+			}
+			edgexErr = cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			require.NoError(t, edgexErr)
+			parsedURI, err := url.Parse(tt.path)
+			require.NoError(t, err)
+			addProfilesReq, edgexErr = loadProfilesFromURI(tt.path, parsedURI, dpcMock, tt.secretProvider, lc)
 			assert.Equal(t, len(addProfilesReq), tt.expectedNumProfiles)
 			if edgexErr != nil {
 				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)

--- a/internal/provision/provisionwatchers.go
+++ b/internal/provision/provisionwatchers.go
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2023 IOTech Ltd
+// Copyright (C) 2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,11 +9,18 @@ package provision
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/file"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
@@ -24,69 +32,32 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
 )
 
+var timeout = 15 * time.Second
+
 func LoadProvisionWatchers(path string, dic *di.Container) errors.EdgeX {
+	var addProvisionWatchersReq []requests.AddProvisionWatcherRequest
 	if path == "" {
 		return nil
 	}
 
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path", err)
-	}
-
-	files, err := os.ReadDir(absPath)
-	if err != nil {
-		return errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory", err)
-	}
-
-	if len(files) == 0 {
-		return nil
-	}
-
 	lc := container.LoggingClientFrom(dic.Get)
-	lc.Infof("Loading pre-defined provision watchers from %s(%d files found)", absPath, len(files))
 
-	var addProvisionWatchersReq []requests.AddProvisionWatcherRequest
-	for _, file := range files {
-		var watcher dtos.ProvisionWatcher
-		filename := filepath.Join(absPath, file.Name())
-		data, err := os.ReadFile(filename)
-		if err != nil {
-			lc.Errorf("Failed to read %s: %v", filename, err)
-			continue
+	parsedUrl, err := url.Parse(path)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to parse url", err)
+	}
+	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
+		secretProvider := container.SecretProviderFrom(dic.Get)
+		edgexErr := loadProvisionWatchersFromUri(lc, path, secretProvider, addProvisionWatchersReq)
+		if edgexErr != nil {
+			return edgexErr
 		}
-
-		if strings.HasSuffix(filename, yamlExt) || strings.HasSuffix(filename, ymlExt) {
-			err = yaml.Unmarshal(data, &watcher)
-			if err != nil {
-				lc.Errorf("Failed to YAML decode %s: %v", filename, err)
-				continue
-			}
-		} else if strings.HasSuffix(filename, jsonExt) {
-			err := json.Unmarshal(data, &watcher)
-			if err != nil {
-				lc.Errorf("Failed to JSON decode %s: %v", filename, err)
-				continue
-			}
-		} else {
-			continue
-		}
-
-		err = common.Validate(watcher)
-		if err != nil {
-			lc.Errorf("ProvisionWatcher %s validation failed: %v", watcher.Name, err)
-			continue
-		}
-
-		if _, ok := cache.ProvisionWatchers().ForName(watcher.Name); ok {
-			lc.Infof("ProvisionWatcher %s exists, using the existing one", watcher.Name)
-		} else {
-			lc.Infof("ProvisionWatcher %s not found in Metadata, adding it...", watcher.Name)
-			req := requests.NewAddProvisionWatcherRequest(watcher)
-			addProvisionWatchersReq = append(addProvisionWatchersReq, req)
+	} else {
+		edgexErr := loadProvisionWatchersFromFile(lc, path, addProvisionWatchersReq)
+		if edgexErr != nil {
+			return edgexErr
 		}
 	}
-
 	if len(addProvisionWatchersReq) == 0 {
 		return nil
 	}
@@ -95,4 +66,107 @@ func LoadProvisionWatchers(path string, dic *di.Container) errors.EdgeX {
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) //nolint: staticcheck
 	_, edgexErr := pwc.Add(ctx, addProvisionWatchersReq)
 	return edgexErr
+}
+
+func loadProvisionWatchersFromFile(lc logger.LoggingClient, path string, addProvisionWatchersReq []requests.AddProvisionWatcherRequest) errors.EdgeX {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path", err)
+	}
+	files, err := os.ReadDir(path)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory", err)
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	lc.Infof("Loading pre-defined provision watchers from %s(%d files found)", absPath, len(files))
+
+	for _, file := range files {
+		filename := filepath.Join(absPath, file.Name())
+		addProvisionWatchersReq = processProvisonWatcherFile(lc, filename, nil, addProvisionWatchersReq)
+	}
+	return nil
+}
+
+func loadProvisionWatchersFromUri(lc logger.LoggingClient, inputUri string, secretProvider interfaces.SecretProvider, addProvisionWatchersReq []requests.AddProvisionWatcherRequest) errors.EdgeX {
+	parsedUrl, err := url.Parse(inputUri)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "could not parse uri for Provision Watcher", err)
+	}
+
+	bytes, err := file.Load(inputUri, timeout, secretProvider)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to read uri %s", parsedUrl.Redacted()), err)
+	}
+
+	if len(bytes) == 0 {
+		return nil
+	}
+
+	var files []string
+
+	err = json.Unmarshal(bytes, &files)
+	if err != nil {
+		return errors.NewCommonEdgeX(errors.KindServerError, "could not unmarshal Provision Watcher contents", err)
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	baseUrl, _ := path.Split(inputUri)
+	lc.Infof("Loading pre-defined provision watchers from %s(%d files found)", parsedUrl.Redacted(), len(files))
+
+	for _, file := range files {
+		provisionWatcherUrl, err := url.JoinPath(baseUrl, file)
+		if err != nil {
+			lc.Error("could not join uri path for provision watcher %s: %v", file, err)
+			continue
+		}
+		addProvisionWatchersReq = processProvisonWatcherFile(lc, provisionWatcherUrl, secretProvider, addProvisionWatchersReq)
+	}
+	return nil
+}
+
+func processProvisonWatcherFile(lc logger.LoggingClient, path string, secretProvider interfaces.SecretProvider, addProvisionWatchersReq []requests.AddProvisionWatcherRequest) []requests.AddProvisionWatcherRequest {
+	var watcher dtos.ProvisionWatcher
+	data, err := file.Load(path, timeout, secretProvider)
+	if err != nil {
+		lc.Errorf("Failed to read Provision Watcher: %v", err)
+		return addProvisionWatchersReq
+	}
+
+	if strings.HasSuffix(path, yamlExt) || strings.HasSuffix(path, ymlExt) {
+		err = yaml.Unmarshal(data, &watcher)
+		if err != nil {
+			lc.Errorf("Failed to YAML decode Provision Watcher: %v", err)
+			return addProvisionWatchersReq
+		}
+	} else if strings.HasSuffix(path, jsonExt) {
+		err := json.Unmarshal(data, &watcher)
+		if err != nil {
+			lc.Errorf("Failed to JSON decode Provision Watcher: %v", err)
+			return addProvisionWatchersReq
+		}
+	} else {
+		return addProvisionWatchersReq
+	}
+
+	err = common.Validate(watcher)
+	if err != nil {
+		lc.Errorf("ProvisionWatcher %s validation failed: %v", watcher.Name, err)
+		return addProvisionWatchersReq
+	}
+
+	if _, ok := cache.ProvisionWatchers().ForName(watcher.Name); ok {
+		lc.Infof("ProvisionWatcher %s exists, using the existing one", watcher.Name)
+	} else {
+		lc.Infof("ProvisionWatcher %s not found in Metadata, adding it...", watcher.Name)
+		req := requests.NewAddProvisionWatcherRequest(watcher)
+		addProvisionWatchersReq = append(addProvisionWatchersReq, req)
+	}
+	return addProvisionWatchersReq
 }

--- a/internal/provision/provisionwatchers.go
+++ b/internal/provision/provisionwatchers.go
@@ -89,6 +89,7 @@ func loadProvisionWatchersFromFile(path string, lc logger.LoggingClient) ([]requ
 }
 
 func loadProvisionWatchersFromURI(inputURI string, parsedURI *url.URL, secretProvider interfaces.SecretProvider, lc logger.LoggingClient) ([]requests.AddProvisionWatcherRequest, errors.EdgeX) {
+	// the input URI contains the index file containing the Provision Watcher list to be loaded
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
 		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Provision Watchers list from URI %s", parsedURI.Redacted()), err)

--- a/internal/provision/provisionwatchers.go
+++ b/internal/provision/provisionwatchers.go
@@ -38,7 +38,7 @@ func LoadProvisionWatchers(path string, dic *di.Container) errors.EdgeX {
 
 	parsedUrl, err := url.Parse(path)
 	if err != nil {
-		return errors.NewCommonEdgeX(errors.KindServerError, "failed to parse provision watcher path as a URI", err)
+		return errors.NewCommonEdgeX(errors.KindServerError, "failed to parse Provision Watcher path as a URI", err)
 	}
 	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
 		secretProvider := container.SecretProviderFrom(dic.Get)
@@ -65,18 +65,18 @@ func LoadProvisionWatchers(path string, dic *di.Container) errors.EdgeX {
 func loadProvisionWatchersFromFile(path string, lc logger.LoggingClient) ([]requests.AddProvisionWatcherRequest, errors.EdgeX) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path for provision watchers", err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path for Provision Watchers", err)
 	}
 	files, err := os.ReadDir(path)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory for provision watchers", err)
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory for Provision Watchers", err)
 	}
 
 	if len(files) == 0 {
 		return nil, nil
 	}
 
-	lc.Infof("Loading pre-defined provision watchers from %s(%d files found)", absPath, len(files))
+	lc.Infof("Loading pre-defined Provision Watchers from %s(%d files found)", absPath, len(files))
 	var addProvisionWatchersReq, processedProvisionWatchersReq []requests.AddProvisionWatcherRequest
 	for _, file := range files {
 		fullPath := filepath.Join(absPath, file.Name())
@@ -91,11 +91,7 @@ func loadProvisionWatchersFromFile(path string, lc logger.LoggingClient) ([]requ
 func loadProvisionWatchersFromURI(inputURI string, parsedURI *url.URL, secretProvider interfaces.SecretProvider, lc logger.LoggingClient) ([]requests.AddProvisionWatcherRequest, errors.EdgeX) {
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Provision Watchers List from URI %s", parsedURI), err)
-	}
-
-	if len(bytes) == 0 {
-		return nil, nil
+		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Provision Watchers list from URI %s", parsedURI.Redacted()), err)
 	}
 
 	var files []string
@@ -106,16 +102,14 @@ func loadProvisionWatchersFromURI(inputURI string, parsedURI *url.URL, secretPro
 	}
 
 	if len(files) == 0 {
+		lc.Infof("Index file %s for Provision Watchers list is empty", parsedURI.Redacted())
 		return nil, nil
 	}
 
-	lc.Infof("Loading pre-defined provision watchers from %s(%d files found)", parsedURI, len(files))
+	lc.Infof("Loading pre-defined Provision Watchers from %s(%d files found)", parsedURI.Redacted(), len(files))
 	var addProvisionWatchersReq, processedProvisionWatchersReq []requests.AddProvisionWatcherRequest
 	for _, file := range files {
-		fullPath, redactedPath := GetFullAndRedactedURI(parsedURI, file, "provison watcher", lc)
-		if fullPath == "" || redactedPath == "" {
-			continue
-		}
+		fullPath, redactedPath := GetFullAndRedactedURI(parsedURI, file, "Provison Watcher", lc)
 		processedProvisionWatchersReq = processProvisionWatcherFile(fullPath, redactedPath, secretProvider, lc)
 		if len(processedProvisionWatchersReq) > 0 {
 			addProvisionWatchersReq = append(addProvisionWatchersReq, processedProvisionWatchersReq...)

--- a/internal/provision/provisionwatchers_test.go
+++ b/internal/provision/provisionwatchers_test.go
@@ -25,10 +25,10 @@ func Test_processProvisionWatcherFile(t *testing.T) {
 		expectedNumProvisionWatchers int
 	}{
 		{"valid load provision watcher from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "provisionwatchers", "Simple-Provision-Watcher.yml"), nil, 1},
-		{"valid load provision watcher invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/Simple-Provision-Watcher.yml", nil, 1},
+		{"valid load provision watcher from valid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/Simple-Provision-Watcher.yml", nil, 1},
 		{"invalid load provision watcher empty path", "", nil, 0},
 		{"invalid load provision watcher from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "provisionwatchers", "bogus.yml"), nil, 0},
-		{"invalid load provision watcher invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/bogus.yml", nil, 0},
+		{"invalid load provision watcher from invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/bogus.yml", nil, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/provision/provisionwatchers_test.go
+++ b/internal/provision/provisionwatchers_test.go
@@ -35,7 +35,7 @@ func Test_processProvisionWatcherFile(t *testing.T) {
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
 			cache.InitCache(TestDeviceService, TestDeviceService, dic)
-			addProvisionWatchersReq = processProvisonWatcherFile(tt.path, tt.secretProvider, lc, addProvisionWatchersReq)
+			addProvisionWatchersReq = processProvisonWatcherFile(tt.path, tt.path, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumProvisionWatchers, len(addProvisionWatchersReq))
 		})
 	}

--- a/internal/provision/provisionwatchers_test.go
+++ b/internal/provision/provisionwatchers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"path"
 	"testing"
 )
@@ -34,8 +35,9 @@ func Test_processProvisionWatcherFile(t *testing.T) {
 			var addProvisionWatchersReq []requests.AddProvisionWatcherRequest
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
-			cache.InitCache(TestDeviceService, TestDeviceService, dic)
-			addProvisionWatchersReq = processProvisonWatcherFile(tt.path, tt.path, tt.secretProvider, lc)
+			err := cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			require.NoError(t, err)
+			addProvisionWatchersReq = processProvisionWatcherFile(tt.path, tt.path, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumProvisionWatchers, len(addProvisionWatchersReq))
 		})
 	}

--- a/internal/provision/provisionwatchers_test.go
+++ b/internal/provision/provisionwatchers_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// # Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+package provision
+
+import (
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/requests"
+	"github.com/stretchr/testify/assert"
+	"path"
+	"testing"
+)
+
+func Test_processProvisionWatcherFile(t *testing.T) {
+
+	tests := []struct {
+		name                         string
+		path                         string
+		secretProvider               interfaces.SecretProvider
+		expectedNumProvisionWatchers int
+	}{
+		{"valid load provision watcher from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "provisionwatchers", "Simple-Provision-Watcher.yml"), nil, 1},
+		{"valid load provision watcher invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/Simple-Provision-Watcher.yml", nil, 1},
+		{"invalid load provision watcher empty path", "", nil, 0},
+		{"invalid load provision watcher from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "provisionwatchers", "bogus.yml"), nil, 0},
+		{"invalid load provision watcher invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/provisionwatchers/bogus.yml", nil, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var addProvisionWatchersReq []requests.AddProvisionWatcherRequest
+			lc := logger.MockLogger{}
+			dic, _ := NewMockDIC()
+			cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			addProvisionWatchersReq = processProvisonWatcherFile(tt.path, tt.secretProvider, lc, addProvisionWatchersReq)
+			assert.Equal(t, tt.expectedNumProvisionWatchers, len(addProvisionWatchersReq))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
**Non-Secure testing**
1. pull the latest code and build device simple
2. run the non-secure edgex stack
3. run device-simple with its standard configuration
4. stop device-simple 
5. modify the configuration to point to a custom index.json file (created in internal/uri-test-files/*/index.json)
6. run device-simple and ensure that the index.json works without errors

** Secure testing**
1. create a private repo
2. run the secure edgex stack
3. use both configuration options - file and URI
4. run and ensure device-simple works

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->