### PR TITLE
feat: Ensure AutoEvent execution happens at the configured interval

### DIFF
--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -53,13 +53,9 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, buffer chan bool
 		select {
 		case <-ctx.Done():
 			return
-		default:
+		case <-time.After(time.Until(deadline)):
 			if e.stop {
 				return
-			}
-			sleepDuration := time.Until(deadline)
-			if sleepDuration > 0 {
-				time.Sleep(sleepDuration)
 			}
 			deadline = deadline.Add(e.duration)
 			lc.Debugf("AutoEvent - reading %s", e.sourceName)

--- a/internal/autoevent/executor.go
+++ b/internal/autoevent/executor.go
@@ -47,14 +47,21 @@ func (e *Executor) Run(ctx context.Context, wg *sync.WaitGroup, buffer chan bool
 	defer wg.Done()
 
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
+	deadline := time.Now().Add(e.duration)
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(e.duration):
+		default:
 			if e.stop {
 				return
 			}
+			sleepDuration := time.Until(deadline)
+			if sleepDuration > 0 {
+				time.Sleep(sleepDuration)
+			}
+			deadline = deadline.Add(e.duration)
 			lc.Debugf("AutoEvent - reading %s", e.sourceName)
 			evt, err := readResource(e, dic)
 			if err != nil {


### PR DESCRIPTION
This change ensures AutoEvent execution happens at the given interval. If `readResource` takes longer than the AutoEvent interval, events will come at the speed of the read function.

fix: #1627 
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Use [device-simple](https://github.com/edgexfoundry/device-sdk-go/tree/main/example). Modify the [HandleReadCommands](https://github.com/edgexfoundry/device-sdk-go/blob/ef783aee92ebef88ebd5d55046da9029b3983fb4/example/driver/simpledriver.go#L180-L182) method in simpledriver.go to include a time.Sleep call to simulate a delay in reading resources.
2. In the [device configuration](https://github.com/edgexfoundry/device-sdk-go/blob/ef783aee92ebef88ebd5d55046da9029b3983fb4/example/cmd/device-simple/res/devices/simple-device.yml#L11-L14), extend/shorten the autoevent interval setting (based on the sleep duration in step 1) to test different interval durations.
3. Run device-simple.
 4. Check the timestamps of the autoevents to verify that they are taking place at the expected intervals.
