### PR TITLE
feat: Accept Url escape in API path

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -71,7 +71,7 @@ func SendEvent(event *dtos.Event, correlationID string, dic *di.Container) {
 	ctx = context.WithValue(ctx, common.ContentType, encoding) // nolint: staticcheck
 	envelope := types.NewMessageEnvelope(bytes, ctx)
 	serviceName := container.DeviceServiceFrom(dic.Get).Name
-	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, serviceName, event.ProfileName, event.DeviceName, common.URLEncode(event.SourceName))
+	publishTopic := common.BuildTopic(configuration.MessageBus.GetBaseTopicPrefix(), common.EventsPublishTopic, DeviceServiceEventPrefix, common.URLEncode(serviceName), common.URLEncode(event.ProfileName), common.URLEncode(event.DeviceName), common.URLEncode(event.SourceName))
 	err = mc.Publish(envelope, publishTopic)
 	if err != nil {
 		lc.Errorf("Failed to publish event to MessageBus: %s", err)

--- a/internal/controller/messaging/callback.go
+++ b/internal/controller/messaging/callback.go
@@ -28,7 +28,7 @@ func MetadataSystemEventsCallback(ctx context.Context, serviceBaseName string, d
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
 	deviceService := container.DeviceServiceFrom(dic.Get)
 	metadataSystemEventTopic := common.BuildTopic(messageBusInfo.GetBaseTopicPrefix(),
-		common.MetadataSystemEventSubscribeTopic, deviceService.Name, "#")
+		common.MetadataSystemEventSubscribeTopic, common.URLEncode(deviceService.Name), "#")
 
 	lc.Infof("Subscribing to System Events on topic: %s", metadataSystemEventTopic)
 
@@ -49,7 +49,7 @@ func MetadataSystemEventsCallback(ctx context.Context, serviceBaseName string, d
 		// Must replace the first wildcard with the type for Provision Watchers
 		baseSubscribeTopic := strings.Replace(common.MetadataSystemEventSubscribeTopic, "+", common.ProvisionWatcherSystemEventType, 1)
 		provisionWatcherSystemEventSubscribeTopic := common.BuildTopic(messageBusInfo.GetBaseTopicPrefix(),
-			baseSubscribeTopic, serviceBaseName, "#")
+			baseSubscribeTopic, common.URLEncode(serviceBaseName), "#")
 
 		topics = append(topics, types.TopicChannel{
 			Topic:    provisionWatcherSystemEventSubscribeTopic,

--- a/internal/controller/messaging/validation.go
+++ b/internal/controller/messaging/validation.go
@@ -23,7 +23,7 @@ import (
 func SubscribeDeviceValidation(ctx context.Context, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	messageBusInfo := container.ConfigurationFrom(dic.Get).MessageBus
-	serviceName := container.DeviceServiceFrom(dic.Get).Name
+	serviceName := common.URLEncode(container.DeviceServiceFrom(dic.Get).Name)
 
 	requestTopic := common.BuildTopic(messageBusInfo.GetBaseTopicPrefix(), serviceName, common.ValidateDeviceSubscribeTopic)
 	lc.Infof("Subscribing to device validation requests on topic: %s", requestTopic)


### PR DESCRIPTION
Use escaped for message bus topic
- service name
- profile name
- device name

Close #1495

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ]  I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core service and device service to test the API.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->