### PR TITLE
fix: prevent HOL blocking on MQTT command consumer

### DIFF
--- a/example/cmd/device-simple/res/configuration.yaml
+++ b/example/cmd/device-simple/res/configuration.yaml
@@ -15,6 +15,9 @@ MessageBus:
   Optional:
     ClientId: device-simple
 
+# Cap on in-flight MQTT command requests; <= 0 uses built-in default (32).
+MaxConcurrentCommands: 32
+
 # Example overriding of Common Config settings
 Device:
   AsyncBufferSize: 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,9 @@ type ConfigurationStruct struct {
 	MessageBus bootstrapConfig.MessageBusInfo
 	// MaxEventSize is the maximum event size that can be sent to MessageBus or CoreData
 	MaxEventSize int64
+	// MaxConcurrentCommands caps in-flight MQTT command requests so a slow/offline device
+	// cannot starve the consumer. Values <= 0 fall back to the built-in default (32).
+	MaxConcurrentCommands int
 }
 
 // UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is

--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -134,7 +134,7 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 					}
 				}(msgEnvelope, responsePublishTopic, deviceName, commandName, upperMethod == "GET")
 
-				lc.Debugf("Command request dispatched. Topic: %s, Correlation-id: %s", responsePublishTopic, msgEnvelope.CorrelationID)
+				lc.Debugf("Command request dispatched. Response will be published on topic: %s, Correlation-id: %s", responsePublishTopic, msgEnvelope.CorrelationID)
 			}
 		}
 	}()

--- a/internal/controller/messaging/command.go
+++ b/internal/controller/messaging/command.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2025 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +24,16 @@ import (
 	"github.com/edgexfoundry/device-sdk-go/v4/internal/container"
 )
 
+// defaultMaxConcurrentCommands caps in-flight MQTT command requests so a single slow or
+// offline device cannot block the consumer goroutine and starve commands to every other
+// device served by this device service. At capacity, new requests are rejected inline with
+// a "service busy" envelope; queuing further would only defer the same failure and risks
+// unbounded growth.
+//
+// Drivers that require per-device serialization must enforce it themselves — the HTTP and
+// AutoEvent paths already invoke application.GetCommand / SetCommand concurrently today.
+const defaultMaxConcurrentCommands = 32
+
 func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 	lc := bootstrapContainer.LoggingClientFrom(dic.Get)
 	configuration := container.ConfigurationFrom(dic.Get)
@@ -46,6 +56,12 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 			Messages: messages,
 		},
 	}
+
+	maxInFlight := configuration.MaxConcurrentCommands
+	if maxInFlight <= 0 {
+		maxInFlight = defaultMaxConcurrentCommands
+	}
+	sem := make(chan struct{}, maxInFlight)
 
 	messageBus := bootstrapContainer.MessagingClientFrom(dic.Get)
 	err := messageBus.Subscribe(topics, messageErrors)
@@ -87,17 +103,38 @@ func SubscribeCommands(ctx context.Context, dic *di.Container) errors.EdgeX {
 
 				responsePublishTopic := common.BuildTopic(responsePublishTopicPrefix, msgEnvelope.RequestID)
 
-				switch strings.ToUpper(method) {
-				case "GET":
-					getCommand(ctx, msgEnvelope, responsePublishTopic, deviceName, commandName, dic)
-				case "SET":
-					setCommand(ctx, msgEnvelope, responsePublishTopic, deviceName, commandName, dic)
-				default:
+				upperMethod := strings.ToUpper(method)
+				if upperMethod != "GET" && upperMethod != "SET" {
 					lc.Errorf("unknown command method '%s', only 'get' or 'set' is allowed", method)
 					continue
 				}
 
-				lc.Debugf("Command response published on message queue. Topic: %s, Correlation-id: %s", responsePublishTopic, msgEnvelope.CorrelationID)
+				// Non-blocking acquire — never block the consumer goroutine. At capacity we
+				// reject inline rather than queue, so a stuck device cannot cause head-of-line
+				// blocking on subsequent commands to other devices.
+				select {
+				case sem <- struct{}{}:
+				default:
+					lc.Warnf("device command in-flight limit (%d) reached; rejecting %s request for device '%s'/'%s'",
+						cap(sem), method, deviceName, commandName)
+					busy := types.NewMessageEnvelopeWithError(msgEnvelope.RequestID,
+						"device service busy: too many concurrent commands")
+					if pubErr := messageBus.Publish(busy, responsePublishTopic); pubErr != nil {
+						lc.Errorf("Failed to publish busy response: %s", pubErr.Error())
+					}
+					continue
+				}
+
+				go func(env types.MessageEnvelope, topic, dev, cmd string, isGet bool) {
+					defer func() { <-sem }()
+					if isGet {
+						getCommand(ctx, env, topic, dev, cmd, dic)
+					} else {
+						setCommand(ctx, env, topic, dev, cmd, dic)
+					}
+				}(msgEnvelope, responsePublishTopic, deviceName, commandName, upperMethod == "GET")
+
+				lc.Debugf("Command request dispatched. Topic: %s, Correlation-id: %s", responsePublishTopic, msgEnvelope.CorrelationID)
 			}
 		}
 	}()

