### PR TITLE
feat: Add device up/down detection

### DIFF
--- a/internal/application/callback.go
+++ b/internal/application/callback.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -96,6 +96,10 @@ func AddDevice(addDeviceRequest requests.AddDeviceRequest, dic *di.Container) er
 		return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
 
+	config := container.ConfigurationFrom(dic.Get)
+	reqFailsTracker := container.AllowedRequestFailuresTrackerFrom(dic.Get)
+	reqFailsTracker.Set(device.Name, int(config.Device.AllowedFails))
+
 	lc.Debugf("starting AutoEvents for device %s", device.Name)
 	container.AutoEventManagerFrom(dic.Get).RestartForDevice(device.Name)
 	return nil
@@ -189,6 +193,9 @@ func DeleteDevice(name string, dic *di.Container) errors.EdgeX {
 		errMsg := fmt.Sprintf("driver.RemoveDevice callback failed for %s", device.Name)
 		return errors.NewCommonEdgeX(errors.KindServerError, errMsg, err)
 	}
+
+	reqFailsTracker := container.AllowedRequestFailuresTrackerFrom(dic.Get)
+	reqFailsTracker.Remove(device.Name)
 
 	return nil
 }

--- a/internal/application/devicereturn.go
+++ b/internal/application/devicereturn.go
@@ -1,0 +1,108 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"context"
+	"time"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
+	sdkCommon "github.com/edgexfoundry/device-sdk-go/v4/internal/common"
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/container"
+)
+
+func deviceReturn(deviceName string, dic *di.Container) {
+	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	dc := bootstrapContainer.DeviceClientFrom(dic.Get)
+	config := container.ConfigurationFrom(dic.Get)
+
+	for {
+	LOOP:
+		time.Sleep(time.Duration(config.Device.DeviceDownTimeout) * time.Second)
+		lc.Infof("Checking operational state for device: %s", deviceName)
+
+		d, found := cache.Devices().ForName(deviceName)
+		if !found {
+			lc.Warnf("Device %s not found. Exiting retry loop.", deviceName)
+			return
+		}
+
+		if d.OperatingState == models.Up {
+			lc.Infof("Device %s is already operational. Exiting retry loop.", deviceName)
+			return
+		}
+
+		p, found := cache.Profiles().ForName(d.ProfileName)
+		if !found {
+			lc.Warnf("Device %s has no profile. Cannot set operational state automatically.", deviceName)
+			return
+		}
+
+		for _, dr := range p.DeviceResources {
+			if dr.Properties.ReadWrite == common.ReadWrite_R ||
+				dr.Properties.ReadWrite == common.ReadWrite_RW ||
+				dr.Properties.ReadWrite == common.ReadWrite_WR {
+				_, err := GetCommand(context.Background(), deviceName, dr.Name, "", true, dic)
+				if err == nil {
+					lc.Infof("Device %s responsive: setting operational state to up.", deviceName)
+					sdkCommon.UpdateOperatingState(deviceName, models.Up, lc, dc)
+					return
+				} else {
+					lc.Errorf("Device %s unresponsive: retrying in %v seconds.", deviceName, config.Device.DeviceDownTimeout)
+					goto LOOP
+				}
+			}
+		}
+		lc.Infof("Device %s has no readable resources. Setting operational state to up without checking.", deviceName)
+		sdkCommon.UpdateOperatingState(deviceName, models.Up, lc, dc)
+		return
+	}
+}
+
+func DeviceRequestFailed(deviceName string, dic *di.Container) {
+	config := container.ConfigurationFrom(dic.Get)
+	if config.Device.AllowedFails > 0 {
+		lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+		dc := bootstrapContainer.DeviceClientFrom(dic.Get)
+		reqFailsTracker := container.AllowedRequestFailuresTrackerFrom(dic.Get)
+
+		if reqFailsTracker.Decrease(deviceName) == 0 {
+			d, ok := cache.Devices().ForName(deviceName)
+			if !ok {
+				return
+			}
+			if d.OperatingState != models.Down {
+				lc.Infof("Marking device %s non-operational", deviceName)
+				sdkCommon.UpdateOperatingState(deviceName, models.Down, lc, dc)
+			}
+			if config.Device.DeviceDownTimeout > 0 {
+				lc.Warnf("Will retry device %s in %v seconds", deviceName, config.Device.DeviceDownTimeout)
+				go deviceReturn(deviceName, dic)
+			}
+			return
+		}
+	}
+}
+
+func DeviceRequestSucceeded(d models.Device, dic *di.Container) {
+	config := container.ConfigurationFrom(dic.Get)
+	reqFailsTracker := container.AllowedRequestFailuresTrackerFrom(dic.Get)
+	if config.Device.AllowedFails > 0 && reqFailsTracker.Value(d.Name) < int(config.Device.AllowedFails) {
+		reqFailsTracker.Set(d.Name, int(config.Device.AllowedFails))
+		if d.OperatingState == models.Down {
+			lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+			dc := bootstrapContainer.DeviceClientFrom(dic.Get)
+			sdkCommon.UpdateOperatingState(d.Name, models.Up, lc, dc)
+		}
+	}
+}

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2019-2023 IOTech Ltd
+// Copyright (C) 2019-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/internal/cache/devices.go
+++ b/internal/cache/devices.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -50,13 +50,10 @@ type deviceCache struct {
 func newDeviceCache(devices []models.Device, dic *di.Container) DeviceCache {
 	defaultSize := len(devices)
 	dMap := make(map[string]*models.Device, defaultSize)
-	for i, d := range devices {
-		dMap[d.Name] = &devices[i]
-	}
-
 	dc = &deviceCache{deviceMap: dMap, dic: dic}
 	lastConnectedMetrics := make(map[string]gometrics.Gauge)
 	for _, d := range devices {
+		dMap[d.Name] = &d
 		deviceMetric := gometrics.NewGauge()
 		registerMetric(d.Name, deviceMetric, dic)
 		lastConnectedMetrics[d.Name] = deviceMetric

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,7 +1,7 @@
 // -*- mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2023 IOTech Ltd
+// Copyright (C) 2018-2025 IOTech Ltd
 // Copyright (c) 2021 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -53,6 +53,10 @@ type DeviceInfo struct {
 	EnableAsyncReadings bool
 	// Labels are properties applied to the device service to help with searching
 	Labels []string
+	// AllowedFails specifies the number of failed requests allowed before a device is marked as down.
+	AllowedFails uint
+	// DeviceDownTimeout specifies the duration in seconds that the Device Service will try to contact a device if it is marked as down.
+	DeviceDownTimeout uint
 }
 
 // DiscoveryInfo is a struct which contains configuration of device auto discovery.

--- a/internal/container/allowedfailstracker.go
+++ b/internal/container/allowedfailstracker.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+// AllowedFailuresTracker wraps a map of device names to atomic integers that track the number of allowed request
+// failures for each device.
+type AllowedFailuresTracker struct {
+	data map[string]*AtomicInt
+}
+
+// NewAllowedFailuresTracker creates and initializes a new tracker.
+func NewAllowedFailuresTracker() AllowedFailuresTracker {
+	return AllowedFailuresTracker{
+		data: make(map[string]*AtomicInt),
+	}
+}
+
+// Get retrieves the AtomicInt for a given device name.
+// Returns nil if the device does not exist.
+func (aft *AllowedFailuresTracker) Get(deviceName string) *AtomicInt {
+	return aft.data[deviceName]
+}
+
+// Set initializes or updates the AtomicInt for a given device.
+func (aft *AllowedFailuresTracker) Set(deviceName string, value int) {
+	if _, exists := aft.data[deviceName]; !exists {
+		aft.data[deviceName] = &AtomicInt{}
+	}
+	aft.data[deviceName].Set(value)
+}
+
+// Decrease decreases the AtomicInt value for a given device by 1.
+// Returns the updated value or -1 if the device does not exist.
+func (aft *AllowedFailuresTracker) Decrease(deviceName string) int {
+	if atomicInt, exists := aft.data[deviceName]; exists {
+		if atomicInt.Value() >= 0 {
+			return atomicInt.Decrease()
+		}
+	}
+	return -1
+}
+
+// Value retrieves the current value of the AtomicInt for a device.
+// Returns -1 if the device does not exist.
+func (aft *AllowedFailuresTracker) Value(deviceName string) int {
+	if atomicInt, exists := aft.data[deviceName]; exists {
+		return atomicInt.Value()
+	}
+	return -1
+}
+
+// Remove deletes the entry for a given device name from the tracker.
+func (aft *AllowedFailuresTracker) Remove(deviceName string) {
+	delete(aft.data, deviceName)
+}

--- a/internal/container/atomicint.go
+++ b/internal/container/atomicint.go
@@ -1,0 +1,34 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//
+// Copyright (C) 2025 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import "sync"
+
+type AtomicInt struct {
+	mutex sync.RWMutex
+	value int
+}
+
+func (i *AtomicInt) Value() int {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+	v := i.value
+	return v
+}
+
+func (i *AtomicInt) Decrease() int {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	i.value--
+	return i.value
+}
+
+func (i *AtomicInt) Set(v int) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	i.value = v
+}

--- a/internal/container/deviceservice.go
+++ b/internal/container/deviceservice.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -59,4 +59,12 @@ func DiscoveryRequestIdFrom(get di.Get) string {
 		return ""
 	}
 	return id
+}
+
+// AllowedRequestFailuresTrackerName contains the name of allowed request failures tracker in the DIC.
+var AllowedRequestFailuresTrackerName = di.TypeInstanceToName(AllowedFailuresTracker{})
+
+// AllowedRequestFailuresTrackerFrom helper function queries the DIC and returns a device request failures tracker.
+func AllowedRequestFailuresTrackerFrom(get di.Get) AllowedFailuresTracker {
+	return get(AllowedRequestFailuresTrackerName).(AllowedFailuresTracker)
 }

