### PR TITLE
fix: Don't run auto events for empty profile

### DIFF
--- a/internal/autoevent/manager.go
+++ b/internal/autoevent/manager.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2020 IOTech Ltd
+// Copyright (C) 2019-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -69,6 +69,10 @@ func (m *manager) StartAutoEvents() {
 	defer m.mutex.Unlock()
 
 	for _, d := range cache.Devices().All() {
+		if len(d.ProfileName) == 0 || d.AdminState == models.Locked {
+			// don't run the auto event if the device doesn't define the profile, or it is locked
+			continue
+		}
 		if _, ok := m.executorMap[d.Name]; !ok {
 			executors := m.triggerExecutors(d.Name, d.AutoEvents, m.dic)
 			m.executorMap[d.Name] = executors
@@ -100,6 +104,11 @@ func (m *manager) RestartForDevice(deviceName string) {
 	d, ok := cache.Devices().ForName(deviceName)
 	if !ok {
 		lc.Errorf("failed to find device %s in cache to start AutoEvent", deviceName)
+	}
+
+	if len(d.ProfileName) == 0 || d.AdminState == models.Locked {
+		// don't run the auto event if the device doesn't define the profile, or it is locked
+		return
 	}
 
 	m.mutex.Lock()


### PR DESCRIPTION
Auto Events should not be triggered if the Device Profile is empty or the Device is locked
Close https://github.com/edgexfoundry/device-sdk-go/issues/1613

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->