--- a/internal/controller/messaging/command_test.go
+++ b/internal/controller/messaging/command_test.go
@@ -1,0 +1,253 @@
+//
+// Copyright (C) 2026 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package messaging
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bootstrapContainer "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
+	bootstrapMocks "github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
+	clientMocks "github.com/edgexfoundry/go-mod-core-contracts/v4/clients/interfaces/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/responses"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
+	messagingMocks "github.com/edgexfoundry/go-mod-messaging/v4/messaging/mocks"
+	"github.com/edgexfoundry/go-mod-messaging/v4/pkg/types"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/cache"
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/config"
+	"github.com/edgexfoundry/device-sdk-go/v4/internal/container"
+	driverMocks "github.com/edgexfoundry/device-sdk-go/v4/pkg/interfaces/mocks"
+	sdkModels "github.com/edgexfoundry/device-sdk-go/v4/pkg/models"
+)
+
+const (
+	testCmdServiceName  = "testCmdService"
+	testCmdDeviceA      = "deviceA"
+	testCmdDeviceB      = "deviceB"
+	testCmdProfile      = "testCmdProfile"
+	testCmdResourceName = "tempSensor"
+)
+
+// newCommandTestDIC builds a DIC and initializes the device/profile cache so that
+// application.GetCommand can run through to driver.HandleReadCommands.
+func newCommandTestDIC(t *testing.T, maxConcurrent int, driver *driverMocks.ProtocolDriver) *di.Container {
+	t.Helper()
+
+	cfg := &config.ConfigurationStruct{
+		MaxConcurrentCommands: maxConcurrent,
+		Device:                config.DeviceInfo{MaxCmdOps: 1},
+	}
+	deviceService := &models.DeviceService{Name: testCmdServiceName, AdminState: models.Unlocked}
+
+	devices := responses.MultiDevicesResponse{
+		Devices: []dtos.Device{
+			{
+				Name: testCmdDeviceA, ProfileName: testCmdProfile, ServiceName: testCmdServiceName,
+				AdminState: models.Unlocked, OperatingState: models.Up,
+			},
+			{
+				Name: testCmdDeviceB, ProfileName: testCmdProfile, ServiceName: testCmdServiceName,
+				AdminState: models.Unlocked, OperatingState: models.Up,
+			},
+		},
+	}
+	profile := responses.DeviceProfileResponse{
+		Profile: dtos.DeviceProfile{
+			DeviceProfileBasicInfo: dtos.DeviceProfileBasicInfo{Name: testCmdProfile},
+			DeviceResources: []dtos.DeviceResource{
+				{
+					Name: testCmdResourceName,
+					Properties: dtos.ResourceProperties{
+						ValueType: common.ValueTypeString,
+						ReadWrite: common.ReadWrite_RW,
+					},
+				},
+			},
+		},
+	}
+
+	dcMock := &clientMocks.DeviceClient{}
+	dcMock.On("DevicesByServiceName", context.Background(), testCmdServiceName, 0, -1).Return(devices, nil)
+
+	dpcMock := &clientMocks.DeviceProfileClient{}
+	dpcMock.On("DeviceProfileByName", context.Background(), testCmdProfile).Return(profile, nil)
+
+	pwcMock := &clientMocks.ProvisionWatcherClient{}
+	pwcMock.On("ProvisionWatchersByServiceName", context.Background(), testCmdServiceName, 0, -1).
+		Return(responses.MultiProvisionWatchersResponse{}, nil)
+
+	mm := &bootstrapMocks.MetricsManager{}
+	mm.On("Register", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mm.On("Unregister", mock.Anything)
+
+	failsTracker := container.NewAllowedFailuresTracker()
+
+	dic := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationName:                    func(_ di.Get) any { return cfg },
+		container.DeviceServiceName:                    func(_ di.Get) any { return deviceService },
+		container.ProtocolDriverName:                   func(_ di.Get) any { return driver },
+		container.AllowedRequestFailuresTrackerName:    func(_ di.Get) any { return failsTracker },
+		bootstrapContainer.LoggingClientInterfaceName:  func(_ di.Get) any { return logger.NewMockClient() },
+		bootstrapContainer.DeviceClientName:            func(_ di.Get) any { return dcMock },
+		bootstrapContainer.DeviceProfileClientName:     func(_ di.Get) any { return dpcMock },
+		bootstrapContainer.ProvisionWatcherClientName:  func(_ di.Get) any { return pwcMock },
+		bootstrapContainer.MetricsManagerInterfaceName: func(_ di.Get) any { return mm },
+	})
+
+	require.NoError(t, cache.InitCache(testCmdServiceName, testCmdServiceName, dic))
+	return dic
+}
+
+func makeGetEnvelope(deviceName string) types.MessageEnvelope {
+	return types.MessageEnvelope{
+		RequestID:     uuid.NewString(),
+		CorrelationID: uuid.NewString(),
+		ContentType:   common.ContentTypeJSON,
+		ReceivedTopic: "edgex/command/request/" + testCmdServiceName + "/" + deviceName + "/" + testCmdResourceName + "/get",
+		// ds-returnevent=false avoids the test needing to produce a real *dtos.Event from the
+		// (empty) driver response — we're testing dispatch concurrency, not event marshaling.
+		QueryParams: map[string]string{common.ReturnEvent: common.ValueFalse},
+	}
+}
+
+// messagingProbe captures the subscriber channel and counts publishes so tests can deterministically
+// wait for worker goroutines to finish (avoiding cross-test races on package-global caches).
+type messagingProbe struct {
+	subReady   sync.WaitGroup
+	subCh      chan types.MessageEnvelope
+	totalCount atomic.Int32 // every Publish + PublishWithSizeLimit call
+	busyCount  atomic.Int32 // ErrorCode == 1 publishes only (overload responses)
+}
+
+func installMessagingMock(t *testing.T, dic *di.Container) *messagingProbe {
+	t.Helper()
+	p := &messagingProbe{}
+	p.subReady.Add(1)
+
+	mockMessaging := &messagingMocks.MessageClient{}
+	mockMessaging.On("Subscribe", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			topics := args.Get(0).([]types.TopicChannel)
+			p.subCh = topics[0].Messages
+			p.subReady.Done()
+		}).Return(nil)
+	mockMessaging.On("Publish", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			env := args.Get(0).(types.MessageEnvelope)
+			if env.ErrorCode == 1 {
+				p.busyCount.Add(1)
+			}
+			p.totalCount.Add(1)
+		}).Return(nil)
+	mockMessaging.On("PublishWithSizeLimit", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) { p.totalCount.Add(1) }).
+		Return(nil)
+
+	dic.Update(di.ServiceConstructorMap{
+		bootstrapContainer.MessagingClientName: func(_ di.Get) any { return mockMessaging },
+	})
+	return p
+}
+
+func (p *messagingProbe) sub() chan types.MessageEnvelope {
+	p.subReady.Wait()
+	return p.subCh
+}
+
+// waitForPublishes blocks until totalCount >= n. Used at end-of-test to make sure all in-flight
+// worker goroutines have finished before the test returns, so they don't race with the next
+// test's cache.InitCache.
+func (p *messagingProbe) waitForPublishes(t *testing.T, n int32) {
+	t.Helper()
+	require.Eventually(t, func() bool { return p.totalCount.Load() >= n },
+		3*time.Second, 5*time.Millisecond, "expected %d publishes, got %d", n, p.totalCount.Load())
+}
+
+// Test_SubscribeCommands_secondRunsWhileFirstBlocked proves the fix: a command to device B can
+// begin processing while a command to device A is still blocked inside the driver. With the
+// pre-fix code this would deadlock — the consumer goroutine would be stuck dispatching the first
+// command synchronously.
+func Test_SubscribeCommands_secondRunsWhileFirstBlocked(t *testing.T) {
+	unblockFirst := make(chan struct{})
+	var phase atomic.Int32
+
+	driver := &driverMocks.ProtocolDriver{}
+	driver.On("HandleReadCommands", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) {
+			if phase.Add(1) == 1 {
+				<-unblockFirst
+			}
+		}).Return([]*sdkModels.CommandValue{}, nil)
+
+	dic := newCommandTestDIC(t, 4, driver)
+	probe := installMessagingMock(t, dic)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, SubscribeCommands(ctx, dic))
+
+	sub := probe.sub()
+	sub <- makeGetEnvelope(testCmdDeviceA)
+	require.Eventually(t, func() bool { return phase.Load() >= 1 },
+		2*time.Second, 5*time.Millisecond, "first driver call should have started")
+
+	sub <- makeGetEnvelope(testCmdDeviceB)
+	require.Eventually(t, func() bool { return phase.Load() >= 2 },
+		2*time.Second, 5*time.Millisecond,
+		"second driver call should run while first is blocked — HOL regression if it doesn't")
+
+	close(unblockFirst)
+	// Drain both worker goroutines before returning so they don't race with the next test's
+	// cache.InitCache (the device cache is a package-global singleton).
+	probe.waitForPublishes(t, 2)
+}
+
+// Test_SubscribeCommands_busyOnOverload proves the backpressure path: when the in-flight budget
+// is exhausted, the next request is rejected inline with a busy envelope and the driver is NOT
+// invoked again.
+func Test_SubscribeCommands_busyOnOverload(t *testing.T) {
+	blockAll := make(chan struct{})
+	var entered atomic.Int32
+
+	driver := &driverMocks.ProtocolDriver{}
+	driver.On("HandleReadCommands", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ mock.Arguments) {
+			entered.Add(1)
+			<-blockAll
+		}).Return([]*sdkModels.CommandValue{}, nil)
+
+	dic := newCommandTestDIC(t, 1, driver) // capacity 1 forces the second message to overload
+	probe := installMessagingMock(t, dic)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, SubscribeCommands(ctx, dic))
+
+	sub := probe.sub()
+	sub <- makeGetEnvelope(testCmdDeviceA)
+	require.Eventually(t, func() bool { return entered.Load() == 1 },
+		2*time.Second, 5*time.Millisecond, "first driver call should have entered")
+
+	sub <- makeGetEnvelope(testCmdDeviceB)
+	require.Eventually(t, func() bool { return probe.busyCount.Load() >= 1 },
+		2*time.Second, 10*time.Millisecond, "busy envelope should be published for the rejected request")
+
+	driver.AssertNumberOfCalls(t, "HandleReadCommands", 1)
+	close(blockAll)
+	// Drain the first worker (1 success publish) + already-counted busy publish = 2 total.
+	probe.waitForPublishes(t, 2)
+}


