### PR TITLE
fix: Upgrade go-mod-bootstrap module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.23
 
 require (
 	github.com/OneOfOne/xxhash v1.2.8
-	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.15
-	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.16
+	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16
+	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.19
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.10
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -70,12 +70,12 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.15 h1:oeSDtoah8q3sBo8huqNdRjjxRF5IcsLh0kby0gJW/o4=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.15/go.mod h1:D+fSf0PWO9E4nz+1tVe0OGYnBeRQ1nHdF3B1tnYrq60=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16 h1:NSEoo/YnSDNWQcZpLAtXqDKHAId5mecTVBxk9zs/ROg=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.16/go.mod h1:66I+qRA22YkjA/SYw4F9R0avZ9oNYM8bg2qhwePTFkI=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.10 h1:DMv5LZDxcqUeb1dREMd/vK+reXmZYlpafgtm8XhYdHQ=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.10/go.mod h1:ltUpMcOpJSzmabBtZox5qg1AK2wEikvZJyIBXtJ7mUQ=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.16 h1:Kb0W7HAFoXdWGN7aYJcLOEgGUTo2v2/BJicGGlOLLng=
-github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.16/go.mod h1:M5JXcRrmnIVNAmqeDNVXd0PSOGdq96fgrEmzivx02c8=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.19 h1:uXZml7n/I/+c7k3eZRuJRrlWjYx/Euk8tlnBqeitvB8=
+github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.19/go.mod h1:M5JXcRrmnIVNAmqeDNVXd0PSOGdq96fgrEmzivx02c8=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.10 h1:xvDQDIJtmj/ZCmKzbAzg3h1F2ZdWz1MPoJSNfYZANGc=
 github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.10/go.mod h1:ibaiw7r3RgLYDuuFfWT1kh//bjP+onDOOQsnSsdD4E8=
 github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.3 h1:6tw6JqEJDOqo2lEgxjZ+scvsub5R20WGpInCuoxS6zE=

--- a/internal/controller/http/restrouter.go
+++ b/internal/controller/http/restrouter.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2023 IOTech Ltd
+// Copyright (C) 2018-2025 IOTech Ltd
 // Copyright (c) 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/handlers"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces"
@@ -52,11 +51,10 @@ func (c *RestController) SetCustomConfigInfo(customConfig interfaces.UpdatableCo
 	c.customConfig = customConfig
 }
 
-func (c *RestController) InitRestRoutes() {
+func (c *RestController) InitRestRoutes(dic *di.Container) {
 	c.lc.Info("Registering routes...")
 
-	secretProvider := container.SecretProviderExtFrom(c.dic.Get)
-	authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, c.lc)
+	authenticationHook := handlers.AutoConfigAuthenticationFunc(dic)
 
 	// discovery
 	c.addReservedRoute(common.ApiDiscoveryRoute, c.Discovery, http.MethodPost, authenticationHook)

--- a/internal/controller/http/restrouter_test.go
+++ b/internal/controller/http/restrouter_test.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ func TestAddRoute(t *testing.T) {
 	for _, test := range tests {
 		r := echo.New()
 		controller := NewRestController(r, dic, uuid.NewString())
-		controller.InitRestRoutes()
+		controller.InitRestRoutes(dic)
 
 		err := controller.AddRoute(test.Route, handlerFunc, []string{test.Method})
 		if test.ErrorExpected {
@@ -116,7 +116,7 @@ func TestInitRestRoutes(t *testing.T) {
 	})
 	r := echo.New()
 	controller := NewRestController(r, dic, uuid.NewString())
-	controller.InitRestRoutes()
+	controller.InitRestRoutes(dic)
 
 	// Traverse all registered routes for the router
 	for _, route := range r.Routes() {

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -50,7 +50,7 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 	s.commonController = controller.NewCommonController(dic, b.router, s.serviceKey, common.ServiceVersion)
 	s.commonController.SetSDKVersion(common.SDKVersion)
 	s.controller = http.NewRestController(b.router, dic, s.serviceKey)
-	s.controller.InitRestRoutes()
+	s.controller.InitRestRoutes(dic)
 
 	if bootstrapContainer.DeviceClientFrom(dic.Get) == nil {
 		s.lc.Error("Client configuration for core-metadata not found, missing common config? Use -cp or -cc flags for common config.")

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2024 IOTech Ltd
+// Copyright (C) 2018-2025 IOTech Ltd
 // Copyright (C) 2019,2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -244,9 +244,7 @@ func (s *deviceService) AddRoute(route string, handler func(http.ResponseWriter,
 // AddCustomRoute allows leveraging the existing internal web server to add routes specific to Device Service.
 func (s *deviceService) AddCustomRoute(route string, authentication interfaces.Authentication, handler func(e echo.Context) error, methods ...string) error {
 	if authentication == interfaces.Authenticated {
-		lc := bootstrapContainer.LoggingClientFrom(s.dic.Get)
-		secretProvider := bootstrapContainer.SecretProviderExtFrom(s.dic.Get)
-		authenticationHook := handlers.AutoConfigAuthenticationFunc(secretProvider, lc)
+		authenticationHook := handlers.AutoConfigAuthenticationFunc(s.dic)
 
 		return s.controller.AddRoute(route, handler, methods, authenticationHook)
 	}


### PR DESCRIPTION
Fixes #1670. Upgrade go-mod-bootstrap module to use the latest auth middleware function.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->