### PR TITLE
feat: Add WithoutValidation variants for device add/update/patch in SDK API

### DIFF
--- a/pkg/interfaces/service.go
+++ b/pkg/interfaces/service.go
@@ -1,6 +1,6 @@
 //
 // Copyright (C) 2022-2023 Intel Corporation
-// Copyright (C) 2023-2025 IOTech Ltd
+// Copyright (C) 2023-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -154,4 +154,21 @@ type DeviceServiceSDK interface {
 
 	// PublishGenericSystemEvent publishes a generic system event through the EdgeX message bus
 	PublishGenericSystemEvent(eventType, action string, details any)
+}
+
+// DeviceServiceSDKExt extends DeviceServiceSDK with additional methods that bypass device validation.
+type DeviceServiceSDKExt interface {
+	DeviceServiceSDK
+	// AddDeviceWithoutValidation adds a new Device to the Device Service and Core Metadata
+	// with bypassValidation=true to skip device validation.
+	// Returns new Device id or non-nil error.
+	AddDeviceWithoutValidation(device models.Device) (string, error)
+	// UpdateDeviceWithoutValidation updates the Device in Core Metadata with bypassValidation=true
+	// to skip device validation.
+	UpdateDeviceWithoutValidation(device models.Device) error
+	// PatchDeviceWithoutValidation patches the specified device properties in Core Metadata with bypassValidation=true
+	// to skip device validation. Device name is required to be provided in the UpdateDevice. Note that all properties
+	// of UpdateDevice are pointers and anything that is nil will not modify the device. In the case of Arrays and Maps,
+	// the whole new value must be sent, as it is applied as an overwrite operation.
+	PatchDeviceWithoutValidation(updateDevice dtos.UpdateDevice) error
 }

--- a/pkg/service/async.go
+++ b/pkg/service/async.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2018 Canonical Ltd
-// Copyright (C) 2018-2023 IOTech Ltd
+// Copyright (C) 2018-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +14,7 @@ import (
 
 	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	contractsCommon "github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
@@ -117,7 +118,8 @@ func (s *deviceService) processAsyncFilterAndAdd(ctx context.Context) {
 						}
 
 						req := requests.NewAddDeviceRequest(dtos.FromDeviceModelToDTO(device))
-						_, err := bootstrapContainer.DeviceClientFrom(s.dic.Get).Add(ctx, []requests.AddDeviceRequest{req})
+						_, err := bootstrapContainer.DeviceClientFrom(s.dic.Get).AddWithQueryParams(ctx, []requests.AddDeviceRequest{req},
+							map[string]string{common.BypassValidationQueryParam: contractsCommon.ValueTrue})
 						if err != nil {
 							s.lc.Errorf("failed to create discovered device %s: %v", device.Name, err)
 						} else {

--- a/pkg/service/async_test.go
+++ b/pkg/service/async_test.go
@@ -1,17 +1,28 @@
 //
-// Copyright (C) 2020-2023 IOTech Ltd
+// Copyright (C) 2020-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package service
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v4/clients/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	contractsCommon "github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/responses"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
+	internalCommon "github.com/edgexfoundry/device-sdk-go/v4/internal/common"
 	sdkModels "github.com/edgexfoundry/device-sdk-go/v4/pkg/models"
 )
 