--- a/internal/controller/http/command_test.go
+++ b/internal/controller/http/command_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2023 IOTech Ltd
+// Copyright (C) 2022-2025 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -207,6 +207,9 @@ func mockDic() *di.Container {
 		},
 		bootstrapContainer.MetricsManagerInterfaceName: func(get di.Get) interface{} {
 			return mockMetricsManager
+		},
+		container.AllowedRequestFailuresTrackerName: func(get di.Get) any {
+			return container.NewAllowedFailuresTracker()
 		},
 	})
 

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -63,6 +63,18 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, _ 
 		return false
 	}
 
+	devices := cache.Devices().All()
+	config := container.ConfigurationFrom(dic.Get)
+	reqFailsTracker := container.NewAllowedFailuresTracker()
+	for _, d := range devices {
+		reqFailsTracker.Set(d.Name, int(config.Device.AllowedFails))
+	}
+	dic.Update(di.ServiceConstructorMap{
+		container.AllowedRequestFailuresTrackerName: func(get di.Get) any {
+			return reqFailsTracker
+		},
+	})
+
 	if s.AsyncReadingsEnabled() {
 		s.asyncCh = make(chan *models.AsyncValues, s.config.Device.AsyncBufferSize)
 		wg.Add(1)


### PR DESCRIPTION
fix: #1665 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) 
  https://github.com/edgexfoundry/edgex-docs/pull/1407

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run Edgex stack using Edgex compose-builder
```
make run no-secty modbus-sim
```
Run device-modbus with this version of the device sdk and the following configuration
```
Writable:
  LogLevel: INFO

Service:
  Host: localhost
  Port: 59901
  StartupMsg: device modbus started

MessageBus:
  Optional:
    ClientId: device-modbus

Device:
  ProfilesDir: ""
  DevicesDir: ""
  AllowedFails: 1
  DeviceDownTimeout: 10
```
Upload device profile and onboard a device
```
# profile sample: https://github.com/edgexfoundry/device-modbus-go/blob/main/cmd/res/profiles/modbus.test.device.profile.yml 
curl http://localhost:59881/api/v3/deviceprofile/uploadfile -F "file=@modbus.test.device.profile.yml"
```
```
curl http://localhost:59881/api/v3/device -H "Content-Type:application/json" -X POST \
  -d '[
        {
            "apiVersion" : "v3",
            "device": {
               "name" :"Modbus-TCP-Temperature-Sensor",
               "description":"This device is a product for monitoring the temperature via the ethernet",
               "labels":[ 
                  "Temperature",
                  "Modbus TCP"
               ],
               "serviceName": "device-modbus",
               "profileName": "Test-Device-Modbus-Profile",
               "protocols":{
                  "modbus-tcp":{
                     "Address" : "localhost",
                     "Port" : "1502",
                     "UnitID" : "1",
                     "Timeout" : "1",
                     "IdleTimeout" : "1"
                  }
               },
               "autoEvents":[ 
                  { 
                     "Interval":"5s",
                     "onChange":false,
                     "SourceName":"Temperature"
                  }
               ],
               "adminState":"UNLOCKED",
               "operatingState":"UP"
            }
        }
    ]'
```
Stop the modbus simulator and the following will be in device-modbus's log
```
level=INFO ts=2025-01-07T20:23:55.013483+08:00 app=device-modbus source=driver.go:137 msg="Read command failed. Cmd:Temperature err:dial tcp [::1]:1502: connect: connection refused \n"
level=INFO ts=2025-01-07T20:23:55.013616+08:00 app=device-modbus source=opstate.go:85 msg="Marking device Modbus-TCP-Temperature-Sensor non-operational"
level=WARN ts=2025-01-07T20:23:55.036664+08:00 app=device-modbus source=opstate.go:88 msg="Will retry device Modbus-TCP-Temperature-Sensor in 10 seconds"
level=ERROR ts=2025-01-07T20:23:55.036749+08:00 app=device-modbus source=executor.go:61 msg="AutoEvent - error occurs when reading resource Temperature: error reading Regex DeviceResource(s) Temperature for Modbus-TCP-Temperature-Sensor -> dial tcp [::1]:1502: connect: connection refused"

level=INFO ts=2025-01-07T20:24:05.037492+08:00 app=device-modbus source=opstate.go:31 msg="Checking operational state for device: Modbus-TCP-Temperature-Sensor"
level=INFO ts=2025-01-07T20:24:05.040394+08:00 app=device-modbus source=driver.go:137 msg="Read command failed. Cmd:SwitchA err:dial tcp [::1]:1502: connect: connection refused \n"
level=ERROR ts=2025-01-07T20:24:05.040509+08:00 app=device-modbus source=opstate.go:60 msg="Device Modbus-TCP-Temperature-Sensor unresponsive: retrying in 10 seconds."
```
Restart the modbus simulator and the following will be in device-modbus's log
```
level=INFO ts=2025-01-07T20:24:25.04497+08:00 app=device-modbus source=opstate.go:31 msg="Checking operational state for device: Modbus-TCP-Temperature-Sensor"
2025/01/07 20:24:25 modbus: sending 00 08 00 00 00 06 01 01 00 00 00 01
2025/01/07 20:24:25 modbus: received 00 08 00 00 00 04 01 01 01 00
level=INFO ts=2025-01-07T20:24:25.08558+08:00 app=device-modbus source=modbusclient.go:91 msg="Modbus client GetValue's results [0]"
level=INFO ts=2025-01-07T20:24:25.086155+08:00 app=device-modbus source=driver.go:167 msg="Read command finished. Cmd:SwitchA, DeviceResource: SwitchA, Bool: false \n"
level=INFO ts=2025-01-07T20:24:25.086872+08:00 app=device-modbus source=opstate.go:56 msg="Device Modbus-TCP-Temperature-Sensor responsive: setting operational state to up."

```
Or if the device's operating state has already returned to UP before the check, the following will be in device-modbus's log
```
level=INFO ts=2025-01-07T20:29:09.03874+08:00 app=device-modbus source=opstate.go:31 msg="Checking operational state for device: Modbus-TCP-Temperature-Sensor"
level=INFO ts=2025-01-07T20:29:09.03894+08:00 app=device-modbus source=opstate.go:40 msg="Device Modbus-TCP-Temperature-Sensor is already operational. Exiting retry loop."
```


