### PR TITLE
feat: Issue-1745 Add cli flag to overwrite existing device profiles and devices in core-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following command line options are available
   -od
   --overwriteDevices
         Overwrite core-metadata with the versions of the associated device files.  
-        *** Use with cation *** Use will clobber existing devices in core-metadata, problematic 
+        *** Use with caution *** Use will clobber existing devices in core-metadata, problematic 
         if those devices were edited by hand intentionally.
   -r
   --registry

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ The following command line options are available
   -o
   --overwrite
         Overwrite configuration in the Registry with local values.
+  -op 
+  --overwriteProfiles
+        Overwrite core-metadata with the versions of the associated device profile files.  
+        *** Use with cation *** Use will clobber existing profiles in core-metadata, problematic 
+        if those profiles were edited by hand intentionally or used by other services.
+  -od
+  --overwriteDevices
+        Overwrite core-metadata with the versions of the associated device files.  
+        *** Use with cation *** Use will clobber existing devices in core-metadata, problematic 
+        if those devices were edited by hand intentionally.
   -r
   --registry
         Indicates the service should use the registry.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following command line options are available
   -op 
   --overwriteProfiles
         Overwrite core-metadata with the versions of the associated device profile files.  
-        *** Use with cation *** Use will clobber existing profiles in core-metadata, problematic 
+        *** Use with caution *** Use will clobber existing profiles in core-metadata, problematic 
         if those profiles were edited by hand intentionally or used by other services.
   -od
   --overwriteDevices

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -7,38 +7,52 @@
 package provision
 
 import (
+	"net/url"
+	"path"
+	"testing"
+
 	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/url"
-	"path"
-	"testing"
 )
 
 func Test_processDevices(t *testing.T) {
 	tests := []struct {
-		name               string
-		path               string
-		secretProvider     interfaces.SecretProvider
-		expectedNumDevices int
+		name                  string
+		path                  string
+		update                bool
+		secretProvider        interfaces.SecretProvider
+		expectedNumDevices    int
+		expectedUpdateDevices int
 	}{
-		{"valid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), nil, 2},
-		{"valid load devices from uri", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/devices.yaml", nil, 6},
-		{"invalid load device empty path", "", nil, 0},
-		{"invalid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "bogus.yml"), nil, 0},
-		{"invalid load device invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/bogus.yml", nil, 0},
+		{"valid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), false, nil, 2, 0},
+		{"valid load devices from uri", "https://raw.githubusercontent.com/edgexfoundry/device-virtual-go/main/cmd/res/devices/devices.yaml", false, nil, 6, 0},
+		{"valid overwrite device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "simple-device.yml"), true, nil, 1, 1},
+		{"invalid load device empty path", "", false, nil, 0, 0},
+		{"invalid load device from file", path.Join("..", "..", "example", "cmd", "device-simple", "res", "devices", "bogus.yml"), false, nil, 0, 0},
+		{"invalid load device invalid uri", "https://raw.githubusercontent.com/edgexfoundry/device-sdk-go/main/example/cmd/device-simple/res/devices/bogus.yml", false, nil, 0, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
 			err := cache.InitCache(TestDeviceService, TestDeviceService, dic)
+			if tt.update {
+				cache.Devices().Add(models.Device{
+					Name: "Simple-Device01",
+				})
+			}
+
 			require.NoError(t, err)
-			addDeviceRequests := processDevices(tt.path, tt.path, TestDeviceService, tt.secretProvider, lc)
+			addDeviceRequests, updateDeviceRequests := processDevices(tt.path, tt.path, TestDeviceService, tt.update, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumDevices, len(addDeviceRequests))
+			if tt.update {
+				assert.Equal(t, tt.expectedUpdateDevices, len(updateDeviceRequests))
+			}
 		})
 	}
 }
@@ -66,14 +80,16 @@ func Test_loadDevicesFromURI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var addDeviceReq []requests.AddDeviceRequest
+			var updateDeviceReq []requests.UpdateDeviceRequest
 			lc := logger.MockLogger{}
 			dic, _ := NewMockDIC()
 			edgexErr := cache.InitCache(TestDeviceService, TestDeviceService, dic)
 			require.NoError(t, edgexErr)
 			parsedURI, err := url.Parse(tt.path)
 			require.NoError(t, err)
-			addDeviceReq, edgexErr = loadDevicesFromURI(tt.path, parsedURI, tt.serviceName, tt.secretProvider, lc)
+			addDeviceReq, updateDeviceReq, edgexErr = loadDevicesFromURI(tt.path, parsedURI, tt.serviceName, false, tt.secretProvider, lc)
 			assert.Equal(t, tt.expectedNumDevices, len(addDeviceReq))
+			assert.Equal(t, 0, len(updateDeviceReq))
 			if edgexErr != nil {
 				assert.Contains(t, edgexErr.Error(), tt.expectedEdgexErrMsg)
 			}

--- a/internal/provision/devices_test.go
+++ b/internal/provision/devices_test.go
@@ -42,9 +42,10 @@ func Test_processDevices(t *testing.T) {
 			dic, _ := NewMockDIC()
 			err := cache.InitCache(TestDeviceService, TestDeviceService, dic)
 			if tt.update {
-				cache.Devices().Add(models.Device{
+				err := cache.Devices().Add(models.Device{
 					Name: "Simple-Device01",
 				})
+				require.NoError(t, err)
 			}
 
 			require.NoError(t, err)

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -197,6 +197,15 @@ func processProfiles(fullPath, displayPath string, overwrite bool, secretProvide
 		req := requests.NewDeviceProfileRequest(profile)
 		addProfilesReq = append(addProfilesReq, req)
 	} else if update {
+		res, err := dpc.DeviceProfileByName(context.Background(), profile.Name)
+
+		if err != nil {
+			lc.Errorf("Failed to overwrite Device Profile %s: %v", profile.Name, err)
+			return nil, nil, err
+		}
+
+		profile.Id = res.Profile.Id
+		profile.DBTimestamp = res.Profile.DBTimestamp
 		req := requests.NewDeviceProfileRequest(profile)
 		updateProfilesReq = append(updateProfilesReq, req)
 	} else {

--- a/internal/provision/profiles.go
+++ b/internal/provision/profiles.go
@@ -12,6 +12,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
 	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/file"
@@ -25,9 +29,6 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
-	"net/url"
-	"os"
-	"path/filepath"
 )
 
 const (
@@ -36,8 +37,9 @@ const (
 	ymlExt  = ".yml"
 )
 
-func LoadProfiles(path string, dic *di.Container) errors.EdgeX {
+func LoadProfiles(path string, overwrite bool, dic *di.Container) errors.EdgeX {
 	var addProfilesReq []requests.DeviceProfileRequest
+	var updateProfilesReq []requests.DeviceProfileRequest
 	var edgexErr errors.EdgeX
 	if path == "" {
 		return nil
@@ -51,109 +53,127 @@ func LoadProfiles(path string, dic *di.Container) errors.EdgeX {
 
 	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
 		secretProvider := bootstrapContainer.SecretProviderFrom(dic.Get)
-		addProfilesReq, edgexErr = loadProfilesFromURI(path, parsedUrl, dpc, secretProvider, lc)
+		addProfilesReq, updateProfilesReq, edgexErr = loadProfilesFromURI(path, parsedUrl, overwrite, dpc, secretProvider, lc)
 		if edgexErr != nil {
 			return edgexErr
 		}
 	} else {
-		addProfilesReq, edgexErr = loadProfilesFromFile(path, dpc, lc)
+		addProfilesReq, updateProfilesReq, edgexErr = loadProfilesFromFile(path, overwrite, dpc, lc)
 		if edgexErr != nil {
 			return edgexErr
 		}
 	}
 
-	if len(addProfilesReq) == 0 {
+	if len(addProfilesReq) == 0 && len(updateProfilesReq) == 0 {
 		return nil
 	}
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck
 	_, edgexErr = dpc.Add(ctx, addProfilesReq)
+	if edgexErr != nil {
+		return edgexErr
+	}
+
+	_, edgexErr = dpc.Update(ctx, updateProfilesReq)
+
 	return edgexErr
 }
 
-func loadProfilesFromFile(path string, dpc interfaces.DeviceProfileClient, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, errors.EdgeX) {
+func loadProfilesFromFile(path string, overwrite bool, dpc interfaces.DeviceProfileClient, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, []requests.DeviceProfileRequest, errors.EdgeX) {
 	var edgexErr errors.EdgeX
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path for profiles", err)
+		return nil, nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to create absolute path for profiles", err)
 	}
 
 	files, err := os.ReadDir(absPath)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory for profiles", err)
+		return nil, nil, errors.NewCommonEdgeX(errors.KindServerError, "failed to read directory for profiles", err)
 	}
 
 	if len(files) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	lc.Infof("Loading pre-defined Device Profiles from %s(%d files found)", absPath, len(files))
 	var addProfilesReq, processedProfilesReq []requests.DeviceProfileRequest
+	var updateProfilesReq, processedUpdateProfilesReq []requests.DeviceProfileRequest
 	for _, file := range files {
 		fullPath := filepath.Join(absPath, file.Name())
-		processedProfilesReq, edgexErr = processProfiles(fullPath, fullPath, nil, lc, dpc)
+		processedProfilesReq, processedUpdateProfilesReq, edgexErr = processProfiles(fullPath, fullPath, overwrite, nil, lc, dpc)
 		if edgexErr != nil {
-			return nil, edgexErr
+			return nil, nil, edgexErr
 		}
 		if len(processedProfilesReq) > 0 {
 			addProfilesReq = append(addProfilesReq, processedProfilesReq...)
 		}
+
+		if len(processedUpdateProfilesReq) > 0 {
+			updateProfilesReq = append(updateProfilesReq, processedUpdateProfilesReq...)
+		}
 	}
-	return addProfilesReq, nil
+	return addProfilesReq, updateProfilesReq, nil
 }
 
-func loadProfilesFromURI(inputURI string, parsedURI *url.URL, dpc interfaces.DeviceProfileClient, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, errors.EdgeX) {
+func loadProfilesFromURI(inputURI string, parsedURI *url.URL, overwrite bool, dpc interfaces.DeviceProfileClient, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient) ([]requests.DeviceProfileRequest, []requests.DeviceProfileRequest, errors.EdgeX) {
 	// the input URI contains the index file containing the Profile list to be loaded
 	bytes, err := file.Load(inputURI, secretProvider, lc)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Device Profile list from URI %s", parsedURI.Redacted()), err)
+		return nil, nil, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to load Device Profile list from URI %s", parsedURI.Redacted()), err)
 	}
 
 	var files map[string]string
 	err = json.Unmarshal(bytes, &files)
 	if err != nil {
-		return nil, errors.NewCommonEdgeX(errors.KindServerError, "could not unmarshal Profile list contents", err)
+		return nil, nil, errors.NewCommonEdgeX(errors.KindServerError, "could not unmarshal Profile list contents", err)
 	}
 	if len(files) == 0 {
 		lc.Infof("Index file %s for Device Profiles list is empty", parsedURI.Redacted())
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	lc.Infof("Loading pre-defined Device Profiles from %s(%d files found)", parsedURI.Redacted(), len(files))
 	var addProfilesReq, processedProfilesReq []requests.DeviceProfileRequest
+	var updateProfilesReq, processedUpdateProfilesReq []requests.DeviceProfileRequest
 	for name, file := range files {
-		done, edgexErr := checkDeviceProfile(name, dpc, lc)
-		if done {
+		add, update, edgexErr := checkDeviceProfile(name, overwrite, dpc, lc)
+		if !add && !update {
 			if edgexErr != nil {
-				return addProfilesReq, edgexErr
+				return addProfilesReq, updateProfilesReq, edgexErr
 			}
-		} else {
+		} else if add || update {
 			fullPath, redactedPath := GetFullAndRedactedURI(parsedURI, file, "Device Profile", lc)
-			processedProfilesReq, edgexErr = processProfiles(fullPath, redactedPath, secretProvider, lc, dpc)
+			processedProfilesReq, updateProfilesReq, edgexErr = processProfiles(fullPath, redactedPath, overwrite, secretProvider, lc, dpc)
 			if edgexErr != nil {
-				return nil, edgexErr
+				return nil, nil, edgexErr
 			}
 			if len(processedProfilesReq) > 0 {
 				addProfilesReq = append(addProfilesReq, processedProfilesReq...)
 			}
+
+			if len(processedUpdateProfilesReq) > 0 {
+				updateProfilesReq = append(updateProfilesReq, processedUpdateProfilesReq...)
+			}
 		}
 	}
-	return addProfilesReq, nil
+	return addProfilesReq, updateProfilesReq, nil
 }
 
-func processProfiles(fullPath, displayPath string, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient, dpc interfaces.DeviceProfileClient) ([]requests.DeviceProfileRequest, errors.EdgeX) {
+func processProfiles(fullPath, displayPath string, overwrite bool, secretProvider bootstrapInterfaces.SecretProvider, lc logger.LoggingClient, dpc interfaces.DeviceProfileClient) ([]requests.DeviceProfileRequest, []requests.DeviceProfileRequest, errors.EdgeX) {
 	var profile dtos.DeviceProfile
 	var addProfilesReq []requests.DeviceProfileRequest
+	var updateProfilesReq []requests.DeviceProfileRequest
+
 	fileType := GetFileType(fullPath)
 
 	// if the file type is not yaml or json, it cannot be parsed - just return to not break the loop for other devices
 	if fileType == OTHER {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	content, err := file.Load(fullPath, secretProvider, lc)
 	if err != nil {
 		lc.Errorf("Failed to read Device Profile from %s: %v", displayPath, err)
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	switch fileType {
@@ -161,38 +181,46 @@ func processProfiles(fullPath, displayPath string, secretProvider bootstrapInter
 		err = yaml.Unmarshal(content, &profile)
 		if err != nil {
 			lc.Errorf("Failed to YAML decode Device Profile from %s: %v", displayPath, err)
-			return nil, nil
+			return nil, nil, nil
 		}
 	case JSON:
 		err = json.Unmarshal(content, &profile)
 		if err != nil {
 			lc.Errorf("Failed to JSON decode Device Profile from %s: %v", displayPath, err)
-			return nil, nil
+			return nil, nil, nil
 		}
 	}
 
-	done, edgexErr := checkDeviceProfile(profile.Name, dpc, lc)
-	if done {
-		if edgexErr != nil {
-			return addProfilesReq, edgexErr
-		}
-	} else {
+	add, update, edgexErr := checkDeviceProfile(profile.Name, overwrite, dpc, lc)
+	if add {
 		lc.Infof("Device Profile %s not found in Metadata, adding it ...", profile.Name)
 		req := requests.NewDeviceProfileRequest(profile)
 		addProfilesReq = append(addProfilesReq, req)
+	} else if update {
+		req := requests.NewDeviceProfileRequest(profile)
+		updateProfilesReq = append(updateProfilesReq, req)
+	} else {
+		if edgexErr != nil {
+			return addProfilesReq, updateProfilesReq, edgexErr
+		}
 	}
-	return addProfilesReq, nil
+	return addProfilesReq, updateProfilesReq, nil
 }
 
-func checkDeviceProfile(name string, dpc interfaces.DeviceProfileClient, lc logger.LoggingClient) (bool, errors.EdgeX) {
+func checkDeviceProfile(name string, overwrite bool, dpc interfaces.DeviceProfileClient, lc logger.LoggingClient) (bool, bool, errors.EdgeX) {
 	res, err := dpc.DeviceProfileByName(context.Background(), name)
 	if err == nil {
-		lc.Infof("Device Profile %s exists, using the existing one", name)
-		err = cache.Profiles().CheckAndAdd(dtos.ToDeviceProfileModel(res.Profile))
-		if err != nil {
-			return true, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
+		if overwrite {
+			lc.Infof("Device Profile %s exists, overwriting with profiles from local files", name)
+			return false, true, nil
+		} else {
+			lc.Infof("Device Profile %s exists, using the existing one", name)
+			err = cache.Profiles().CheckAndAdd(dtos.ToDeviceProfileModel(res.Profile))
+			if err != nil {
+				return false, false, errors.NewCommonEdgeX(errors.KindServerError, fmt.Sprintf("failed to cache the profile %s", res.Profile.Name), err)
+			}
+			return false, false, nil
 		}
-		return true, nil
 	}
-	return false, nil
+	return true, false, nil
 }

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -107,13 +107,13 @@ func (b *Bootstrap) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, st
 		return false
 	}
 
-	edgexErr = provision.LoadProfiles(s.config.Device.ProfilesDir, dic)
+	edgexErr = provision.LoadProfiles(s.config.Device.ProfilesDir, s.overwriteProfiles, dic)
 	if edgexErr != nil {
 		s.lc.Errorf("Failed to load device profiles: %s", edgexErr.Error())
 		return false
 	}
 
-	edgexErr = provision.LoadDevices(s.config.Device.DevicesDir, dic)
+	edgexErr = provision.LoadDevices(s.config.Device.DevicesDir, s.overwriteDevices, dic)
 	if edgexErr != nil {
 		s.lc.Errorf("Failed to load devices: %s", edgexErr.Error())
 		return false

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,6 +65,8 @@ type deviceService struct {
 	asyncCh            chan *sdkModels.AsyncValues
 	deviceCh           chan []sdkModels.DiscoveredDevice
 	flags              *flags.Default
+	overwriteDevices   bool
+	overwriteProfiles  bool
 	deviceServiceModel *models.DeviceService
 	config             *config.ConfigurationStruct
 	configProcessor    *bootstrapConfig.Processor
@@ -101,16 +103,30 @@ func NewDeviceService(serviceKey string, serviceVersion string, driver interface
 
 func (s *deviceService) Run() error {
 	var instanceName string
+	var overwriteDevices bool
+	var overwriteProfiles bool
 	startupTimer := startup.NewStartUpTimer(s.serviceKey)
 
 	additionalUsage :=
-		"    -i, --instance                  Provides a service name suffix which allows unique instance to be created\n" +
+		"    -op, --overwriteProfiles     Overwrite core-metadata with the versions of the associated device profile files.\n" +
+			"                                 *** Use with cation *** Use will clobber existing profiles in core-metadata,\n" +
+			"                                 problematic if those profiles were edited by hand intentionally or used by other services.\n" +
+			"    -od, --overwriteDevices      Overwrite core-metadata with the versions of the associated device files.\n" +
+			"                                 *** Use with cation *** Use will clobber existing devices in core-metadata,\n" +
+			"                                 problematic if those devices were edited by hand intentionally.\n" +
+			"    -i, --instance                  Provides a service name suffix which allows unique instance to be created\n" +
 			"                                    If the option is provided, service name will be replaced with \"<name>_<instance>\"\n"
 	s.flags = flags.NewWithUsage(additionalUsage)
 	s.flags.FlagSet.StringVar(&instanceName, "instance", "", "")
 	s.flags.FlagSet.StringVar(&instanceName, "i", "", "")
+	s.flags.FlagSet.BoolVar(&overwriteProfiles, "op", false, "")
+	s.flags.FlagSet.BoolVar(&overwriteProfiles, "overwriteProfiles", false, "")
+	s.flags.FlagSet.BoolVar(&overwriteDevices, "od", false, "")
+	s.flags.FlagSet.BoolVar(&overwriteDevices, "overwriteDevices", false, "")
 	s.flags.Parse(os.Args[1:])
 	s.setServiceName(instanceName)
+	s.overwriteDevices = overwriteDevices
+	s.overwriteProfiles = overwriteProfiles
 
 	s.config = &config.ConfigurationStruct{}
 	s.deviceServiceModel = &models.DeviceService{Name: s.serviceKey}


### PR DESCRIPTION
This change is to partially address the https://github.com/edgexfoundry/device-sdk-go/issues/1745 issue.  This PR will cover the devices and the device profiles being allowed to be overwritten.  If these changes are acceptable, I will go ahead and also make the changes in regard to the provision watchers.  I have not used the provision watchers feature of EdgeX before but will look into it in order to make the required changes for those.

## PR Checklist
- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  Please let me know where the best place to update the documentation on the new flags added to the device service SDK.

Note that I have a colleague that is currently actively working on this same change for the C Device SDK.

## Testing Instructions
To test, simply start the "device-simple" example, with un-modified profiles and device files.  Then, stop the service, and make a change to either or both the example device for the device-simple service and the profile for the device.  When starting the service, these changes should not be reflected in core-metadata.

Next, stop the service again, and this time launch the service locally with the "-od" to overwrite the devices and the "-op" to overwrite the profiles.  These changes in the local files for both the devices and profiles should be reflected in core-metadata.  The database timestamp's should still indicate reflect the original creation data, and the ID's should not change, but any changes in the devices/profiles should be reflected, and the "Modified" timestamp should reflect the update of these devices/profiles.
