### PR TITLE
feat: Add device last connected metrics

### DIFF
--- a/internal/application/command.go
+++ b/internal/application/command.go
@@ -63,6 +63,8 @@ func GetCommand(ctx context.Context, deviceName string, commandName string, quer
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	lc.Debugf("GET Device Command successfully. Device: %s, Source: %s, %s: %s", deviceName, commandName, common.CorrelationHeader, utils.FromContext(ctx, common.CorrelationHeader))
+
+	cache.Devices().SetLastConnectedByName(deviceName)
 	return res, nil
 }
 
@@ -93,6 +95,8 @@ func SetCommand(ctx context.Context, deviceName string, commandName string, quer
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	lc.Debugf("SET Device Command successfully. Device: %s, Source: %s, %s: %s", deviceName, commandName, common.CorrelationHeader, utils.FromContext(ctx, common.CorrelationHeader))
+
+	cache.Devices().SetLastConnectedByName(deviceName)
 	return event, nil
 }
 

--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -12,11 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
-
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 
@@ -72,13 +69,9 @@ func newDeviceCache(devices []models.Device, dic *di.Container) DeviceCache {
 func registerMetric(deviceName string, metric interface{}, dic *di.Container) {
 	metricsManager := bootstrapContainer.MetricsManagerFrom(dic.Get)
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
-	configuration := container.ConfigurationFrom(dic.Get)
-	if configuration.Service.EnableNameFieldEscape {
-		deviceName = common.URLEncode(deviceName)
-	}
 	registeredName := strings.Replace(lastConnectedPrefix, deviceNameText, deviceName, 1)
 
-	err := metricsManager.Register(registeredName, metric, map[string]string{"device": deviceName})
+	err := metricsManager.Register(registeredName, metric, nil)
 	if err != nil {
 		lc.Warnf("Unable to register %s metric. Metric will not be reported : %s", registeredName, err.Error())
 	} else {
@@ -88,10 +81,6 @@ func registerMetric(deviceName string, metric interface{}, dic *di.Container) {
 
 func unregisterMetric(deviceName string, dic *di.Container) {
 	metricsManager := bootstrapContainer.MetricsManagerFrom(dic.Get)
-	configuration := container.ConfigurationFrom(dic.Get)
-	if configuration.Service.EnableNameFieldEscape {
-		deviceName = common.URLEncode(deviceName)
-	}
 	registeredName := strings.Replace(lastConnectedPrefix, deviceNameText, deviceName, 1)
 
 	metricsManager.Unregister(registeredName)

--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -71,7 +71,7 @@ func registerMetric(deviceName string, metric interface{}, dic *di.Container) {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	registeredName := strings.Replace(lastConnectedPrefix, deviceNameText, deviceName, 1)
 
-	err := metricsManager.Register(registeredName, metric, nil)
+	err := metricsManager.Register(registeredName, metric, map[string]string{"device": deviceName})
 	if err != nil {
 		lc.Warnf("Unable to register %s metric. Metric will not be reported : %s", registeredName, err.Error())
 	} else {

--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -217,12 +217,17 @@ func Devices() DeviceCache {
 	return dc
 }
 
+// currentTimestamp returns the current timestamp in nanoseconds
+var currentTimestamp = func() int64 {
+	return time.Now().UnixNano()
+}
+
 func (d *deviceCache) SetLastConnectedByName(name string) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
 	g := d.lastConnected[name]
-	g.Update(time.Now().UnixNano())
+	g.Update(currentTimestamp())
 }
 
 func (d *deviceCache) GetLastConnectedByName(name string) int64 {

--- a/internal/cache/devices_test.go
+++ b/internal/cache/devices_test.go
@@ -8,8 +8,12 @@ package cache
 import (
 	"testing"
 
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/config"
+	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
+
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
+	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
@@ -41,6 +45,16 @@ func mockDic() *di.Container {
 		},
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()
+		},
+		container.ConfigurationName: func(get di.Get) interface{} {
+			return &config.ConfigurationStruct{
+				Writable: config.WritableInfo{
+					LogLevel: "INFO",
+				},
+				Service: bootstrapConfig.ServiceInfo{
+					EnableNameFieldEscape: true,
+				},
+			}
 		},
 	})
 }

--- a/internal/cache/devices_test.go
+++ b/internal/cache/devices_test.go
@@ -7,6 +7,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/config"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
@@ -160,4 +161,27 @@ func Test_deviceCache_UpdateAdminState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_deviceCache_SetLastConnectedByName(t *testing.T) {
+	dic := mockDic()
+	newDeviceCache([]models.Device{testDevice}, dic)
+
+	// Make currentTimestamp return currentTimeInstant constant in unit test
+	currentTimeInstant := time.Now().UnixNano()
+	currentTimestamp = func() int64 {
+		return currentTimeInstant
+	}
+
+	dc.SetLastConnectedByName(TestDevice)
+	lastConnectedTime := dc.GetLastConnectedByName(TestDevice)
+	require.Equal(t, currentTimeInstant, lastConnectedTime)
+}
+
+func Test_deviceCache_GetLastConnectedByName(t *testing.T) {
+	dic := mockDic()
+	newDeviceCache([]models.Device{testDevice}, dic)
+
+	lastConnectedTime := dc.GetLastConnectedByName(TestDevice)
+	require.Equal(t, int64(0), lastConnectedTime)
 }

--- a/internal/cache/init.go
+++ b/internal/cache/init.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2021 IOTech Ltd
+// Copyright (C) 2020-2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,7 +32,7 @@ func InitCache(instanceName string, baseServiceName string, dic *di.Container) e
 	for i := range deviceRes.Devices {
 		devices[i] = dtos.ToDeviceModel(deviceRes.Devices[i])
 	}
-	newDeviceCache(devices)
+	newDeviceCache(devices, dic)
 
 	// init profile cache
 	profiles := make([]models.DeviceProfile, len(devices))

--- a/internal/common/utils_test.go
+++ b/internal/common/utils_test.go
@@ -122,6 +122,10 @@ func NewMockDIC() *di.Container {
 	pwcMock := &clientMocks.ProvisionWatcherClient{}
 	pwcMock.On("ProvisionWatchersByServiceName", context.Background(), TestDeviceService, 0, -1).Return(responses.MultiProvisionWatchersResponse{}, nil)
 
+	mockMetricsManager := &mocks.MetricsManager{}
+	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMetricsManager.On("Unregister", mock.Anything)
+
 	return di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
@@ -140,6 +144,9 @@ func NewMockDIC() *di.Container {
 		},
 		bootstrapContainer.ProvisionWatcherClientName: func(get di.Get) interface{} {
 			return pwcMock
+		},
+		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+			return mockMetricsManager
 		},
 	})
 }

--- a/internal/controller/http/command_test.go
+++ b/internal/controller/http/command_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	bootstrapMocks "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
@@ -170,6 +171,11 @@ func mockDic() *di.Container {
 	mockDriver.On("HandleReadCommands", driverErrorDevice, mock.Anything, mock.Anything).Return(nil, errors.New("ProtocolDriver returned error"))
 	mockDriver.On("HandleWriteCommands", testDevice, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockDriver.On("HandleWriteCommands", driverErrorDevice, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("ProtocolDriver returned error"))
+
+	mockMetricsManager := &bootstrapMocks.MetricsManager{}
+	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMetricsManager.On("Unregister", mock.Anything)
+
 	dic := di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) any {
 			return &config.ConfigurationStruct{
@@ -198,6 +204,9 @@ func mockDic() *di.Container {
 				Name:       testService,
 				AdminState: models.Unlocked,
 			}
+		},
+		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+			return mockMetricsManager
 		},
 	})
 