### PR DESCRIPTION
A slow or offline device caused application.GetCommand / application.SetCommand to block the single MQTT consumer goroutine in SubscribeCommands for the driver's full timeout, serializing commands to every other device served by this device service.

Dispatch each command into its own goroutine guarded by a bounded semaphore. At capacity, new requests are rejected inline with a "service busy" envelope on the response topic rather than queued -- queuing would only defer the same failure and risks unbounded growth. The method ("GET"/"SET") is validated before acquiring a slot so unknown-method requests do not consume capacity.

Driver concurrency expectations are unchanged: the HTTP controller and the AutoEvent executor already invoke application.GetCommand / SetCommand concurrently, so any ProtocolDriver implementation that requires per-device serialization already enforces it internally. The MQTT consumer's previous synchronous behavior was an accidental property, not a load-bearing one.

The concurrency limit is configurable via the new optional MaxConcurrentCommands setting on ConfigurationStruct; values <= 0 fall back to the built-in default of 32. Existing deployments need no YAML change.

Sibling fix at the core-command layer: edgexfoundry/edgex-go#5428.

close #1829

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. clone refactored modbus simulator from https://github.com/judehung/device-modbus-go/tree/refactor-simulator
2. cd device-modbus-go/simulator
3. run ./build-image.sh
4. prepare a compose file to include core services, device-modbus, and two modbus simulators (I revise edgex-compose/compose-builder locally for testing purpose)
5. run up these services (in my case, just run `make run no-secty arm64 ds-modbus modbus-sim`)
6. `mosquitto_sub -t edgex/command/response/#` to monitor all command respsonse
7. `mosquitto_pub -t edgex/command/request/Modbus-TCP-test-device/RoomTemperature/get -f ../data.json` to test the first modbus simulator
8. `mosquitto_pub -t edgex/command/request/Modbus-TCP-Read-String/StringA/get -f ../data.json` to test the second modbus simulator
9. `curl -X POST 'http://localhost:1503/delay?duration=600s'` to trigger the delay response for the first modbus simulator
10. repeat step 7 now the command response got stuck due to 10-mins delay response
11. repeat step 8 to ensure that we still receive the response from second modbus simulator without affecting by the step 10.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->