### PR TITLE
feat: better error handling when running in hybrid mode but common config is missing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/edgexfoundry/device-sdk-go/v3
 
+replace github.com/edgexfoundry/go-mod-bootstrap/v3 => ../go-mod-bootstrap
+
 go 1.20
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,10 @@
 module github.com/edgexfoundry/device-sdk-go/v3
 
-replace github.com/edgexfoundry/go-mod-bootstrap/v3 => ../go-mod-bootstrap
-
 go 1.20
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.8
+	github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.9
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.1.0-dev.2
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.1.0-dev.11
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQNCyp70xik=
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.8 h1:qoVKEMsiJM4nLJtH+0Cia6O9A/8A0w2m0KgCZDaZUNo=
-github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.8/go.mod h1:zVtOPTNUn7jbEchgGFfbjTlLCv/KzOwqTWXxSFGIsVQ=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.9 h1:sO18almJrbT8H2BB14D6gpZe4U6i7zPH0X9xupAOo8o=
+github.com/edgexfoundry/go-mod-bootstrap/v3 v3.1.0-dev.9/go.mod h1:zVtOPTNUn7jbEchgGFfbjTlLCv/KzOwqTWXxSFGIsVQ=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.1.0-dev.3 h1:xWyraOW+RtFwIO+DnCWBKoaa5w1ZX8vRf91zBa2Ll8c=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.1.0-dev.3/go.mod h1:yaxBuJh45+VxXX+nSt/Q+1gGEk4/BDe9edYWm8aEtfg=
 github.com/edgexfoundry/go-mod-core-contracts/v3 v3.1.0-dev.2 h1:H3ls1vyxCv6pigZ/RZlRhj9lUTQq7CiT5/dnZRsgVmQ=

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -51,6 +51,11 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	s.controller = http.NewRestController(b.router, dic, s.serviceKey)
 	s.controller.InitRestRoutes()
 
+	if bootstrapContainer.DeviceClientFrom(dic.Get) == nil {
+		s.lc.Error("Client configuration for core-metadata not found, missing common config? Use -cp or -cc flags for common config.")
+		return false
+	}
+
 	edgexErr := cache.InitCache(s.serviceKey, s.baseServiceName, dic)
 	if edgexErr != nil {
 		s.lc.Errorf("Failed to init cache: %s", edgexErr.Error())

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -188,6 +188,9 @@ func (s *deviceService) MetricsManager() bootstrapInterfaces.MetricsManager {
 
 // LoggingClient returns the logger.LoggingClient
 func (s *deviceService) LoggingClient() logger.LoggingClient {
+	if s.lc == nil {
+		s.lc = bootstrapContainer.LoggingClientFrom(s.dic.Get)
+	}
 	return s.lc
 }
 


### PR DESCRIPTION
with better error message handling from the go-mod-bootstrap PR, there is some logic needs to be fixed to avoid the app being crashed.

Closes: #1479

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- git clone this PR
- run `make` to compile device sdk in the project base directory
- change the directory to device simple under ./example/cmd/device-simple
- run `./device-simple` without -cc flag to see the results of better error handling messages.
- repeat as needed.
- 
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->