--- a/internal/provision/mockdic_test.go
+++ b/internal/provision/mockdic_test.go
@@ -1,6 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // # Copyright (C) 2023 Intel Corporation
+// # Copyright (C) 2023 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 package provision
@@ -10,12 +11,14 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/config"
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/container"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	bootstrapMocks "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -96,6 +99,10 @@ func NewMockDIC() (*di.Container, *clientMocks.DeviceProfileClient) {
 	pwcMock := &clientMocks.ProvisionWatcherClient{}
 	pwcMock.On("ProvisionWatchersByServiceName", context.Background(), TestDeviceService, 0, -1).Return(responses.MultiProvisionWatchersResponse{}, nil)
 
+	mockMetricsManager := &bootstrapMocks.MetricsManager{}
+	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMetricsManager.On("Unregister", mock.Anything)
+
 	return di.NewContainer(di.ServiceConstructorMap{
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
@@ -114,6 +121,9 @@ func NewMockDIC() (*di.Container, *clientMocks.DeviceProfileClient) {
 		},
 		bootstrapContainer.ProvisionWatcherClientName: func(get di.Get) interface{} {
 			return pwcMock
+		},
+		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+			return mockMetricsManager
 		},
 	}), dpcMock
 }

--- a/internal/transformer/transform_test.go
+++ b/internal/transformer/transform_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	bootstrapMocks "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
@@ -21,6 +22,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/dtos/responses"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/device-sdk-go/v3/internal/cache"
@@ -109,6 +111,10 @@ func NewMockDIC() *di.Container {
 		Device: config.DeviceInfo{MaxCmdOps: 1},
 	}
 
+	mockMetricsManager := &bootstrapMocks.MetricsManager{}
+	mockMetricsManager.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockMetricsManager.On("Unregister", mock.Anything)
+
 	return di.NewContainer(di.ServiceConstructorMap{
 		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
 			return logger.NewMockClient()
@@ -127,6 +133,9 @@ func NewMockDIC() *di.Container {
 		},
 		container.ConfigurationName: func(get di.Get) interface{} {
 			return configuration
+		},
+		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
+			return mockMetricsManager
 		},
 	})
 }

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -53,6 +53,9 @@ func (s *deviceService) sendAsyncValues(acv *sdkModels.AsyncValues, working chan
 		<-working
 	}()
 
+	// Update the LastConnected metric in deviceCache
+	cache.Devices().SetLastConnectedByName(acv.DeviceName)
+
 	if len(acv.CommandValues) == 0 {
 		s.lc.Error("Skip sending AsyncValues because the CommandValues is empty.")
 		return


### PR DESCRIPTION
fixes #1470. Add device last connected metrics to Get/Set command.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) - https://github.com/edgexfoundry/edgex-docs/pull/1231
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->