@@ -23,6 +34,73 @@ func newDeviceService() *deviceService {
 	return &deviceService{
 		serviceKey: "test-service",
 		lc:         logger.NewMockClient(),
+	}
+}
+
+func Test_processAsyncFilterAndAdd_bypassValidation(t *testing.T) {
+	const testServiceKey = "test-service"
+
+	pw := models.ProvisionWatcher{
+		AdminState: models.Unlocked,
+	}
+
+	discovered := sdkModels.DiscoveredDevice{
+		Name: "new-device",
+		Protocols: map[string]models.ProtocolProperties{
+			"http": {"host": "localhost"},
+		},
+	}
+
+	addCalled := make(chan struct{}, 1)
+	dcMock := &clientMocks.DeviceClient{}
+	dcMock.On("DevicesByServiceName", mock.Anything, testServiceKey, 0, -1).Return(
+		responses.MultiDevicesResponse{}, nil)
+	dcMock.On("AddWithQueryParams",
+		mock.Anything,
+		mock.Anything,
+		map[string]string{internalCommon.BypassValidationQueryParam: contractsCommon.ValueTrue},
+	).Return(nil, nil).Run(func(mock.Arguments) { addCalled <- struct{}{} })
+
+	pwcMock := &clientMocks.ProvisionWatcherClient{}
+	pwcMock.On("ProvisionWatchersByServiceName", mock.Anything, testServiceKey, 0, -1).Return(
+		responses.MultiProvisionWatchersResponse{}, nil)
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		bootstrapContainer.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return logger.NewMockClient()
+		},
+		bootstrapContainer.DeviceClientName: func(get di.Get) interface{} {
+			return dcMock
+		},
+		bootstrapContainer.ProvisionWatcherClientName: func(get di.Get) interface{} {
+			return pwcMock
+		},
+	})
+
+	err := cache.InitCache(testServiceKey, testServiceKey, dic)
+	require.NoError(t, err)
+	err = cache.ProvisionWatchers().Add(pw)
+	require.NoError(t, err)
+
+	deviceCh := make(chan []sdkModels.DiscoveredDevice, 1)
+	ds := &deviceService{
+		serviceKey: testServiceKey,
+		lc:         logger.NewMockClient(),
+		dic:        dic,
+		deviceCh:   deviceCh,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ds.processAsyncFilterAndAdd(ctx)
+
+	deviceCh <- []sdkModels.DiscoveredDevice{discovered}
+
+	select {
+	case <-addCalled:
+	case <-time.After(time.Second):
+		t.Fatal("AddWithQueryParams was not called within timeout")
 	}
 }
 

--- a/pkg/service/manageddevices.go
+++ b/pkg/service/manageddevices.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
 // Copyright (C) 2017-2018 Canonical Ltd
