### PR TITLE
fix: prevent startup race panics on device service bootstrap

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -171,7 +171,6 @@ func (s *deviceService) Run() error {
 		true,
 		bootstrapTypes.ServiceTypeDevice,
 		[]bootstrapInterfaces.BootstrapHandler{
-			httpServer.BootstrapHandler,
 			newMessageBusBootstrap(s.baseServiceName).messageBusBootstrapHandler,
 			handlers.NewServiceMetrics(s.serviceKey).BootstrapHandler, // Must be after Messaging
 			handlers.NewClientsBootstrap().BootstrapHandler,
@@ -179,6 +178,7 @@ func (s *deviceService) Run() error {
 			NewBootstrap(s, router).BootstrapHandler,
 			autodiscovery.BootstrapHandler,
 			handlers.NewStartMessage(s.serviceKey, sdkCommon.ServiceVersion).BootstrapHandler,
+			httpServer.BootstrapHandler,
 		})
 
 	defer func() {


### PR DESCRIPTION
Move httpServer.BootstrapHandler to the end of the handler list so the HTTP listener only comes up after the caches, ProtocolDriver, and request failures tracker are fully initialized. The listener is the only ingress without a registration gate (MessageBus subscriptions are guarded by selfRegister), so early requests like GET .../command/... no longer hit nil cache/driver/tracker dependencies.

fix #1836

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-sdk-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?) not impact
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core service and simple service for testing.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->