### PR TITLE
fix: Initialize DeviceService.Properties with an empty map

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -295,6 +295,7 @@ func (s *deviceService) selfRegister() edgexErr.EdgeX {
 		Labels:      s.config.Device.Labels,
 		BaseAddress: bootstrapTypes.DefaultHttpProtocol + "://" + s.config.Service.Host + ":" + strconv.FormatInt(int64(s.config.Service.Port), 10),
 		AdminState:  models.Unlocked,
+		Properties:  make(map[string]any),
 	}
 	*s.deviceServiceModel = localDeviceService
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck


### PR DESCRIPTION
Initialize DeviceService.Properties with an empty map to avoid unintended access to a nil map
fix: #1656 
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) currently not used in sdk
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