-// Copyright (C) 2018-2023 IOTech Ltd
+// Copyright (C) 2018-2026 IOTech Ltd
 // Copyright (C) 2023 Intel
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +11,9 @@ package service
 import (
 	"context"
 	"fmt"
+
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
+	internalCommon "github.com/edgexfoundry/device-sdk-go/v4/internal/common"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
@@ -18,24 +21,47 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
-	"github.com/google/uuid"
 
-	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
+	"github.com/google/uuid"
 )
 
 // AddDevice adds a new Device to the Device Service and Core Metadata
 // Returns new Device id or non-nil error.
 func (s *deviceService) AddDevice(device models.Device) (string, error) {
+	return s.addDevice(device, false)
+}
+
+// AddDeviceWithoutValidation adds a new Device to the Device Service and Core Metadata
+// with bypassValidation=true to skip device validation.
+// Returns new Device id or non-nil error.
+func (s *deviceService) AddDeviceWithoutValidation(device models.Device) (string, error) {
+	return s.addDevice(device, true)
+}
+
+func (s *deviceService) addDevice(device models.Device, bypassValidation bool) (string, error) {
 	if d, ok := cache.Devices().ForName(device.Name); ok {
 		return d.Id, errors.NewCommonEdgeX(errors.KindDuplicateName, fmt.Sprintf("name conflicted, Device %s exists", device.Name), nil)
 	}
 
 	device.ServiceName = s.serviceKey
 
-	s.lc.Debugf("Adding managed Device %s", device.Name)
+	if bypassValidation {
+		s.lc.Debugf("Adding managed Device %s without validation", device.Name)
+	} else {
+		s.lc.Debugf("Adding managed Device %s", device.Name)
+	}
 	req := requests.NewAddDeviceRequest(dtos.FromDeviceModelToDTO(device))
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck
-	res, err := container.DeviceClientFrom(s.dic.Get).Add(ctx, []requests.AddDeviceRequest{req})
+	var (
+		res []commonDTO.BaseWithIdResponse
+		err error
+	)
+	if bypassValidation {
+		res, err = container.DeviceClientFrom(s.dic.Get).AddWithQueryParams(ctx, []requests.AddDeviceRequest{req},
+			map[string]string{internalCommon.BypassValidationQueryParam: common.ValueTrue})
+	} else {
+		res, err = container.DeviceClientFrom(s.dic.Get).Add(ctx, []requests.AddDeviceRequest{req})
+	}
 	if err != nil {
 		s.lc.Errorf("failed to add Device %s to Core Metadata: %v", device.Name, err)
 		return "", err
@@ -88,11 +114,17 @@ func (s *deviceService) UpdateDevice(device models.Device) error {
 	return s.PatchDevice(dtos.FromDeviceModelToUpdateDTO(device))
 }
 
+// UpdateDeviceWithoutValidation updates the Device in Core Metadata with bypassValidation=true
+// to skip device validation.
+func (s *deviceService) UpdateDeviceWithoutValidation(device models.Device) error {
+	return s.PatchDeviceWithoutValidation(dtos.FromDeviceModelToUpdateDTO(device))
+}
+
 // UpdateDeviceOperatingState updates the OperatingState for the Device with given name
 // in Core Metadata
 func (s *deviceService) UpdateDeviceOperatingState(name string, state models.OperatingState) error {
 	stateString := string(state)
-	return s.PatchDevice(dtos.UpdateDevice{
+	return s.PatchDeviceWithoutValidation(dtos.UpdateDevice{
 		Name:           &name,
 		OperatingState: &stateString,
 	})
@@ -103,6 +135,18 @@ func (s *deviceService) UpdateDeviceOperatingState(name string, state models.Ope
 // and anything that is nil will not modify the device. In the case of Arrays and Maps, the whole new value
 // must be sent, as it is applied as an overwrite operation.
 func (s *deviceService) PatchDevice(updateDevice dtos.UpdateDevice) error {
+	return s.patchDevice(updateDevice, false)
+}
+
+// PatchDeviceWithoutValidation patches the specified device properties in Core Metadata with bypassValidation=true
+// to skip device validation. Device name is required to be provided in the UpdateDevice. Note that all properties
+// of UpdateDevice are pointers and anything that is nil will not modify the device. In the case of Arrays and Maps,
+// the whole new value must be sent, as it is applied as an overwrite operation.
+func (s *deviceService) PatchDeviceWithoutValidation(updateDevice dtos.UpdateDevice) error {
+	return s.patchDevice(updateDevice, true)
+}
+
+func (s *deviceService) patchDevice(updateDevice dtos.UpdateDevice, bypassValidation bool) error {
 	if updateDevice.Name == nil {
 		msg := "missing device name for patch device call"
 		s.lc.Error(msg)
@@ -113,13 +157,23 @@ func (s *deviceService) PatchDevice(updateDevice dtos.UpdateDevice) error {
 		return err
 	}
 
-	s.lc.Debugf("Patching managed Device %s", *updateDevice.Name)
+	if bypassValidation {
+		s.lc.Debugf("Patching managed Device %s without validation", *updateDevice.Name)
+	} else {
+		s.lc.Debugf("Patching managed Device %s", *updateDevice.Name)
+	}
 	req := requests.UpdateDeviceRequest{
 		BaseRequest: commonDTO.NewBaseRequest(),
 		Device:      updateDevice,
 	}
 	ctx := context.WithValue(context.Background(), common.CorrelationHeader, uuid.NewString()) // nolint:staticcheck
-	_, err := container.DeviceClientFrom(s.dic.Get).Update(ctx, []requests.UpdateDeviceRequest{req})
+	var err error
+	if bypassValidation {
+		_, err = container.DeviceClientFrom(s.dic.Get).UpdateWithQueryParams(ctx, []requests.UpdateDeviceRequest{req},
+			map[string]string{internalCommon.BypassValidationQueryParam: common.ValueTrue})
+	} else {
+		_, err = container.DeviceClientFrom(s.dic.Get).Update(ctx, []requests.UpdateDeviceRequest{req})
+	}
 	if err != nil {
 		s.lc.Errorf("failed to update Device %s in Core Metadata: %v", *updateDevice.Name, err)
 	}


### PR DESCRIPTION
fix: #1823 

Expose AddDeviceWithoutValidation, UpdateDeviceWithoutValidation, and PatchDeviceWithoutValidation via the new DeviceServiceSDKExt interface, which extends DeviceServiceSDK. This is a non-breaking change, since *deviceService implements DeviceServiceSDKExt, consumers can access these methods via a single type assertion on their DeviceServiceSDK reference.

Also update UpdateDeviceOperatingState to use the bypass variant, as the operating state change originates from the device service itself and does not require re-validation.

In addition, update the async device discovery flow to pass bypassValidation=true when adding discovered devices to Core Metadata, avoiding unnecessary validation round-trips.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->